### PR TITLE
fix: LlmChatHandler admin check uses wrong env var

### DIFF
--- a/src/llm-chat-config-store.ts
+++ b/src/llm-chat-config-store.ts
@@ -141,5 +141,5 @@ export class LlmChatConfigStore {
 
 // Singleton instance — process-wide by design.
 // Config is shared across all users; mutation access (set/reset) is restricted
-// to ADMIN_USER_ID at the command handler layer (LlmChatHandler.isAdmin).
+// to ADMIN_USERS via isAdminUser() at the command handler layer (LlmChatHandler.requireAdmin).
 export const llmChatConfigStore = new LlmChatConfigStore();

--- a/src/slack/commands/llm-chat-handler.ts
+++ b/src/slack/commands/llm-chat-handler.ts
@@ -1,8 +1,7 @@
 import { CommandHandler, CommandContext, CommandResult } from './types';
 import { CommandParser } from '../command-parser';
 import { llmChatConfigStore } from '../../llm-chat-config-store';
-
-const ADMIN_USER_ID = process.env.ADMIN_USER_ID;
+import { isAdminUser } from '../../admin-utils';
 
 /**
  * Handles llm_chat configuration commands (set/show/reset)
@@ -19,7 +18,7 @@ export class LlmChatHandler implements CommandHandler {
 
   /** Returns true if admin, otherwise sends permission denied and returns false. */
   private async requireAdmin(userId: string, reply: (msg: string) => Promise<unknown>): Promise<boolean> {
-    if (ADMIN_USER_ID && userId === ADMIN_USER_ID) return true;
+    if (isAdminUser(userId)) return true;
     await reply(`🔒 *Permission Denied*\n\nOnly admins can modify LLM chat configuration.`);
     return false;
   }


### PR DESCRIPTION
## Summary
- LlmChatHandler was checking `process.env.ADMIN_USER_ID` (non-existent) instead of using `isAdminUser()` from `admin-utils.ts`
- This caused ALL `set`/`reset llm_chat` commands to be denied, even for actual admins
- Fix: replace custom admin check with shared `isAdminUser()` utility (same as cct-handler, admin-handler)

## Root cause
The original implementation used a singleton env var pattern (`ADMIN_USER_ID`) that doesn't exist in this codebase. The codebase uses `ADMIN_USERS` (plural, comma-separated) via `admin-utils.ts`.

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 986 tests pass
- [x] Verified admin check now uses correct `isAdminUser()` function

Generated with Claude Code