### PR TITLE
fix: context window max(SDK, model lookup) for 1M

### DIFF
--- a/src/slack/pipeline/session-usage.test.ts
+++ b/src/slack/pipeline/session-usage.test.ts
@@ -26,6 +26,25 @@ import type { SessionUsage } from '../../types';
 // Matches the renamed constant in stream-executor.ts
 const FALLBACK_CONTEXT_WINDOW = 200_000;
 
+// Mirrors MODEL_CONTEXT_WINDOWS from stream-executor.ts
+const MODEL_CONTEXT_WINDOWS: [string, number][] = [
+  ['opus-4-6', 1_000_000],
+  ['sonnet-4-6', 1_000_000],
+  ['opus-4-5', 1_000_000],
+  ['sonnet-4-5', 1_000_000],
+  ['haiku-4-5', 200_000],
+  ['sonnet-4-', 200_000],
+  ['haiku-4-', 200_000],
+];
+
+function resolveContextWindow(modelName?: string): number {
+  if (!modelName) return FALLBACK_CONTEXT_WINDOW;
+  for (const [pattern, size] of MODEL_CONTEXT_WINDOWS) {
+    if (modelName.includes(pattern)) return size;
+  }
+  return FALLBACK_CONTEXT_WINDOW;
+}
+
 /**
  * Simulates the updateSessionUsage logic from stream-executor.ts
  * This is extracted for testing purposes.
@@ -61,9 +80,12 @@ function updateSessionUsage(
     };
   }
 
-  // Dynamically update context window from SDK if available
-  if (usageData.contextWindow && usageData.contextWindow > 0) {
-    session.usage.contextWindow = usageData.contextWindow;
+  // Dynamically update context window: max(SDK, model lookup)
+  const sdkWindow = (usageData.contextWindow && usageData.contextWindow > 0) ? usageData.contextWindow : 0;
+  const lookupWindow = resolveContextWindow(usageData.modelName || session.model);
+  const resolvedWindow = Math.max(sdkWindow, lookupWindow);
+  if (resolvedWindow > 0) {
+    session.usage.contextWindow = resolvedWindow;
   }
 
   // Update model name on session
@@ -246,10 +268,10 @@ describe('Dynamic Context Window from SDK', () => {
     // With old hardcoded 200k: (200k-150k)/200k = 25% remaining (WRONG)
   });
 
-  it('should preserve SDK contextWindow across turns', () => {
+  it('should preserve 1M contextWindow across turns via model lookup', () => {
     const session: { usage?: SessionUsage; model?: string } = {};
 
-    // Turn 1: SDK reports 1M
+    // Turn 1: SDK reports 1M, model name captured
     updateSessionUsage(session, {
       inputTokens: 5000,
       outputTokens: 2000,
@@ -257,11 +279,13 @@ describe('Dynamic Context Window from SDK', () => {
       cacheCreationInputTokens: 0,
       totalCostUsd: 0.05,
       contextWindow: 1_000_000,
+      modelName: 'claude-opus-4-6-20250414',
     });
 
     expect(session.usage!.contextWindow).toBe(1_000_000);
+    expect(session.model).toBe('claude-opus-4-6-20250414');
 
-    // Turn 2: SDK does NOT report contextWindow
+    // Turn 2: SDK does NOT report contextWindow, but session.model is set
     updateSessionUsage(session, {
       inputTokens: 10000,
       outputTokens: 3000,
@@ -270,7 +294,7 @@ describe('Dynamic Context Window from SDK', () => {
       totalCostUsd: 0.08,
     });
 
-    // Should keep 1M, not reset to 200k
+    // max(0 SDK, 1M lookup via session.model) = 1M
     expect(session.usage!.contextWindow).toBe(1_000_000);
   });
 
@@ -287,6 +311,42 @@ describe('Dynamic Context Window from SDK', () => {
     });
 
     expect(session.model).toBe('claude-sonnet-4-5-20250414');
+  });
+
+  it('should use model lookup (1M) when SDK reports base window (200k)', () => {
+    const session: { usage?: SessionUsage; model?: string } = {};
+
+    // SDK reports 200k but model is opus-4-6 which supports 1M with beta
+    updateSessionUsage(session, {
+      inputTokens: 5000,
+      outputTokens: 2000,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      totalCostUsd: 0.05,
+      contextWindow: 200_000,
+      modelName: 'claude-opus-4-6-20250414',
+    });
+
+    // max(200k SDK, 1M lookup) = 1M
+    expect(session.usage!.contextWindow).toBe(1_000_000);
+  });
+
+  it('should use SDK value when larger than model lookup', () => {
+    const session: { usage?: SessionUsage; model?: string } = {};
+
+    // Hypothetical: SDK reports 2M for a future model not in our table
+    updateSessionUsage(session, {
+      inputTokens: 5000,
+      outputTokens: 2000,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      totalCostUsd: 0.05,
+      contextWindow: 2_000_000,
+      modelName: 'claude-future-model-5-0',
+    });
+
+    // max(2M SDK, 200k fallback) = 2M
+    expect(session.usage!.contextWindow).toBe(2_000_000);
   });
 });
 

--- a/src/slack/pipeline/stream-executor.ts
+++ b/src/slack/pipeline/stream-executor.ts
@@ -50,17 +50,20 @@ export interface ExecuteResult {
 const FALLBACK_CONTEXT_WINDOW = 200_000;
 
 /**
- * Known model context window sizes.
+ * Known model context window sizes (with 1M beta enabled).
  * Key: model family substring matched against the full model name.
- * When SDK doesn't provide ModelUsage.contextWindow, we look up here.
+ *
+ * SDK's ModelUsage.contextWindow often reports the BASE window (200k)
+ * even when the 1M beta header is active. This table provides the
+ * EFFECTIVE window so we can take max(sdk, lookup).
  */
 const MODEL_CONTEXT_WINDOWS: [pattern: string, contextWindow: number][] = [
-  // 4.6 models: 1M native (no beta header needed)
+  // 4.6 models: 1M with context-1m beta
   ['opus-4-6', 1_000_000],
   ['sonnet-4-6', 1_000_000],
-  // 4.5 models: 200k default (1M with beta header, but we use default)
-  ['opus-4-5', 200_000],
-  ['sonnet-4-5', 200_000],
+  // 4.5 models: 1M with context-1m beta
+  ['opus-4-5', 1_000_000],
+  ['sonnet-4-5', 1_000_000],
   ['haiku-4-5', 200_000],
   // 4.0 models
   ['sonnet-4-', 200_000],
@@ -1099,18 +1102,14 @@ export class StreamExecutor {
     }
 
     // Dynamically update context window:
-    // 1. SDK's ModelUsage.contextWindow (if available)
-    // 2. Model-name lookup table (opus-4-6 → 1M, etc.)
-    // 3. Keep existing value (don't downgrade to fallback)
-    if (usage.contextWindow && usage.contextWindow > 0) {
-      session.usage.contextWindow = usage.contextWindow;
-    } else if (session.usage.contextWindow === FALLBACK_CONTEXT_WINDOW) {
-      // Only do lookup if still at fallback — don't override a previous SDK value
-      const modelName = usage.modelName || session.model;
-      const resolved = resolveContextWindow(modelName);
-      if (resolved !== FALLBACK_CONTEXT_WINDOW) {
-        session.usage.contextWindow = resolved;
-      }
+    // Take max(SDK value, model lookup) because SDK often reports the BASE
+    // window (200k) even when the 1M beta is active.
+    const sdkWindow = (usage.contextWindow && usage.contextWindow > 0) ? usage.contextWindow : 0;
+    const modelName = usage.modelName || session.model;
+    const lookupWindow = resolveContextWindow(modelName);
+    const resolved = Math.max(sdkWindow, lookupWindow);
+    if (resolved > 0) {
+      session.usage.contextWindow = resolved;
     }
 
     // Update current context window state.


### PR DESCRIPTION
## Summary
- SDK `ModelUsage.contextWindow`가 1M beta 활성화 상태에서도 base 200k를 보고하는 문제 수정
- `max(SDK 값, 모델 룩업 테이블)` 로직으로 변경하여 더 큰 값 채택
- 4.5 모델(opus/sonnet)도 1M beta 지원하므로 룩업 테이블 업데이트

## Root Cause
SDK 0.2.80의 `ModelUsage.contextWindow`는 non-optional `number` 타입으로 항상 값을 반환.
`context-1m-2025-08-07` beta header를 보내도 SDK는 base window(200k)를 보고.
기존 코드는 SDK 값을 먼저 채택하므로 모델 룩업(1M)에 도달하지 않음.

## Fix
```typescript
// Before: SDK-first (200k가 이김)
if (usage.contextWindow > 0) session.usage.contextWindow = usage.contextWindow;
else if (fallback) { lookup... }

// After: max of both (1M이 이김)
const resolved = Math.max(sdkWindow, lookupWindow);
session.usage.contextWindow = resolved;
```

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest` 1020 passed (1 pre-existing failure)
- [x] New test: SDK 200k + opus-4-6 → 1M
- [x] New test: SDK 2M + unknown model → 2M (forward-compatible)
- [ ] 배포 후 opus-4.6 세션에서 `16.4k/1M` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)