### PR TITLE
fix: empty fields[] guard + beta conditional on API key

### DIFF
--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -547,8 +547,11 @@ export class ClaudeHandler {
       this.logger.debug('Starting new Claude conversation');
     }
 
-    // Enable 1M context window beta (applies to supported models)
-    options.betas = ['context-1m-2025-08-07'];
+    // Enable 1M context window beta (applies to supported models).
+    // Only set for API key users — subscription users get a noisy warning from the SDK.
+    if (process.env.ANTHROPIC_API_KEY) {
+      options.betas = ['context-1m-2025-08-07'];
+    }
 
     // Set abort controller
     if (abortController) {

--- a/src/slack/action-panel-builder.ts
+++ b/src/slack/action-panel-builder.ts
@@ -536,11 +536,14 @@ export class ActionPanelBuilder {
     }
     // Context info is shown in thread header badge — no need to duplicate here.
 
-    blocks.push({
-      type: 'section',
-      text: { type: 'mrkdwn', text: '*작업 요약*' },
-      fields,
-    });
+    // Only add summary section when there are actual fields (Slack rejects empty fields[])
+    if (fields.length > 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '*작업 요약*' },
+        fields,
+      });
+    }
 
     // Context footer: timestamp + link
     const footerElements: any[] = [];


### PR DESCRIPTION
## Summary
- Closed panel에서 `turnSummary` 없을 때 빈 `fields[]` 전송 → Slack `invalid_blocks` 에러 수정
- `context-1m` beta를 `ANTHROPIC_API_KEY` 있을 때만 설정 (subscription 환경 경고 제거)

## Root Cause
```
[ERROR] must provide at least 1 items [json-pointer:/blocks/3/fields]
```
`buildClosedPanel()`에서 `turnSummary`가 없으면 `fields`가 빈 배열로 section에 전달됨.

```
Warning: Custom betas are only available for API key users. Ignoring provided betas.
```
Subscription 사용자에게 beta header가 무시되며 매 요청마다 경고 로그 발생.

## Changes
| File | Change |
|------|--------|
| `action-panel-builder.ts` | `fields.length > 0`일 때만 summary section 추가 |
| `claude-handler.ts` | `ANTHROPIC_API_KEY` 존재 시에만 betas 설정 |

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 1020 passed
- [ ] `turnSummary` 없는 세션 종료 시 Slack 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)