### PR TITLE
feat: runtime LLM model configuration via set/show/reset commands

### DIFF
--- a/src/llm-chat-config-store.test.ts
+++ b/src/llm-chat-config-store.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LlmChatConfigStore } from './llm-chat-config-store';
+
+describe('LlmChatConfigStore', () => {
+  let store: LlmChatConfigStore;
+
+  beforeEach(() => {
+    store = new LlmChatConfigStore();
+  });
+
+  describe('constructor / defaults', () => {
+    it('should initialize with default codex model', () => {
+      const cfg = store.getBackendConfig('codex');
+      expect(cfg.model).toBe('gpt-5.3-codex');
+      expect(cfg.backend).toBe('codex');
+    });
+
+    it('should initialize with default gemini model', () => {
+      const cfg = store.getBackendConfig('gemini');
+      expect(cfg.model).toBe('gemini-3.1-pro-preview');
+      expect(cfg.backend).toBe('gemini');
+    });
+
+    it('should have codex reasoning effort as xhigh by default', () => {
+      const cfg = store.getBackendConfig('codex');
+      expect(cfg.configOverride?.model_reasoning_effort).toBe('xhigh');
+    });
+  });
+
+  describe('set()', () => {
+    it('should update model for valid provider', () => {
+      const err = store.set('codex', 'model', 'gpt-5.4');
+      expect(err).toBeUndefined();
+      expect(store.getBackendConfig('codex').model).toBe('gpt-5.4');
+    });
+
+    it('should update config override for valid key', () => {
+      const err = store.set('codex', 'model_reasoning_effort', 'low');
+      expect(err).toBeUndefined();
+      expect(store.getBackendConfig('codex').configOverride?.model_reasoning_effort).toBe('low');
+    });
+
+    it('should reject unknown provider', () => {
+      const err = store.set('openai', 'model', 'gpt-5');
+      expect(err).toContain('Unknown provider');
+    });
+
+    it('should reject unknown key', () => {
+      const err = store.set('codex', 'temperature', '0.5');
+      expect(err).toContain('Unknown key');
+    });
+
+    it('should reject values with double quotes', () => {
+      const err = store.set('codex', 'model', 'gpt"5');
+      expect(err).toContain('Invalid value');
+    });
+
+    it('should reject values with angle brackets', () => {
+      expect(store.set('codex', 'model', 'gpt<5>')).toContain('Invalid value');
+    });
+
+    it('should reject values with spaces (allowlist)', () => {
+      const err = store.set('codex', 'model', 'gpt 5.4');
+      expect(err).toContain('Invalid value');
+    });
+
+    it('should reject values with unicode special chars', () => {
+      const err = store.set('codex', 'model', 'gpt\u200B5'); // zero-width space
+      expect(err).toContain('Invalid value');
+    });
+
+    it('should accept valid model names with dots and hyphens', () => {
+      expect(store.set('codex', 'model', 'gpt-5.3-codex')).toBeUndefined();
+      expect(store.set('gemini', 'model', 'gemini-3.1-pro-preview')).toBeUndefined();
+    });
+
+    it('should accept values with colons', () => {
+      expect(store.set('codex', 'model', 'org:model-v1')).toBeUndefined();
+    });
+  });
+
+  describe('reset()', () => {
+    it('should restore default values after modification', () => {
+      store.set('codex', 'model', 'custom-model');
+      store.reset();
+      expect(store.getBackendConfig('codex').model).toBe('gpt-5.3-codex');
+    });
+  });
+
+  describe('getConfig() / getBackendConfig()', () => {
+    it('should return cloned config (mutation-safe)', () => {
+      const cfg1 = store.getConfig();
+      const cfg2 = store.getConfig();
+      expect(cfg1).toEqual(cfg2);
+      expect(cfg1).not.toBe(cfg2); // different references
+    });
+
+    it('should return cloned backend config', () => {
+      const cfg1 = store.getBackendConfig('codex');
+      const cfg2 = store.getBackendConfig('codex');
+      expect(cfg1).toEqual(cfg2);
+      expect(cfg1).not.toBe(cfg2);
+    });
+  });
+
+  describe('toPromptSnippet()', () => {
+    it('should generate valid prompt snippet with model names', () => {
+      const snippet = store.toPromptSnippet();
+      expect(snippet).toContain('codex');
+      expect(snippet).toContain('gemini');
+      expect(snippet).toContain('gpt-5.3-codex');
+      expect(snippet).toContain('gemini-3.1-pro-preview');
+    });
+
+    it('should include config overrides in snippet', () => {
+      const snippet = store.toPromptSnippet();
+      expect(snippet).toContain('model_reasoning_effort');
+      expect(snippet).toContain('xhigh');
+    });
+
+    it('should reflect updated values', () => {
+      store.set('codex', 'model', 'gpt-5.4');
+      const snippet = store.toPromptSnippet();
+      expect(snippet).toContain('gpt-5.4');
+      expect(snippet).not.toContain('gpt-5.3-codex');
+    });
+  });
+
+  describe('formatForDisplay()', () => {
+    it('should format config for Slack display', () => {
+      const display = store.formatForDisplay();
+      expect(display).toContain('*codex*');
+      expect(display).toContain('*gemini*');
+      expect(display).toContain('gpt-5.3-codex');
+    });
+  });
+});

--- a/src/llm-chat-config-store.ts
+++ b/src/llm-chat-config-store.ts
@@ -1,0 +1,145 @@
+/**
+ * LlmChatConfigStore - In-memory runtime configuration for llm_chat MCP tools
+ *
+ * Manages model/config settings for codex and gemini backends.
+ * Settings persist per-process (session); reset on restart.
+ * Designed for future extension to file-based persistence.
+ */
+
+import { Logger } from './logger';
+
+export type LlmBackend = 'codex' | 'gemini';
+
+export interface LlmBackendConfig {
+  backend: LlmBackend;
+  model: string;
+  configOverride?: Record<string, string>;
+}
+
+export type LlmChatConfig = Record<LlmBackend, LlmBackendConfig>;
+
+const SETTABLE_KEYS = new Set(['model', 'model_reasoning_effort']);
+
+const DEFAULT_CONFIG: LlmChatConfig = {
+  codex: {
+    backend: 'codex',
+    model: 'gpt-5.3-codex',
+    configOverride: { model_reasoning_effort: 'xhigh' },
+  },
+  gemini: {
+    backend: 'gemini',
+    model: 'gemini-3.1-pro-preview',
+  },
+};
+
+const VALID_BACKENDS: ReadonlySet<string> = new Set(Object.keys(DEFAULT_CONFIG));
+
+export class LlmChatConfigStore {
+  private logger = new Logger('LlmChatConfigStore');
+  private config: LlmChatConfig;
+
+  constructor() {
+    this.config = this.cloneConfig(DEFAULT_CONFIG);
+    this.logger.info('Initialized with default config', {
+      codexModel: this.config.codex.model,
+      geminiModel: this.config.gemini.model,
+    });
+  }
+
+  getConfig(): Readonly<LlmChatConfig> {
+    return this.cloneConfig(this.config);
+  }
+
+  getBackendConfig(backend: LlmBackend): Readonly<LlmBackendConfig> {
+    return this.cloneBackendConfig(this.config[backend]);
+  }
+
+  /** @returns Error message if invalid, undefined on success */
+  set(provider: string, key: string, value: string): string | undefined {
+    if (!VALID_BACKENDS.has(provider)) {
+      return `Unknown provider: \`${provider}\`. Valid providers: ${[...VALID_BACKENDS].join(', ')}`;
+    }
+    if (!SETTABLE_KEYS.has(key)) {
+      return `Unknown key: \`${key}\`. Valid keys: ${[...SETTABLE_KEYS].join(', ')}`;
+    }
+    if (!/^[\w.:-]+$/.test(value)) {
+      return 'Invalid value: must contain only alphanumeric characters, dots, hyphens, and colons';
+    }
+
+    const backend = provider as LlmBackend;
+
+    if (key === 'model') {
+      const oldModel = this.config[backend].model;
+      this.config[backend].model = value;
+      this.logger.info('Model updated', { backend, oldModel, newModel: value });
+    } else {
+      const overrides = this.config[backend].configOverride ??= {};
+      const oldValue = overrides[key];
+      overrides[key] = value;
+      this.logger.info('Config override updated', { backend, key, oldValue, newValue: value });
+    }
+
+    return undefined;
+  }
+
+  reset(): void {
+    this.config = this.cloneConfig(DEFAULT_CONFIG);
+    this.logger.info('Config reset to defaults');
+  }
+
+  formatForDisplay(): string {
+    const lines: string[] = [];
+
+    for (const backend of Object.keys(this.config) as LlmBackend[]) {
+      const cfg = this.config[backend];
+      lines.push(`*${backend}* {`);
+      lines.push(`  backend: '${cfg.backend}',`);
+      lines.push(`  model: '${cfg.model}',`);
+      if (cfg.configOverride && Object.keys(cfg.configOverride).length > 0) {
+        const overrideStr = Object.entries(cfg.configOverride)
+          .map(([k, v]) => `${k}: '${v}'`)
+          .join(', ');
+        lines.push(`  configOverride: { ${overrideStr} },`);
+      }
+      lines.push('}');
+      lines.push('');
+    }
+
+    return lines.join('\n').trimEnd();
+  }
+
+  /** Generate prompt snippet for system prompt injection (replaces hardcoded models in common.prompt) */
+  toPromptSnippet(): string {
+    const formatBackend = (cfg: LlmBackendConfig): string => {
+      const configStr = cfg.configOverride && Object.keys(cfg.configOverride).length > 0
+        ? `, config: { ${Object.entries(cfg.configOverride).map(([k, v]) => `"${k}":"${v}"`).join(', ')} }`
+        : '';
+      return `    - ${cfg.backend}: <parameters>model: "${cfg.model}"${configStr}</parameters>`;
+    };
+
+    return (Object.keys(this.config) as LlmBackend[])
+      .map((key) => formatBackend(this.config[key]))
+      .join('\n');
+  }
+
+  private cloneBackendConfig(cfg: LlmBackendConfig): LlmBackendConfig {
+    return {
+      backend: cfg.backend,
+      model: cfg.model,
+      configOverride: cfg.configOverride ? { ...cfg.configOverride } : undefined,
+    };
+  }
+
+  private cloneConfig(source: LlmChatConfig): LlmChatConfig {
+    const result = {} as LlmChatConfig;
+    for (const key of Object.keys(source) as LlmBackend[]) {
+      result[key] = this.cloneBackendConfig(source[key]);
+    }
+    return result;
+  }
+}
+
+// Singleton instance — process-wide by design.
+// Config is shared across all users; mutation access (set/reset) is restricted
+// to ADMIN_USER_ID at the command handler layer (LlmChatHandler.isAdmin).
+export const llmChatConfigStore = new LlmChatConfigStore();

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -6,6 +6,7 @@
 
 import { Logger } from './logger';
 import { userSettingsStore } from './user-settings-store';
+import { llmChatConfigStore } from './llm-chat-config-store';
 import { SYSTEM_PROMPT_FILE } from './env-paths';
 import { WorkflowType } from './types';
 import * as path from 'path';
@@ -20,6 +21,8 @@ const PERSONA_DIR = path.join(__dirname, 'persona');
 
 // Include directive pattern: {{include:filename.prompt}}
 const INCLUDE_PATTERN = /\{\{include:([^}]+)\}\}/g;
+// Runtime variable pattern: {{variable_name}}
+const VARIABLE_PATTERN = /\{\{(\w+)\}\}/g;
 
 /**
  * PromptBuilder handles system prompt, workflow prompts, and persona loading
@@ -40,7 +43,10 @@ export class PromptBuilder {
   private loadDefaultPrompt(): void {
     try {
       if (fs.existsSync(DEFAULT_PROMPT_PATH)) {
-        this.defaultSystemPrompt = fs.readFileSync(DEFAULT_PROMPT_PATH, 'utf-8');
+        let content = fs.readFileSync(DEFAULT_PROMPT_PATH, 'utf-8');
+        // Process include directives (e.g., {{include:./common.prompt}})
+        content = this.processIncludes(content);
+        this.defaultSystemPrompt = content;
       }
 
       // Load local system prompt if exists (not committed to source)
@@ -144,6 +150,20 @@ export class PromptBuilder {
           fs.closeSync(fd);
         }
       }
+    });
+  }
+
+  /**
+   * Process runtime variable placeholders in prompt content
+   * Replaces {{variable_name}} with runtime values
+   */
+  private processVariables(content: string): string {
+    return content.replace(VARIABLE_PATTERN, (match, varName) => {
+      if (varName === 'llm_chat_config') {
+        return llmChatConfigStore.toPromptSnippet();
+      }
+      // Unknown variables are left as-is
+      return match;
     });
   }
 
@@ -262,6 +282,12 @@ export class PromptBuilder {
 
         this.logger.debug('Applied persona', { user: userId, persona: personaName, workflow });
       }
+    }
+
+    // Process runtime variables (e.g., {{llm_chat_config}})
+    // Done last so dynamic config values are always current
+    if (systemPrompt) {
+      systemPrompt = this.processVariables(systemPrompt);
     }
 
     return systemPrompt || undefined;

--- a/src/prompt/common.prompt
+++ b/src/prompt/common.prompt
@@ -12,6 +12,5 @@ You are a 400-yr full stack software engineer from assembly to c++, rust, javasc
 # 똑똑한 부하 모델(MCP)
 - 유저의 명시적 요청이 있거나, 네 생각에 복잡도가 일정 이상일 경우 다음 모델을 사용해서 네가 판단을 내린 코드 스니펫과 네 출력을 다음의 똑똑한 부하 mcp들에게 물어보고 그 답변까지 고려해서 답을 해줘. 먼저 네 답변을 출력하고 이 codex mcp는 답변에 좀 시간이 걸리니까 그것도 유저에게 알려줘야해.
   - 부하 MCP:
-    - llm_chat: <parameters>model: "codex"</parameters>
-    - llm_chat: <parameters>model: "gemini"</parameters>
+{{llm_chat_config}}
 </system_prompt>

--- a/src/slack/command-parser.ts
+++ b/src/slack/command-parser.ts
@@ -11,6 +11,11 @@ export type NewCommandResult = { prompt?: string };
 export type OnboardingCommandResult = { prompt?: string };
 export type SessionsCommandResult = { isPublic: boolean };
 export type LinkCommandResult = { linkType: 'issue' | 'pr' | 'doc'; url: string } | null;
+export type LlmChatAction =
+  | { action: 'show' }
+  | { action: 'set'; provider: string; key: string; value: string }
+  | { action: 'reset' }
+  | { action: 'error'; message: string };
 export type SessionCommandAction =
   | { type: 'info' }
   | { type: 'model'; action: 'status' | 'set'; model?: string }
@@ -340,6 +345,52 @@ export class CommandParser {
   }
 
   /**
+   * Check if text is any llm_chat command (set/show/reset)
+   */
+  static isLlmChatCommand(text: string): boolean {
+    return /^\/?(?:set|show|reset)\s+llm_chat\b/i.test(text.trim());
+  }
+
+  /**
+   * Parse llm_chat command
+   */
+  static parseLlmChatCommand(text: string): LlmChatAction {
+    const trimmed = text.trim();
+
+    if (/^\/?show\s+llm_chat\s*$/i.test(trimmed)) {
+      return { action: 'show' };
+    }
+
+    if (/^\/?reset\s+llm_chat\s*$/i.test(trimmed)) {
+      return { action: 'reset' };
+    }
+
+    // Parse: set llm_chat <provider> <key> <value>
+    const setMatch = trimmed.match(
+      /^\/?set\s+llm_chat\s+(\S+)\s+(\S+)\s+(.+)$/i
+    );
+    if (setMatch) {
+      return {
+        action: 'set',
+        provider: setMatch[1].toLowerCase(),
+        key: setMatch[2].toLowerCase(),
+        value: setMatch[3].trim(),
+      };
+    }
+
+    // If "set llm_chat" but missing args, return error with usage guidance
+    if (/^\/?set\s+llm_chat/i.test(trimmed)) {
+      return {
+        action: 'error',
+        message: 'Usage: `set llm_chat <provider> <key> <value>`\nExample: `set llm_chat codex model gpt-5.4`',
+      };
+    }
+
+    // Fallback for any other unrecognized pattern
+    return { action: 'error', message: 'Unrecognized llm_chat command.\nUsage: `show llm_chat` | `set llm_chat <provider> <key> <value>` | `reset llm_chat`' };
+  }
+
+  /**
    * Check if text is a marketplace command
    */
   static isMarketplaceCommand(text: string): boolean {
@@ -551,6 +602,12 @@ export class CommandParser {
       '• `model list` - List available models',
       '• `verbosity` - Show current log verbosity',
       '• `verbosity <level>` - Set log verbosity (minimal/compact/detail/verbose)',
+      '',
+      '*LLM Chat Config:*',
+      '• `show llm_chat` - Show current llm_chat model configuration',
+      '• `set llm_chat <provider> model <value>` - Change model (e.g., `set llm_chat codex model gpt-5.4`)',
+      '• `set llm_chat <provider> model_reasoning_effort <value>` - Change reasoning effort',
+      '• `reset llm_chat` - Reset llm_chat config to defaults',
       '',
       '*Session Settings ($ prefix):*',
       '• `$` - Show current session info (model, effort, verbosity, context, etc.)',

--- a/src/slack/commands/command-router.ts
+++ b/src/slack/commands/command-router.ts
@@ -20,6 +20,7 @@ import { MarketplaceHandler } from './marketplace-handler';
 import { PluginsHandler } from './plugins-handler';
 import { CctHandler } from './cct-handler';
 import { AdminHandler } from './admin-handler';
+import { LlmChatHandler } from './llm-chat-handler';
 import { CommandParser } from '../command-parser';
 
 /**
@@ -33,6 +34,7 @@ export class CommandRouter {
     // Register all command handlers in priority order
     // Order matters - more specific handlers should come first
     this.handlers = [
+      new LlmChatHandler(),
       new AdminHandler(),
       new CctHandler(),
       new CwdHandler(deps),

--- a/src/slack/commands/llm-chat-handler.ts
+++ b/src/slack/commands/llm-chat-handler.ts
@@ -1,0 +1,64 @@
+import { CommandHandler, CommandContext, CommandResult } from './types';
+import { CommandParser } from '../command-parser';
+import { llmChatConfigStore } from '../../llm-chat-config-store';
+
+const ADMIN_USER_ID = process.env.ADMIN_USER_ID;
+
+/**
+ * Handles llm_chat configuration commands (set/show/reset)
+ *
+ * Commands:
+ *   show llm_chat              - Display current config (all users)
+ *   set llm_chat <p> <k> <v>  - Update a setting (admin only)
+ *   reset llm_chat             - Reset to defaults (admin only)
+ */
+export class LlmChatHandler implements CommandHandler {
+  canHandle(text: string): boolean {
+    return CommandParser.isLlmChatCommand(text);
+  }
+
+  /** Returns true if admin, otherwise sends permission denied and returns false. */
+  private async requireAdmin(userId: string, reply: (msg: string) => Promise<unknown>): Promise<boolean> {
+    if (ADMIN_USER_ID && userId === ADMIN_USER_ID) return true;
+    await reply(`🔒 *Permission Denied*\n\nOnly admins can modify LLM chat configuration.`);
+    return false;
+  }
+
+  async execute(ctx: CommandContext): Promise<CommandResult> {
+    const { text, user, threadTs, say } = ctx;
+    const action = CommandParser.parseLlmChatCommand(text);
+
+    const reply = (message: string) => say({ text: message, thread_ts: threadTs });
+
+    switch (action.action) {
+      case 'show': {
+        const display = llmChatConfigStore.formatForDisplay();
+        await reply(`⚙️ *LLM Chat Configuration*\n\n\`\`\`\n${display}\n\`\`\`\n\n_Use \`set llm_chat <provider> <key> <value>\` to change settings (admin only)._`);
+        break;
+      }
+      case 'reset': {
+        if (!await this.requireAdmin(user, reply)) break;
+        llmChatConfigStore.reset();
+        const display = llmChatConfigStore.formatForDisplay();
+        await reply(`🔄 *LLM Chat Config Reset*\n\nConfiguration reset to defaults:\n\`\`\`\n${display}\n\`\`\``);
+        break;
+      }
+      case 'set': {
+        if (!await this.requireAdmin(user, reply)) break;
+        const error = llmChatConfigStore.set(action.provider, action.key, action.value);
+        if (error) {
+          await reply(`❌ *Configuration Error*\n\n${error}`);
+        } else {
+          await reply(`✅ *LLM Chat Config Updated*\n\n\`${action.provider}.${action.key}\` → \`${action.value}\`\n\n_This change applies to new llm_chat calls in this session._`);
+        }
+        break;
+      }
+      case 'error': {
+        await reply(`❌ *Invalid Command*\n\n${action.message}`);
+        break;
+      }
+    }
+
+    return { handled: true };
+  }
+}


### PR DESCRIPTION
## Summary
- `llm_chat` MCP 도구의 모델 설정을 런타임에 변경 가능하도록 `set`/`show`/`reset` 커맨드 추가
- In-memory config store로 세션 단위 설정 관리
- 시스템 프롬프트에 `{{llm_chat_config}}` 템플릿 변수를 통한 동적 설정 주입
- Admin-only 접근 제어, allowlist input validation, workflow prompt caching

## Changes
- **`src/llm-chat-config-store.ts`** — codex/gemini 백엔드 런타임 설정 관리 (싱글톤)
- **`src/slack/commands/llm-chat-handler.ts`** — `set llm_chat`/`show llm_chat`/`reset llm_chat` 커맨드 핸들러
- **`src/slack/command-parser.ts`** — 새 커맨드 파싱 로직 + 헬프 메시지 업데이트
- **`src/slack/commands/command-router.ts`** — LlmChatHandler 등록
- **`src/prompt-builder.ts`** — `{{llm_chat_config}}` 런타임 변수 처리 + workflow prompt caching
- **`src/prompt/common.prompt`** — 하드코딩된 모델명을 `{{llm_chat_config}}` 플레이스홀더로 교체

## Tests
- `src/llm-chat-config-store.test.ts` — 20 test cases (set/reset/validation/display)
- `src/slack/command-parser.test.ts` — 19 new test cases (isLlmChatCommand/parseLlmChatCommand)
- 945 total tests pass ✅ | TypeScript clean ✅

## Review
3-agent review completed (Claude + Oracle Codex + Oracle Gemini): APPROVE
- P0/P1: 0건 | P2: 5건 수정 완료 (allowlist validation, error msg fix, cache restoration, fallback error, tests)

Rebased on dev branch (conflict-free)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)