### PR TITLE
feat(ui): improve AskUserQuestions multi-choice form UX

### DIFF
--- a/src/slack/actions/choice-action-handler.ts
+++ b/src/slack/actions/choice-action-handler.ts
@@ -86,7 +86,6 @@ export class ChoiceActionHandler {
       const userId = body.user?.id;
       const channel = body.channel?.id;
       const messageTs = body.message?.ts;
-      const threadTs = body.message?.thread_ts || messageTs;
 
       this.logger.info('Multi-choice selection', { formId, questionId, choiceId, label, userId });
 
@@ -104,34 +103,159 @@ export class ChoiceActionHandler {
       // 선택 저장
       pendingForm.selections[questionId] = { choiceId, label };
 
+      // 폼 UI 업데이트 (자동 제출 없음 - Submit 버튼으로 제출)
+      await this.updateFormUI(pendingForm, channel, messageTs);
+    } catch (error) {
+      this.logger.error('Error processing multi-choice selection', error);
+    }
+  }
+
+  /**
+   * Handle edit choice - clear selection for a question and show options again
+   */
+  async handleEditChoice(body: any): Promise<void> {
+    try {
+      const action = body.actions[0];
+      const valueData = JSON.parse(action.value);
+      const { formId, questionId } = valueData;
+      const userId = body.user?.id;
+      const channel = body.channel?.id;
+      const messageTs = body.message?.ts;
+
+      this.logger.info('Edit choice requested', { formId, questionId, userId });
+
+      const pendingForm = this.formStore.get(formId);
+      if (!pendingForm) {
+        this.logger.warn('Pending form not found for edit', { formId });
+        await this.ctx.slackApi.postEphemeral(
+          channel,
+          userId,
+          '❌ 폼을 찾을 수 없습니다. 시간이 만료되었을 수 있습니다.'
+        );
+        return;
+      }
+
+      // 선택 취소
+      delete pendingForm.selections[questionId];
+
+      // UI 업데이트
+      await this.updateFormUI(pendingForm, channel, messageTs);
+    } catch (error) {
+      this.logger.error('Error processing edit choice', error);
+    }
+  }
+
+  /**
+   * Handle form submit - send all selections to Claude
+   */
+  async handleFormSubmit(body: any): Promise<void> {
+    try {
+      const action = body.actions[0];
+      const valueData = JSON.parse(action.value);
+      const { formId, sessionKey } = valueData;
+      const userId = body.user?.id;
+      const channel = body.channel?.id;
+      const messageTs = body.message?.ts;
+      const threadTs = body.message?.thread_ts || messageTs;
+
+      this.logger.info('Form submit requested', { formId, userId });
+
+      const pendingForm = this.formStore.get(formId);
+      if (!pendingForm) {
+        this.logger.warn('Pending form not found for submit', { formId });
+        await this.ctx.slackApi.postEphemeral(
+          channel,
+          userId,
+          '❌ 폼을 찾을 수 없습니다. 시간이 만료되었을 수 있습니다.'
+        );
+        return;
+      }
+
+      // 모든 질문이 선택되었는지 확인
       const totalQuestions = pendingForm.questions.length;
       const answeredCount = Object.keys(pendingForm.selections).length;
 
-      // 폼 UI 업데이트
-      const choicesData: UserChoices = {
-        type: 'user_choices',
-        questions: pendingForm.questions,
-      };
-
-      const updatedPayload = UserChoiceHandler.buildMultiChoiceFormBlocks(
-        choicesData,
-        formId,
-        sessionKey,
-        pendingForm.selections
-      );
-
-      try {
-        await this.ctx.slackApi.updateMessage(channel, messageTs, '📋 선택이 필요합니다', undefined, updatedPayload.attachments);
-      } catch (error) {
-        this.logger.warn('Failed to update multi-choice form', error);
+      if (answeredCount !== totalQuestions) {
+        await this.ctx.slackApi.postEphemeral(
+          channel,
+          userId,
+          `❌ 아직 ${totalQuestions - answeredCount}개의 질문에 답변하지 않았습니다.`
+        );
+        return;
       }
 
-      // 모든 질문 완료 시
-      if (answeredCount === totalQuestions) {
-        await this.completeMultiChoiceForm(pendingForm, userId, channel, threadTs, messageTs);
-      }
+      // 제출 처리
+      await this.completeMultiChoiceForm(pendingForm, userId, channel, threadTs, messageTs);
     } catch (error) {
-      this.logger.error('Error processing multi-choice selection', error);
+      this.logger.error('Error processing form submit', error);
+    }
+  }
+
+  /**
+   * Handle form reset - clear all selections
+   */
+  async handleFormReset(body: any): Promise<void> {
+    try {
+      const action = body.actions[0];
+      const valueData = JSON.parse(action.value);
+      const { formId } = valueData;
+      const userId = body.user?.id;
+      const channel = body.channel?.id;
+      const messageTs = body.message?.ts;
+
+      this.logger.info('Form reset requested', { formId, userId });
+
+      const pendingForm = this.formStore.get(formId);
+      if (!pendingForm) {
+        this.logger.warn('Pending form not found for reset', { formId });
+        await this.ctx.slackApi.postEphemeral(
+          channel,
+          userId,
+          '❌ 폼을 찾을 수 없습니다. 시간이 만료되었을 수 있습니다.'
+        );
+        return;
+      }
+
+      // 모든 선택 초기화
+      pendingForm.selections = {};
+
+      // UI 업데이트
+      await this.updateFormUI(pendingForm, channel, messageTs);
+
+      await this.ctx.slackApi.postEphemeral(
+        channel,
+        userId,
+        '🗑️ 모든 선택이 초기화되었습니다.'
+      );
+    } catch (error) {
+      this.logger.error('Error processing form reset', error);
+    }
+  }
+
+  /**
+   * Update form UI with current selections
+   */
+  private async updateFormUI(
+    pendingForm: PendingChoiceFormData,
+    channel: string,
+    messageTs: string
+  ): Promise<void> {
+    const choicesData: UserChoices = {
+      type: 'user_choices',
+      questions: pendingForm.questions,
+    };
+
+    const updatedPayload = UserChoiceHandler.buildMultiChoiceFormBlocks(
+      choicesData,
+      pendingForm.formId,
+      pendingForm.sessionKey,
+      pendingForm.selections
+    );
+
+    try {
+      await this.ctx.slackApi.updateMessage(channel, messageTs, '📋 선택이 필요합니다', undefined, updatedPayload.attachments);
+    } catch (error) {
+      this.logger.warn('Failed to update form UI', error);
     }
   }
 

--- a/src/slack/actions/index.ts
+++ b/src/slack/actions/index.ts
@@ -84,6 +84,24 @@ export class ActionHandlers {
       await this.choiceHandler.handleMultiChoice(body);
     });
 
+    // Edit choice (reselect a previously answered question)
+    app.action(/^edit_choice_/, async ({ ack, body }) => {
+      await ack();
+      await this.choiceHandler.handleEditChoice(body);
+    });
+
+    // Form submit (final submission of all selections)
+    app.action(/^submit_form_/, async ({ ack, body }) => {
+      await ack();
+      await this.choiceHandler.handleFormSubmit(body);
+    });
+
+    // Form reset (clear all selections)
+    app.action(/^reset_form_/, async ({ ack, body }) => {
+      await ack();
+      await this.choiceHandler.handleFormReset(body);
+    });
+
     app.action('custom_input_single', async ({ ack, body, client }) => {
       await ack();
       await this.formHandler.handleCustomInputSingle(body, client);

--- a/src/slack/user-choice-handler.test.ts
+++ b/src/slack/user-choice-handler.test.ts
@@ -469,13 +469,13 @@ this is not valid json
       const payload = UserChoiceHandler.buildMultiChoiceFormBlocks(sampleChoices, 'form-1', 'session-key', selections);
       const blocks = getBlocks(payload);
 
-      // First question should show as fields (strikethrough question, bold label)
+      // First question should show with checkmark and edit button (accessory)
       const q1Section = blocks.find((b: any) =>
-        b.type === 'section' && b.fields?.some((f: any) => f.text?.includes('First question'))
+        b.type === 'section' && b.text?.text?.includes('First question') && b.accessory
       );
       expect(q1Section).toBeDefined();
 
-      // Should only have 1 actions block (for q2)
+      // Should have 1 actions block for q2 (unanswered question)
       const actionBlocks = blocks.filter((b: any) => b.type === 'actions');
       expect(actionBlocks).toHaveLength(1);
     });
@@ -512,10 +512,17 @@ this is not valid json
       const payload = UserChoiceHandler.buildMultiChoiceFormBlocks(sampleChoices, 'form-1', 'session-key', selections);
       const blocks = getBlocks(payload);
 
+      // Now shows completion section with submit/reset buttons
       const completionBlock = blocks.find((b: any) =>
-        b.type === 'section' && b.text?.text?.includes('모든 선택 완료')
+        b.type === 'section' && b.text?.text?.includes('모든 선택이 완료')
       );
       expect(completionBlock).toBeDefined();
+
+      // Should have submit and reset buttons
+      const submitActions = blocks.find((b: any) =>
+        b.type === 'actions' && b.elements?.some((e: any) => e.action_id?.startsWith('submit_form_'))
+      );
+      expect(submitActions).toBeDefined();
     });
 
     it('should change color to green when complete', () => {


### PR DESCRIPTION
## Summary
- Add edit button (🔄 변경) to reselect previously answered questions
- Replace auto-submit with explicit Submit button (🚀 제출하기) when all questions answered
- Add Reset button (🗑️ 모두 초기화) with confirmation dialog to clear all selections
- Improve visual hierarchy with numbered emojis (1️⃣ 2️⃣ 3️⃣ 4️⃣)
- Add question status indicators (❓ pending, ✅ selected)
- Show selected answer with arrow indicator (➜ *답변*)

## Test plan
- [ ] Test multi-choice form with 2+ questions
- [ ] Verify edit button reopens question for reselection
- [ ] Verify submit button only appears when all questions answered
- [ ] Verify reset button clears all selections with confirmation
- [ ] Verify single-option questions still work with immediate submit

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)