### PR TITLE
fix: cache 토큰 컨텍스트 계산 포함 + 모델별 1M lookup

### DIFF
--- a/src/slack/commands/context-handler.test.ts
+++ b/src/slack/commands/context-handler.test.ts
@@ -155,7 +155,7 @@ describe('ContextHandler', () => {
     });
 
     it('should show warning when context is nearly full', async () => {
-      // 180k used out of 200k = only 10% available
+      // Total used = 150k + 30k + 5k(cacheRead) + 2k(cacheCreate) = 187k of 200k = 7% remaining
       const usage: SessionUsage = {
         currentInputTokens: 150000,
         currentOutputTokens: 30000,
@@ -180,7 +180,7 @@ describe('ContextHandler', () => {
 
       const postSystemMessage = mockDeps.slackApi.postSystemMessage as ReturnType<typeof vi.fn>;
       const message = postSystemMessage.mock.calls[0][1];
-      expect(message).toContain('10% available');
+      expect(message).toContain('7% available');
       expect(message).toContain('⚠️ Context running low');
       expect(message).toContain('/renew');
     });
@@ -210,6 +210,8 @@ describe('ContextHandler', () => {
 
       const postSystemMessage = mockDeps.slackApi.postSystemMessage as ReturnType<typeof vi.fn>;
       const message = postSystemMessage.mock.calls[0][1];
+      // Context now includes cache tokens: 5000 + 3000 + 500 + 1000 = 9500 = 9.5k
+      expect(message).toContain('9.5k/200k');
       expect(message).toContain('Cache read: 3k');
       expect(message).toContain('Cache created: 500');
     });

--- a/src/slack/commands/context-handler.ts
+++ b/src/slack/commands/context-handler.ts
@@ -37,7 +37,7 @@ export class ContextHandler implements CommandHandler {
     const usage = session.usage;
 
     // Calculate context window usage using single source of truth
-    const currentContext = usage.currentInputTokens + usage.currentOutputTokens;
+    const currentContext = ContextWindowManager.computeUsedTokens(usage);
     const contextWindow = usage.contextWindow;
     const availablePercent = ContextWindowManager.computeRemainingPercent(usage);
 

--- a/src/slack/context-window-manager.ts
+++ b/src/slack/context-window-manager.ts
@@ -86,9 +86,30 @@ export class ContextWindowManager {
    */
   static computeRemainingPercent(usage: SessionUsage): number {
     if (!usage || usage.contextWindow <= 0) return 0;
-    const usedTokens = usage.currentInputTokens + usage.currentOutputTokens;
+    const usedTokens = this.computeUsedTokens(usage);
     const contextWindow = usage.contextWindow;
     return Math.max(0, Math.min(100, ((contextWindow - usedTokens) / contextWindow) * 100));
+  }
+
+  /**
+   * Compute total tokens occupying the context window.
+   *
+   * SDK's modelUsage reports `inputTokens` as non-cached tokens only.
+   * Cache-read and cache-creation tokens still occupy context window
+   * space, so we must include them:
+   *
+   *   contextUsed = inputTokens + cacheReadTokens + cacheCreateTokens + outputTokens
+   *
+   * Example: inputTokens=3, cacheRead=117.5k, cacheCreate=5.8k, output=626
+   *   → actual context = 123,929 tokens (not 629)
+   */
+  static computeUsedTokens(usage: SessionUsage): number {
+    return (
+      usage.currentInputTokens +
+      usage.currentCacheReadTokens +
+      usage.currentCacheCreateTokens +
+      usage.currentOutputTokens
+    );
   }
 
   /**

--- a/src/slack/pipeline/session-usage.test.ts
+++ b/src/slack/pipeline/session-usage.test.ts
@@ -284,6 +284,37 @@ describe('Dynamic Context Window from SDK', () => {
   });
 });
 
+describe('Cache tokens in context calculation', () => {
+  /**
+   * CRITICAL BUG FIX: SDK's modelUsage reports `inputTokens` as
+   * non-cached tokens only. Cache tokens must be included for context size.
+   *
+   * Real data from Opus 4.6 session:
+   *   inputTokens=3, cacheRead=117.5k, cacheCreate=5.8k, output=626
+   *   Wrong: 3 + 626 = 629 (what old code showed)
+   *   Right: 3 + 117,500 + 5,800 + 626 = 123,929
+   */
+  it('should include cache tokens in total context used', () => {
+    const session: { usage?: SessionUsage } = {};
+
+    updateSessionUsage(session, {
+      inputTokens: 3,
+      outputTokens: 626,
+      cacheReadInputTokens: 117_500,
+      cacheCreationInputTokens: 5_800,
+      totalCostUsd: 0.11,
+    });
+
+    const u = session.usage!;
+    // Total context = input + cacheRead + cacheCreate + output
+    const totalUsed = u.currentInputTokens + u.currentCacheReadTokens + u.currentCacheCreateTokens + u.currentOutputTokens;
+    expect(totalUsed).toBe(123_929);
+
+    // Old calculation (WRONG): just inputTokens + outputTokens
+    expect(u.currentInputTokens + u.currentOutputTokens).toBe(629);
+  });
+});
+
 /**
  * MATHEMATICAL PROOF:
  *

--- a/src/slack/pipeline/stream-executor.ts
+++ b/src/slack/pipeline/stream-executor.ts
@@ -47,9 +47,34 @@ export interface ExecuteResult {
 }
 
 // Fallback context window size when SDK doesn't report contextWindow.
-// Modern models (Opus 4.6, Sonnet 4.6) have 1M natively, but older models
-// default to 200k. We use 200k as a safe fallback.
 const FALLBACK_CONTEXT_WINDOW = 200_000;
+
+/**
+ * Known model context window sizes.
+ * Key: model family substring matched against the full model name.
+ * When SDK doesn't provide ModelUsage.contextWindow, we look up here.
+ */
+const MODEL_CONTEXT_WINDOWS: [pattern: string, contextWindow: number][] = [
+  // 4.6 models: 1M native (no beta header needed)
+  ['opus-4-6', 1_000_000],
+  ['sonnet-4-6', 1_000_000],
+  // 4.5 models: 200k default (1M with beta header, but we use default)
+  ['opus-4-5', 200_000],
+  ['sonnet-4-5', 200_000],
+  ['haiku-4-5', 200_000],
+  // 4.0 models
+  ['sonnet-4-', 200_000],
+  ['haiku-4-', 200_000],
+];
+
+/** Resolve context window for a model by name pattern matching. */
+function resolveContextWindow(modelName?: string): number {
+  if (!modelName) return FALLBACK_CONTEXT_WINDOW;
+  for (const [pattern, size] of MODEL_CONTEXT_WINDOWS) {
+    if (modelName.includes(pattern)) return size;
+  }
+  return FALLBACK_CONTEXT_WINDOW;
+}
 
 interface StreamExecutorDeps {
   claudeHandler: ClaudeHandler;
@@ -1068,34 +1093,46 @@ export class StreamExecutor {
       };
     }
 
-    // Dynamically update context window from SDK if available.
-    // This replaces the hardcoded 200k — the SDK knows the model's actual max.
-    if (usage.contextWindow && usage.contextWindow > 0) {
-      session.usage.contextWindow = usage.contextWindow;
-    }
-
     // Update model name on session (useful for display)
     if (usage.modelName && !session.model) {
       session.model = usage.modelName;
     }
 
-    // Update current context (overwrite - this is the current context window usage)
-    // Context window = input (history + new message) + output (current response)
+    // Dynamically update context window:
+    // 1. SDK's ModelUsage.contextWindow (if available)
+    // 2. Model-name lookup table (opus-4-6 → 1M, etc.)
+    // 3. Keep existing value (don't downgrade to fallback)
+    if (usage.contextWindow && usage.contextWindow > 0) {
+      session.usage.contextWindow = usage.contextWindow;
+    } else if (session.usage.contextWindow === FALLBACK_CONTEXT_WINDOW) {
+      // Only do lookup if still at fallback — don't override a previous SDK value
+      const modelName = usage.modelName || session.model;
+      const resolved = resolveContextWindow(modelName);
+      if (resolved !== FALLBACK_CONTEXT_WINDOW) {
+        session.usage.contextWindow = resolved;
+      }
+    }
+
+    // Update current context (overwrite — this is the current context window usage)
+    // NOTE: inputTokens from SDK modelUsage = non-cached tokens only.
+    // Cache tokens are stored separately and included in context calculations
+    // via ContextWindowManager.computeUsedTokens().
     session.usage.currentInputTokens = usage.inputTokens;
     session.usage.currentOutputTokens = usage.outputTokens;
     session.usage.currentCacheReadTokens = usage.cacheReadInputTokens;
     session.usage.currentCacheCreateTokens = usage.cacheCreationInputTokens;
 
-    // Accumulate totals
+    // Accumulate totals (billing-oriented: each field summed independently)
     session.usage.totalInputTokens += usage.inputTokens;
     session.usage.totalOutputTokens += usage.outputTokens;
     session.usage.totalCostUsd += usage.totalCostUsd;
     session.usage.lastUpdated = Date.now();
 
+    const totalUsed = usage.inputTokens + usage.cacheReadInputTokens + usage.cacheCreationInputTokens + usage.outputTokens;
     this.logger.debug('Updated session usage', {
-      currentContext: session.usage.currentInputTokens + session.usage.currentOutputTokens,
+      currentContext: totalUsed,
       contextWindow: session.usage.contextWindow,
-      contextWindowSource: usage.contextWindow ? 'sdk' : 'fallback',
+      contextWindowSource: usage.contextWindow ? 'sdk' : (session.model ? 'model-lookup' : 'fallback'),
       totalInput: session.usage.totalInputTokens,
       totalOutput: session.usage.totalOutputTokens,
       totalCostUsd: session.usage.totalCostUsd,

--- a/src/slack/thread-header-builder.ts
+++ b/src/slack/thread-header-builder.ts
@@ -1,4 +1,5 @@
 import { SessionLinks, SessionUsage, WorkflowType, ConversationSession } from '../types';
+import { ContextWindowManager } from './context-window-manager';
 
 export interface ThreadHeaderData {
   title?: string;
@@ -122,7 +123,7 @@ export class ThreadHeaderBuilder {
   static formatContextBar(usage?: SessionUsage): string | undefined {
     if (!usage || usage.contextWindow <= 0) return undefined;
 
-    const used = usage.currentInputTokens + usage.currentOutputTokens;
+    const used = ContextWindowManager.computeUsedTokens(usage);
     const total = usage.contextWindow;
     const usedPercent = Math.min(100, (used / total) * 100);
 

--- a/src/slack/thread-panel.test.ts
+++ b/src/slack/thread-panel.test.ts
@@ -173,7 +173,9 @@ describe('ThreadPanel', () => {
       block.type === 'section' && Array.isArray(block.fields)
     );
     const fieldsText = fieldsSection?.fields?.map((f: any) => String(f.text || '')).join(' ') || '';
-    expect(fieldsText).toContain('60%');
+    // Context used = input(70k) + cacheRead(5k) + cacheCreate(2k) + output(10k) = 87k
+    // Remaining = (200k - 87k) / 200k = 56.5%
+    expect(fieldsText).toContain('56.5%');
   });
 
   it('does not fetch thread permalink while rendering panel', async () => {


### PR DESCRIPTION
## Summary
PR #46 머지 후 실제 Slack에서 확인한 결과 2가지 추가 버그 발견 및 수정:

1. **SDK `inputTokens`는 비캐시 토큰만 보고** — 캐시 토큰이 빠져서 `629` 표시 (실제 `123,929`)
2. **SDK가 `contextWindow` 필드를 제공하지 않음** — fallback 200k → 모델명 lookup 추가

### 수정 내용

| 변경 | 설명 |
|------|------|
| `ContextWindowManager.computeUsedTokens()` | `input + cacheRead + cacheCreate + output` 단일 소스 추가 |
| `formatContextBar()` | `computeUsedTokens()` 사용으로 캐시 포함 |
| `context-handler.ts` | `computeUsedTokens()` 사용 |
| `stream-executor.ts` | `MODEL_CONTEXT_WINDOWS` lookup table + `resolveContextWindow()` 추가 |

### Before → After

```
Before: ░░░░░ 629/200k (100% available)
After:  ▓░░░░ 123.9k/1M (88% available)
```

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` — 1017 passed
- [ ] 배포 후 Slack `/context` 명령으로 1M 기준 + 캐시 포함 정확한 수치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)