### PR TITLE
fix: harden task list against mrkdwn injection and block overflow

### DIFF
--- a/src/slack/task-list-block-builder.test.ts
+++ b/src/slack/task-list-block-builder.test.ts
@@ -46,8 +46,8 @@ describe('TaskListBlockBuilder', () => {
     expect(text).toContain('🟢');
     expect(text).toContain('types.ts 수정');
 
-    // Active form shown as sub-status
-    expect(text).toContain('llm_chat(codex) 진행중');
+    // Active form shown as sub-status (underscores escaped to ˍ)
+    expect(text).toContain('llmˍchat(codex) 진행중');
 
     // Pending task: ⚪
     expect(text).toContain('⚪');
@@ -120,7 +120,8 @@ describe('TaskListBlockBuilder', () => {
       (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('Start:')
     );
     expect(timeCtx).toBeDefined();
-    expect(timeCtx.elements[0].text).toContain('12:01');
+    // Now uses Slack date tokens
+    expect(timeCtx.elements[0].text).toContain('<!date^');
   });
 
   it('does not show time context when startedAt is not provided', () => {
@@ -286,5 +287,104 @@ describe('TodoManager.hasSignificantChange', () => {
       { id: '1', content: 'task', status: 'in_progress', priority: 'medium', activeForm: 'Running' },
     ];
     expect(manager.hasSignificantChange(old, same)).toBe(false);
+  });
+
+  it('detects dependency change', () => {
+    const old: Todo[] = [
+      { id: '1', content: 'task', status: 'pending', priority: 'medium', dependencies: ['a'] },
+    ];
+    const updated: Todo[] = [
+      { id: '1', content: 'task', status: 'pending', priority: 'medium', dependencies: ['a', 'b'] },
+    ];
+    expect(manager.hasSignificantChange(old, updated)).toBe(true);
+  });
+
+  it('detects dependency removal', () => {
+    const old: Todo[] = [
+      { id: '1', content: 'task', status: 'pending', priority: 'medium', dependencies: ['a'] },
+    ];
+    const updated: Todo[] = [
+      { id: '1', content: 'task', status: 'pending', priority: 'medium' },
+    ];
+    expect(manager.hasSignificantChange(old, updated)).toBe(true);
+  });
+});
+
+describe('mrkdwn escaping in task content', () => {
+  let todoManager: TodoManager;
+  let builder: TaskListBlockBuilder;
+
+  beforeEach(() => {
+    todoManager = new TodoManager();
+    builder = new TaskListBlockBuilder(todoManager);
+  });
+
+  it('escapes mrkdwn formatting characters in content', () => {
+    const todos: Todo[] = [
+      { id: '1', content: 'Fix *bold* and _italic_ and ~strike~', status: 'in_progress', priority: 'medium' },
+    ];
+    const blocks = builder.buildBlocks(todos);
+    const taskSection = blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('🟢'),
+    );
+    const text = taskSection.text.text;
+    // Should NOT contain raw mrkdwn chars
+    expect(text).not.toContain('*bold*');
+    expect(text).not.toContain('_italic_');
+    expect(text).not.toContain('~strike~');
+  });
+
+  it('escapes angle brackets and ampersands to prevent mention/link injection', () => {
+    const todos: Todo[] = [
+      { id: '1', content: 'Check <!channel> and <@U123> and <http://evil.com|click>', status: 'pending', priority: 'medium' },
+    ];
+    const blocks = builder.buildBlocks(todos);
+    const taskSection = blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('⚪'),
+    );
+    const text = taskSection.text.text;
+    // Angle brackets should be escaped
+    expect(text).not.toContain('<!channel>');
+    expect(text).not.toContain('<@U123>');
+    expect(text).not.toContain('<http://');
+    expect(text).toContain('&lt;');
+  });
+
+  it('flattens newlines in content to prevent layout break', () => {
+    const todos: Todo[] = [
+      { id: '1', content: 'line1\nline2\nline3', status: 'pending', priority: 'medium' },
+    ];
+    const blocks = builder.buildBlocks(todos);
+    const taskSection = blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('⚪'),
+    );
+    // The task content line should not contain raw newlines from content
+    const taskLine = taskSection.text.text.split('\n').find((l: string) => l.includes('line1'));
+    expect(taskLine).toContain('line1 line2 line3');
+  });
+});
+
+describe('Slack date token in time display', () => {
+  let todoManager: TodoManager;
+  let builder: TaskListBlockBuilder;
+
+  beforeEach(() => {
+    todoManager = new TodoManager();
+    builder = new TaskListBlockBuilder(todoManager);
+  });
+
+  it('uses Slack date token format for startedAt', () => {
+    const todos: Todo[] = [
+      { id: '1', content: 'task', status: 'in_progress', priority: 'medium' },
+    ];
+    const ts = new Date('2025-06-15T14:30:00Z').getTime();
+    const blocks = builder.buildBlocks(todos, { startedAt: ts });
+    const timeCtx = blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('Start:'),
+    );
+    expect(timeCtx).toBeDefined();
+    // Should contain Slack date token format <!date^epoch^{time}|fallback>
+    expect(timeCtx.elements[0].text).toContain('<!date^');
+    expect(timeCtx.elements[0].text).toContain('^{time}|');
   });
 });

--- a/src/slack/task-list-block-builder.ts
+++ b/src/slack/task-list-block-builder.ts
@@ -4,6 +4,24 @@ import { Todo, TodoManager } from '../todo-manager';
 const MAX_SECTION_TEXT_LENGTH = 2800;
 /** Max content length per task before truncation */
 const MAX_TASK_CONTENT_LENGTH = 80;
+/** Slack messages can have at most 50 blocks */
+const MAX_TASK_LIST_BLOCKS = 5;
+
+/**
+ * Escape user-supplied text for safe embedding in Slack mrkdwn.
+ * Neutralizes formatting chars, mentions, links, and newlines.
+ */
+function escapeMrkdwn(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\*/g, '∗')   // fullwidth asterisk
+    .replace(/~/g, '∼')    // tilde operator
+    .replace(/_/g, 'ˍ')    // modifier letter low macron
+    .replace(/`/g, 'ʼ')    // modifier letter apostrophe
+    .replace(/\n/g, ' ');   // flatten newlines
+}
 
 /**
  * Renders a task list as Slack Block Kit blocks for embedding in the thread header.
@@ -160,10 +178,11 @@ export class TaskListBlockBuilder {
     return false;
   }
 
-  /** Truncate task content to prevent overflow */
+  /** Truncate and escape task content for safe mrkdwn embedding */
   private truncateContent(text: string): string {
-    if (text.length <= MAX_TASK_CONTENT_LENGTH) return text;
-    return text.slice(0, MAX_TASK_CONTENT_LENGTH - 1) + '…';
+    const escaped = escapeMrkdwn(text);
+    if (escaped.length <= MAX_TASK_CONTENT_LENGTH) return escaped;
+    return escaped.slice(0, MAX_TASK_CONTENT_LENGTH - 1) + '…';
   }
 
   // ---------------------------------------------------------------------------
@@ -219,9 +238,17 @@ export class TaskListBlockBuilder {
   // Formatting helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * Format timestamp as Slack date token so each viewer sees their local time.
+   * Falls back to UTC HH:MM if timestamp is invalid.
+   */
   private formatTime(ts: number): string {
-    const d = new Date(ts);
-    return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
+    const epoch = Math.floor(ts / 1000);
+    if (!Number.isFinite(epoch) || epoch <= 0) {
+      const d = new Date(ts);
+      return `${d.getUTCHours().toString().padStart(2, '0')}:${d.getUTCMinutes().toString().padStart(2, '0')}`;
+    }
+    return `<!date^${epoch}^{time}|${new Date(ts).toISOString().slice(11, 16)}>`;
   }
 
   private formatDuration(ms: number): string {

--- a/src/slack/thread-surface.ts
+++ b/src/slack/thread-surface.ts
@@ -563,21 +563,37 @@ export class ThreadSurface {
     blocks.push(...panelPayload.blocks);
 
     // ── 3. Task list section (at bottom of header area) ──
+    // Slack enforces a 50-block maximum per message. Reserve room for summary.
+    const SLACK_MAX_BLOCKS = 50;
+    const summaryBlocks = (session.actionPanel?.summaryBlocks && Array.isArray(session.actionPanel.summaryBlocks))
+      ? session.actionPanel.summaryBlocks
+      : [];
+    const budgetForTaskList = SLACK_MAX_BLOCKS - blocks.length - summaryBlocks.length;
+
     const todos = session.sessionId
       ? this.deps.todoManager.getTodos(session.sessionId)
       : [];
-    if (todos.length > 0) {
+    if (todos.length > 0 && budgetForTaskList >= 4) {
       const taskListBlocks = this.taskListBuilder.buildBlocks(todos, {
         startedAt: session.taskListStartedAt,
         completedAt: session.taskListCompletedAt,
       });
-      blocks.push(...taskListBlocks);
+      // Only append if it fits within the block budget
+      if (taskListBlocks.length <= budgetForTaskList) {
+        blocks.push(...taskListBlocks);
+      } else {
+        this.logger.debug('Skipping task list blocks (would exceed 50-block limit)', {
+          current: blocks.length,
+          taskListBlocks: taskListBlocks.length,
+          summaryBlocks: summaryBlocks.length,
+        });
+      }
     }
 
     // Append executive summary blocks if present
     // Trace: docs/turn-summary-lifecycle/trace.md, S3
-    if (session.actionPanel?.summaryBlocks && Array.isArray(session.actionPanel.summaryBlocks)) {
-      blocks.push(...session.actionPanel.summaryBlocks);
+    if (summaryBlocks.length > 0) {
+      blocks.push(...summaryBlocks);
     }
 
     return blocks;

--- a/src/todo-manager.ts
+++ b/src/todo-manager.ts
@@ -100,13 +100,14 @@ export class TodoManager {
       return true;
     }
 
-    // Check if any task status, activeForm, or content changed
+    // Check if any task status, activeForm, content, or dependencies changed
     for (const newTodo of newTodos) {
       const oldTodo = oldTodos.find(t => t.id === newTodo.id);
       if (!oldTodo
         || oldTodo.status !== newTodo.status
         || oldTodo.activeForm !== newTodo.activeForm
-        || oldTodo.content !== newTodo.content) {
+        || oldTodo.content !== newTodo.content
+        || JSON.stringify(oldTodo.dependencies) !== JSON.stringify(newTodo.dependencies)) {
         return true;
       }
     }


### PR DESCRIPTION
## Summary
- **mrkdwn injection defense**: escapeMrkdwn() neutralizes formatting chars, mentions, links, newlines
- **Dependency change detection**: hasSignificantChange now detects dependencies array changes  
- **50-block budget guard**: skips task list if it would exceed Slack 50-block limit
- **Slack date tokens**: formatTime emits date tokens for viewer-local timezone

Follow-up to #212 + #220, issues found via Codex post-merge review.

## Test plan
- [x] vitest 26 task list + 7 thread panel tests pass
- [x] tsc no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)