### PR TITLE
fix(token): resolve ${VAR} env references in named token list

### DIFF
--- a/src/token-manager.test.ts
+++ b/src/token-manager.test.ts
@@ -55,6 +55,28 @@ describe('TokenManager', () => {
       expect(tokens[2].name).toBe('info');
     });
 
+    it('should resolve ${VAR} references from process.env', async () => {
+      process.env.AI3_TOKEN = 'sk-ant-real-ai3';
+      process.env.AI2_TOKEN = 'sk-ant-real-ai2';
+      process.env.CLAUDE_CODE_OAUTH_TOKEN_LIST = 'ai3=${AI3_TOKEN},ai2=${AI2_TOKEN}';
+      const { tokenManager } = await import('./token-manager');
+      tokenManager.initialize();
+
+      const tokens = tokenManager.getAllTokens();
+      expect(tokens[0]).toMatchObject({ name: 'ai3', value: 'sk-ant-real-ai3' });
+      expect(tokens[1]).toMatchObject({ name: 'ai2', value: 'sk-ant-real-ai2' });
+    });
+
+    it('should keep raw value if env var not found', async () => {
+      delete process.env.MISSING_TOKEN;
+      process.env.CLAUDE_CODE_OAUTH_TOKEN_LIST = 'missing=${MISSING_TOKEN}';
+      const { tokenManager } = await import('./token-manager');
+      tokenManager.initialize();
+
+      const tokens = tokenManager.getAllTokens();
+      expect(tokens[0]).toMatchObject({ name: 'missing', value: '${MISSING_TOKEN}' });
+    });
+
     // Trace: Scenario 1, Step 2
     it('should fallback to single CLAUDE_CODE_OAUTH_TOKEN', async () => {
       delete process.env.CLAUDE_CODE_OAUTH_TOKEN_LIST;

--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -70,9 +70,11 @@ export class TokenManager {
       this.tokens = entries.map((entry, i) => {
         const eqIndex = entry.indexOf('=');
         if (eqIndex > 0) {
+          const name = entry.slice(0, eqIndex);
+          const rawValue = entry.slice(eqIndex + 1);
           return {
-            name: entry.slice(0, eqIndex),
-            value: entry.slice(eqIndex + 1),
+            name,
+            value: TokenManager.resolveEnvRef(rawValue),
             cooldownUntil: null,
           };
         }
@@ -226,6 +228,16 @@ export class TokenManager {
     if (this.tokens.length > 0) {
       process.env.CLAUDE_CODE_OAUTH_TOKEN = this.tokens[this.activeIndex].value;
     }
+  }
+
+  /** Resolve ${VAR_NAME} references from process.env */
+  static resolveEnvRef(value: string): string {
+    const match = value.match(/^\$\{(\w+)\}$/);
+    if (match) {
+      const resolved = process.env[match[1]];
+      if (resolved) return resolved;
+    }
+    return value;
   }
 
   /** Mask a token value for safe display: first 20 + last 10 chars */


### PR DESCRIPTION
## Summary

- dotenv가 `${AI3_TOKEN}` 같은 변수 참조를 확장하지 않아 리터럴 문자열이 토큰값으로 사용되던 문제 수정
- `resolveEnvRef()`로 `process.env`에서 실제 값 조회 후 사용

## Test plan

- [x] `${VAR}` 참조 해결 테스트 추가
- [x] 존재하지 않는 변수는 원본 유지 테스트 추가
- [x] 33개 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)