### PR TITLE
feat(token): support named tokens in CLAUDE_CODE_OAUTH_TOKEN_LIST

### DIFF
--- a/src/token-manager.test.ts
+++ b/src/token-manager.test.ts
@@ -18,8 +18,8 @@ describe('TokenManager', () => {
   // === Scenario 1: Token Initialization ===
 
   describe('initialize', () => {
-    // Trace: Scenario 1, Step 3
-    it('should load multiple tokens from CLAUDE_CODE_OAUTH_TOKEN_LIST', async () => {
+    // Trace: Scenario 1, Step 3 (legacy unnamed format)
+    it('should load multiple tokens with cctN fallback names', async () => {
       process.env.CLAUDE_CODE_OAUTH_TOKEN_LIST = 'tokenA,tokenB,tokenC';
       const { tokenManager } = await import('./token-manager');
       tokenManager.initialize();
@@ -29,6 +29,30 @@ describe('TokenManager', () => {
       expect(tokens[0].name).toBe('cct1');
       expect(tokens[1].name).toBe('cct2');
       expect(tokens[2].name).toBe('cct3');
+    });
+
+    // Named token format: name=value
+    it('should load named tokens from name=value format', async () => {
+      process.env.CLAUDE_CODE_OAUTH_TOKEN_LIST = 'ai3=tokenA,ai2=tokenB,info=tokenC';
+      const { tokenManager } = await import('./token-manager');
+      tokenManager.initialize();
+
+      const tokens = tokenManager.getAllTokens();
+      expect(tokens).toHaveLength(3);
+      expect(tokens[0]).toMatchObject({ name: 'ai3', value: 'tokenA' });
+      expect(tokens[1]).toMatchObject({ name: 'ai2', value: 'tokenB' });
+      expect(tokens[2]).toMatchObject({ name: 'info', value: 'tokenC' });
+    });
+
+    it('should handle mixed named and unnamed entries', async () => {
+      process.env.CLAUDE_CODE_OAUTH_TOKEN_LIST = 'ai3=tokenA,tokenB,info=tokenC';
+      const { tokenManager } = await import('./token-manager');
+      tokenManager.initialize();
+
+      const tokens = tokenManager.getAllTokens();
+      expect(tokens[0].name).toBe('ai3');
+      expect(tokens[1].name).toBe('cct2');
+      expect(tokens[2].name).toBe('info');
     });
 
     // Trace: Scenario 1, Step 2

--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -10,7 +10,7 @@ import { Logger } from './logger';
 const logger = new Logger('TokenManager');
 
 export interface TokenEntry {
-  readonly name: string; // "cct1", "cct2", ...
+  readonly name: string; // e.g. "ai3", "ai2", or fallback "cct1"
   readonly value: string; // actual token value
   cooldownUntil: Date | null; // null = available
 }
@@ -63,15 +63,21 @@ export class TokenManager {
     const singleToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
 
     if (tokenList) {
-      const values = tokenList
+      const entries = tokenList
         .split(',')
         .map((t) => t.trim())
         .filter((t) => t.length > 0);
-      this.tokens = values.map((value, i) => ({
-        name: `cct${i + 1}`,
-        value,
-        cooldownUntil: null,
-      }));
+      this.tokens = entries.map((entry, i) => {
+        const eqIndex = entry.indexOf('=');
+        if (eqIndex > 0) {
+          return {
+            name: entry.slice(0, eqIndex),
+            value: entry.slice(eqIndex + 1),
+            cooldownUntil: null,
+          };
+        }
+        return { name: `cct${i + 1}`, value: entry, cooldownUntil: null };
+      });
     } else if (singleToken) {
       this.tokens = [
         {


### PR DESCRIPTION
## Summary

- `name=value` 형식 지원: `ai3=${AI3_TOKEN},ai2=${AI2_TOKEN},...`
- 기존 형식(`tokenA,tokenB`) 하위 호환 (cctN 폴백)
- `set_cct ai3` 같이 의미 있는 이름으로 토큰 전환 가능

## Test plan

- [x] 31개 기존 테스트 통과
- [x] named token 파싱 테스트 추가
- [x] mixed format 테스트 추가
- [x] 실제 .env 형식 통합 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)