### PR TITLE
fix: render task list in header regardless of verbosity

### DIFF
--- a/src/slack/pipeline/stream-executor.ts
+++ b/src/slack/pipeline/stream-executor.ts
@@ -498,7 +498,8 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
           }
         },
         onTodoUpdate: async (input, ctx) => {
-          if (!isOutputEnabled(OutputFlag.TODO_UPDATE)) return;
+          // Task list is part of thread header — always update regardless of verbosity.
+          // The TODO_UPDATE flag only gates the legacy standalone message inside handleTodoUpdate.
           await this.deps.todoDisplayManager.handleTodoUpdate(
             input,
             ctx.sessionKey,


### PR DESCRIPTION
## Summary
- **Root cause**: `onTodoUpdate` was gated by `OutputFlag.TODO_UPDATE` which is only in `LOG_DETAIL`. Users with COMPACT/MINIMAL verbosity never got task list in the thread header.
- **Fix**: Remove the output flag gate — task list is part of the header UI, not a log message. Must always render.
- 1 line changed, 0 risk.

## Test plan
- [x] tsc clean, 33 tests pass
- [x] Manual: set verbosity to minimal → task list should now appear in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)