### PR TITLE
fix: context window에 billing 누적 대신 per-turn usage 사용

### DIFF
--- a/src/slack/pipeline/session-usage.test.ts
+++ b/src/slack/pipeline/session-usage.test.ts
@@ -40,6 +40,11 @@ function updateSessionUsage(
     totalCostUsd: number;
     contextWindow?: number;
     modelName?: string;
+    // Per-turn usage from last assistant message (context window state)
+    lastTurnInputTokens?: number;
+    lastTurnOutputTokens?: number;
+    lastTurnCacheReadTokens?: number;
+    lastTurnCacheCreateTokens?: number;
   }
 ): void {
   if (!session.usage) {
@@ -66,13 +71,14 @@ function updateSessionUsage(
     session.model = usageData.modelName;
   }
 
-  // CURRENT values are OVERWRITTEN (not accumulated)
-  session.usage.currentInputTokens = usageData.inputTokens;
-  session.usage.currentOutputTokens = usageData.outputTokens;
-  session.usage.currentCacheReadTokens = usageData.cacheReadInputTokens;
-  session.usage.currentCacheCreateTokens = usageData.cacheCreationInputTokens;
+  // CURRENT values: prefer per-turn (actual context state) over aggregate (billing)
+  const hasPerTurn = usageData.lastTurnInputTokens !== undefined;
+  session.usage.currentInputTokens = hasPerTurn ? usageData.lastTurnInputTokens! : usageData.inputTokens;
+  session.usage.currentOutputTokens = hasPerTurn ? usageData.lastTurnOutputTokens! : usageData.outputTokens;
+  session.usage.currentCacheReadTokens = hasPerTurn ? usageData.lastTurnCacheReadTokens! : usageData.cacheReadInputTokens;
+  session.usage.currentCacheCreateTokens = hasPerTurn ? usageData.lastTurnCacheCreateTokens! : usageData.cacheCreationInputTokens;
 
-  // TOTAL values are ACCUMULATED
+  // TOTAL values are ACCUMULATED (billing: use aggregate values)
   session.usage.totalInputTokens += usageData.inputTokens;
   session.usage.totalOutputTokens += usageData.outputTokens;
   session.usage.totalCostUsd += usageData.totalCostUsd;
@@ -312,6 +318,76 @@ describe('Cache tokens in context calculation', () => {
 
     // Old calculation (WRONG): just inputTokens + outputTokens
     expect(u.currentInputTokens + u.currentOutputTokens).toBe(629);
+  });
+});
+
+describe('Per-turn usage vs billing aggregate', () => {
+  /**
+   * CRITICAL FIX: SDK modelUsage is a billing cumulative across ALL API
+   * calls in an agent loop. For context window display we need the LAST
+   * assistant message's per-turn usage.
+   *
+   * Example: Agent makes 10 tool calls, each reading ~200k cached context.
+   * - Billing aggregate cacheRead: 10 × 200k = 2M
+   * - Actual context (last turn): 200k
+   *
+   * OLD BUG: showed 2M/200k (impossibly > 100%)
+   * FIX: show 200k/200k (correct)
+   */
+  it('should use per-turn values for currentXxx instead of billing aggregate', () => {
+    const session: { usage?: SessionUsage } = {};
+
+    updateSessionUsage(session, {
+      // Billing aggregate (cumulative across 10 tool calls)
+      inputTokens: 500,          // sum of non-cached inputs across all calls
+      outputTokens: 8000,        // sum of all outputs
+      cacheReadInputTokens: 2_000_000,  // 10 × 200k
+      cacheCreationInputTokens: 200_000,
+      totalCostUsd: 2.50,
+      // Per-turn: last assistant message's actual usage
+      lastTurnInputTokens: 50,
+      lastTurnOutputTokens: 800,
+      lastTurnCacheReadTokens: 180_000,
+      lastTurnCacheCreateTokens: 5_000,
+    });
+
+    const u = session.usage!;
+    // currentXxx should reflect per-turn (last API call), NOT aggregate
+    expect(u.currentInputTokens).toBe(50);
+    expect(u.currentOutputTokens).toBe(800);
+    expect(u.currentCacheReadTokens).toBe(180_000);
+    expect(u.currentCacheCreateTokens).toBe(5_000);
+
+    // Context used = 50 + 800 + 180k + 5k = 185,850 (reasonable)
+    const contextUsed = u.currentInputTokens + u.currentOutputTokens
+      + u.currentCacheReadTokens + u.currentCacheCreateTokens;
+    expect(contextUsed).toBe(185_850);
+
+    // NOT the old buggy value: 2M + 200k + 500 + 8k ≈ 2.2M
+    expect(contextUsed).not.toBe(2_208_500);
+
+    // Billing totals still use aggregate
+    expect(u.totalInputTokens).toBe(500);
+    expect(u.totalOutputTokens).toBe(8000);
+  });
+
+  it('should fall back to aggregate when per-turn is not available', () => {
+    const session: { usage?: SessionUsage } = {};
+
+    updateSessionUsage(session, {
+      inputTokens: 3,
+      outputTokens: 626,
+      cacheReadInputTokens: 117_500,
+      cacheCreationInputTokens: 5_800,
+      totalCostUsd: 0.11,
+      // No lastTurnXxx → fall back to aggregate
+    });
+
+    const u = session.usage!;
+    expect(u.currentInputTokens).toBe(3);
+    expect(u.currentOutputTokens).toBe(626);
+    expect(u.currentCacheReadTokens).toBe(117_500);
+    expect(u.currentCacheCreateTokens).toBe(5_800);
   });
 });
 

--- a/src/slack/pipeline/stream-executor.ts
+++ b/src/slack/pipeline/stream-executor.ts
@@ -1113,26 +1113,32 @@ export class StreamExecutor {
       }
     }
 
-    // Update current context (overwrite — this is the current context window usage)
-    // NOTE: inputTokens from SDK modelUsage = non-cached tokens only.
-    // Cache tokens are stored separately and included in context calculations
-    // via ContextWindowManager.computeUsedTokens().
-    session.usage.currentInputTokens = usage.inputTokens;
-    session.usage.currentOutputTokens = usage.outputTokens;
-    session.usage.currentCacheReadTokens = usage.cacheReadInputTokens;
-    session.usage.currentCacheCreateTokens = usage.cacheCreationInputTokens;
+    // Update current context window state.
+    // Prefer per-turn usage from the LAST assistant message (actual context occupancy)
+    // over the billing aggregate (which sums ALL API calls in the agent loop).
+    //
+    // Why: An agent loop with 10 tool calls accumulates ~10× the actual context
+    // in cacheRead alone. The per-turn value from BetaMessage.usage reflects the
+    // real context window state at the end of the loop.
+    const hasPerTurn = usage.lastTurnInputTokens !== undefined;
+    session.usage.currentInputTokens = hasPerTurn ? usage.lastTurnInputTokens! : usage.inputTokens;
+    session.usage.currentOutputTokens = hasPerTurn ? usage.lastTurnOutputTokens! : usage.outputTokens;
+    session.usage.currentCacheReadTokens = hasPerTurn ? usage.lastTurnCacheReadTokens! : usage.cacheReadInputTokens;
+    session.usage.currentCacheCreateTokens = hasPerTurn ? usage.lastTurnCacheCreateTokens! : usage.cacheCreationInputTokens;
 
-    // Accumulate totals (billing-oriented: each field summed independently)
+    // Accumulate totals (billing-oriented: use aggregate values, not per-turn)
     session.usage.totalInputTokens += usage.inputTokens;
     session.usage.totalOutputTokens += usage.outputTokens;
     session.usage.totalCostUsd += usage.totalCostUsd;
     session.usage.lastUpdated = Date.now();
 
-    const totalUsed = usage.inputTokens + usage.cacheReadInputTokens + usage.cacheCreationInputTokens + usage.outputTokens;
+    const contextUsed = session.usage.currentInputTokens + session.usage.currentCacheReadTokens
+      + session.usage.currentCacheCreateTokens + session.usage.currentOutputTokens;
     this.logger.debug('Updated session usage', {
-      currentContext: totalUsed,
+      currentContext: contextUsed,
       contextWindow: session.usage.contextWindow,
       contextWindowSource: usage.contextWindow ? 'sdk' : (session.model ? 'model-lookup' : 'fallback'),
+      usageSource: hasPerTurn ? 'per-turn' : 'aggregate-fallback',
       totalInput: session.usage.totalInputTokens,
       totalOutput: session.usage.totalOutputTokens,
       totalCostUsd: session.usage.totalCostUsd,

--- a/src/slack/stream-processor.ts
+++ b/src/slack/stream-processor.ts
@@ -126,6 +126,7 @@ export interface CompactToolCallEntry {
  * maximum context size (e.g. 1_000_000 for Opus 4.6).
  */
 export interface UsageData {
+  // --- Billing aggregates (cumulative across all API calls in agent loop) ---
   inputTokens: number;
   outputTokens: number;
   cacheReadInputTokens: number;
@@ -135,6 +136,14 @@ export interface UsageData {
   contextWindow?: number;
   /** Model name (e.g. "claude-opus-4-6-20250414") from the SDK usage key */
   modelName?: string;
+
+  // --- Per-turn usage from last assistant message (context window state) ---
+  // These reflect the LAST API call's actual token counts, NOT cumulative.
+  // Use these for context window calculation (how full is the window right now).
+  lastTurnInputTokens?: number;
+  lastTurnOutputTokens?: number;
+  lastTurnCacheReadTokens?: number;
+  lastTurnCacheCreateTokens?: number;
 }
 
 export interface FinalResponseFooterParams {
@@ -205,6 +214,13 @@ export class StreamProcessor {
   private pendingTaskInputs = new Map<string, any>();
   /** Maps background task_id → original Task input metadata (for TaskOutput display) */
   private backgroundTaskMeta = new Map<string, { name?: string; subagentLabel?: string; promptPreview?: string }>();
+  /** Per-turn usage from the last SDKAssistantMessage (BetaMessage.usage) */
+  private _lastAssistantTurnUsage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+  } | null = null;
 
   constructor(callbacks: StreamCallbacks = {}) {
     this.callbacks = callbacks;
@@ -252,6 +268,16 @@ export class StreamProcessor {
         }
       }
 
+      // Merge per-turn usage from the last assistant message into the
+      // aggregate UsageData so consumers can distinguish billing totals
+      // from actual context window state.
+      if (lastUsage && this._lastAssistantTurnUsage) {
+        lastUsage.lastTurnInputTokens = this._lastAssistantTurnUsage.inputTokens;
+        lastUsage.lastTurnOutputTokens = this._lastAssistantTurnUsage.outputTokens;
+        lastUsage.lastTurnCacheReadTokens = this._lastAssistantTurnUsage.cacheReadTokens;
+        lastUsage.lastTurnCacheCreateTokens = this._lastAssistantTurnUsage.cacheCreateTokens;
+      }
+
       // Call usage update callback if we have usage data
       if (lastUsage && this.callbacks.onUsageUpdate) {
         this.callbacks.onUsageUpdate(lastUsage);
@@ -282,6 +308,18 @@ export class StreamProcessor {
     currentMessages: string[]
   ): Promise<void> {
     if (message.type !== 'assistant') return;
+
+    // Capture per-turn usage from BetaMessage.usage (NOT cumulative).
+    // Each assistant message carries usage for that single API call.
+    const msgUsage = (message.message as any).usage;
+    if (msgUsage) {
+      this._lastAssistantTurnUsage = {
+        inputTokens: msgUsage.input_tokens || 0,
+        outputTokens: msgUsage.output_tokens || 0,
+        cacheReadTokens: msgUsage.cache_read_input_tokens || 0,
+        cacheCreateTokens: msgUsage.cache_creation_input_tokens || 0,
+      };
+    }
 
     const content = message.message.content;
     const hasToolUse = content?.some((part: any) => part.type === 'tool_use');


### PR DESCRIPTION
## Summary

- SDK `modelUsage`가 에이전트 루프의 **billing 누적합**을 반환하는데, 이를 컨텍스트 윈도우 사용량으로 표시하고 있었음
- 도구 호출 10회 × cache_read 200k = **4.6M**이 컨텍스트로 표시되어 `▓▓▓▓▓ 4.6M/200k (0%)` 같은 불가능한 값 출력
- `SDKAssistantMessage.message.usage` (BetaMessage.usage)에서 **마지막 API 호출의 per-turn 토큰**을 캡처하여 `currentXxxTokens`에 저장
- billing 합산(`totalXxx`)은 기존대로 aggregate 사용

## Changes

| 파일 | 변경 |
|------|------|
| `stream-processor.ts` | `_lastAssistantTurnUsage` 필드 추가, `handleAssistantMessage()`에서 `BetaMessage.usage` 캡처, `process()`에서 `UsageData.lastTurnXxx`에 병합 |
| `stream-executor.ts` | `updateSessionUsage()`가 `lastTurnXxx` 우선 사용, 없으면 aggregate 폴백 |
| `session-usage.test.ts` | per-turn vs aggregate 테스트 2건 추가 |

## Before → After

```
Before: ▓▓▓▓▓ 4.6M/200k (0% available)  ← billing 누적
After:  ▓░░░░ 185.9k/200k (7% available) ← 실제 컨텍스트
```

## Test plan

- [x] `npx vitest run` — 1017 passed (1 pre-existing failure unrelated)
- [x] `session-usage.test.ts` — 12 passed (2 new per-turn tests)
- [ ] Deploy and verify `/context` output in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)