### PR TITLE
docs: mention default plugins in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 A TypeScript bot that brings AI coding intelligence into your Slack workspace.
 Powered by the Claude Code SDK, it provides a conversational coding assistant with 12 genius personas, automatic workflow dispatch, an extensible MCP tool ecosystem, and real-time task tracking.
 
+> **Default Plugins**: `superpowers` and `stv` are now auto-loaded on startup — no config required.
+
 [한국어 README](./README.ko.md)
 
 ---


### PR DESCRIPTION
## Summary
- Add a note about auto-loaded default plugins (superpowers, stv) to README

## Test plan
- [x] Visual check — one line added to README intro section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>