### PR TITLE
refactor: migrate hook business logic from shell to Fastify service

### DIFF
--- a/src/conversation/web-server.ts
+++ b/src/conversation/web-server.ts
@@ -8,6 +8,7 @@ import Fastify, {
 import * as jwt from 'jsonwebtoken';
 import { config } from '../config';
 import { IS_DEV } from '../env-paths';
+import { registerHookRoutes } from '../hooks';
 import { Logger } from '../logger';
 import { registerDashboardRoutes } from './dashboard';
 import {
@@ -460,6 +461,9 @@ export async function startWebServer(options: StartWebServerOptions = {}): Promi
     reply.send({ status: 'ok', service: 'conversation-viewer' });
   });
 
+  // Hook routes (no auth — localhost only)
+  await registerHookRoutes(server);
+
   // Root redirect
   server.get('/', async (_request, reply) => {
     reply.redirect('/dashboard');
@@ -504,6 +508,13 @@ export async function startWebServer(options: StartWebServerOptions = {}): Promi
  */
 export async function stopWebServer(): Promise<void> {
   if (server) {
+    // Flush hook state before closing
+    try {
+      const { hookState } = await import('../hooks');
+      hookState.flushSync();
+    } catch {
+      // Hook module may not be loaded
+    }
     await server.close();
     server = null;
     activePort = null;

--- a/src/hooks/call-tracker.test.ts
+++ b/src/hooks/call-tracker.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock env-paths and logger before importing modules
+vi.mock('../env-paths', () => ({
+  DATA_DIR: '/tmp/test-hooks-call-tracker',
+  IS_DEV: true,
+}));
+vi.mock('../logger', () => ({
+  Logger: class {
+    debug() {}
+    info() {}
+    warn() {}
+    error() {}
+  },
+}));
+
+// Mock fs to prevent file I/O during tests
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue('{}'),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+describe('call-tracker', () => {
+  let trackPreCall: typeof import('./call-tracker').trackPreCall;
+  let trackPostCall: typeof import('./call-tracker').trackPostCall;
+  let hookState: typeof import('./hook-state').hookState;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+
+    const stateModule = await import('./hook-state');
+    hookState = stateModule.hookState;
+
+    const trackerModule = await import('./call-tracker');
+    trackPreCall = trackerModule.trackPreCall;
+    trackPostCall = trackerModule.trackPostCall;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not create state for non-tracked tool (Read)', () => {
+    trackPreCall({
+      session_id: 'sess-1',
+      tool_name: 'Read',
+    });
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(0);
+  });
+
+  it('should not create state for non-tracked tool (Edit)', () => {
+    trackPreCall({
+      session_id: 'sess-1',
+      tool_name: 'Edit',
+    });
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(0);
+  });
+
+  it('should create pending call for Task tool', () => {
+    trackPreCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_input: { description: 'run tests' },
+    });
+
+    // Pending call should exist — verify by completing it
+    trackPostCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_response: 'done',
+    });
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(1);
+    expect(log[0].toolName).toBe('Task');
+    expect(log[0].description).toBe('run tests');
+    expect(log[0].status).toBe('ok');
+  });
+
+  it('should create pending call for mcp__ tool', () => {
+    trackPreCall({
+      session_id: 'sess-1',
+      tool_name: 'mcp__slack-mcp__send_thread_message',
+    });
+
+    trackPostCall({
+      session_id: 'sess-1',
+      tool_name: 'mcp__slack-mcp__send_thread_message',
+      tool_response: 'sent',
+    });
+
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(1);
+    expect(log[0].toolName).toBe('mcp__slack-mcp__send_thread_message');
+  });
+
+  it('should create log entry with duration after post matches pre', () => {
+    const startTime = new Date('2026-04-10T10:00:00Z');
+    vi.setSystemTime(startTime);
+
+    trackPreCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_input: { description: 'build project' },
+    });
+
+    // Advance time by 2 seconds
+    vi.advanceTimersByTime(2000);
+
+    trackPostCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_response: 'build complete',
+    });
+
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(1);
+    expect(log[0].durationMs).toBeGreaterThanOrEqual(2000);
+    expect(log[0].status).toBe('ok');
+    expect(log[0].description).toBe('build project');
+  });
+
+  it('should not create log entry for post without pre (graceful)', () => {
+    trackPostCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_response: 'orphaned result',
+    });
+
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(0);
+  });
+
+  it('should detect error in tool_response', () => {
+    trackPreCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_input: { description: 'failing task' },
+    });
+
+    trackPostCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_response: 'Error: command failed with exit code 1',
+    });
+
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe('error');
+  });
+
+  it('should detect failure in tool_response', () => {
+    trackPreCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+    });
+
+    trackPostCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_response: 'Task failed to complete',
+    });
+
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe('error');
+  });
+
+  it('should detect timeout in tool_response', () => {
+    trackPreCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+    });
+
+    trackPostCall({
+      session_id: 'sess-1',
+      tool_name: 'Task',
+      tool_response: 'Operation timeout after 30s',
+    });
+
+    const log = hookState.getCallLog('sess-1');
+    expect(log).toHaveLength(1);
+    expect(log[0].status).toBe('error');
+  });
+
+  it('should not track when session_id is missing', () => {
+    trackPreCall({
+      tool_name: 'Task',
+    });
+
+    const log = hookState.getCallLog();
+    expect(log).toHaveLength(0);
+  });
+
+  it('should not track when tool_name is missing', () => {
+    trackPreCall({
+      session_id: 'sess-1',
+    });
+
+    const log = hookState.getCallLog();
+    expect(log).toHaveLength(0);
+  });
+});

--- a/src/hooks/call-tracker.ts
+++ b/src/hooks/call-tracker.ts
@@ -1,0 +1,42 @@
+import { shouldTrackTool } from './hook-policy';
+import { hookState } from './hook-state';
+
+interface HookInput {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: { description?: string };
+  tool_response?: string;
+}
+
+/**
+ * Pre/Post correlation: FIFO matching by (sessionId, toolName).
+ * Limitation: concurrent calls to the same tool within a session
+ * may be matched out-of-order. This is a known constraint of the
+ * Claude Code hook payload (no unique call ID provided).
+ */
+
+function getDescription(toolName: string, toolInput?: { description?: string }): string {
+  if (toolName === 'Task') return toolInput?.description || 'agent call';
+  return toolName.replace(/^mcp__plugin_oh-my-claude_/, '').replace(/__/g, ':');
+}
+
+export function trackPreCall(input: HookInput): void {
+  const { session_id, tool_name } = input;
+  if (!session_id || !tool_name || !shouldTrackTool(tool_name)) return;
+
+  hookState.recordCallStart(session_id, {
+    toolName: tool_name,
+    callId: `${tool_name}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    startTime: new Date().toISOString(),
+    epoch: Math.floor(Date.now() / 1000),
+    description: getDescription(tool_name, input.tool_input),
+  });
+}
+
+export function trackPostCall(input: HookInput): void {
+  const { session_id, tool_name, tool_response } = input;
+  if (!session_id || !tool_name || !shouldTrackTool(tool_name)) return;
+
+  const status = tool_response && /error|fail|timeout/i.test(tool_response) ? 'error' : 'ok';
+  hookState.recordCallEnd(session_id, tool_name, status);
+}

--- a/src/hooks/hook-policy.test.ts
+++ b/src/hooks/hook-policy.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { isExemptTool, shouldTrackTool } from './hook-policy';
+
+describe('hook-policy', () => {
+  describe('isExemptTool', () => {
+    it('should exempt ToolSearch', () => {
+      expect(isExemptTool('ToolSearch')).toBe(true);
+    });
+
+    it('should exempt TodoWrite', () => {
+      expect(isExemptTool('TodoWrite')).toBe(true);
+    });
+
+    it('should not exempt Read', () => {
+      expect(isExemptTool('Read')).toBe(false);
+    });
+
+    it('should not exempt Edit', () => {
+      expect(isExemptTool('Edit')).toBe(false);
+    });
+
+    it('should not exempt Bash', () => {
+      expect(isExemptTool('Bash')).toBe(false);
+    });
+
+    it('should not exempt Task', () => {
+      expect(isExemptTool('Task')).toBe(false);
+    });
+
+    it('should not exempt empty string', () => {
+      expect(isExemptTool('')).toBe(false);
+    });
+  });
+
+  describe('shouldTrackTool', () => {
+    it('should track Task', () => {
+      expect(shouldTrackTool('Task')).toBe(true);
+    });
+
+    it('should track mcp__ prefixed tools', () => {
+      expect(shouldTrackTool('mcp__anything')).toBe(true);
+      expect(shouldTrackTool('mcp__plugin_oh-my-claude__some_tool')).toBe(true);
+      expect(shouldTrackTool('mcp__slack-mcp__send_thread_message')).toBe(true);
+    });
+
+    it('should not track Read', () => {
+      expect(shouldTrackTool('Read')).toBe(false);
+    });
+
+    it('should not track Edit', () => {
+      expect(shouldTrackTool('Edit')).toBe(false);
+    });
+
+    it('should not track Bash', () => {
+      expect(shouldTrackTool('Bash')).toBe(false);
+    });
+
+    it('should not track ToolSearch', () => {
+      expect(shouldTrackTool('ToolSearch')).toBe(false);
+    });
+
+    it('should not track TodoWrite', () => {
+      expect(shouldTrackTool('TodoWrite')).toBe(false);
+    });
+
+    it('should not track empty string', () => {
+      expect(shouldTrackTool('')).toBe(false);
+    });
+  });
+});

--- a/src/hooks/hook-policy.ts
+++ b/src/hooks/hook-policy.ts
@@ -1,0 +1,13 @@
+/**
+ * Hook exemption policy — single source of truth.
+ * Tools listed here are never blocked and never counted.
+ */
+const EXEMPT_TOOLS = new Set(['ToolSearch', 'TodoWrite']);
+
+export function isExemptTool(toolName: string): boolean {
+  return EXEMPT_TOOLS.has(toolName);
+}
+
+export function shouldTrackTool(toolName: string): boolean {
+  return toolName === 'Task' || toolName.startsWith('mcp__');
+}

--- a/src/hooks/hook-state.test.ts
+++ b/src/hooks/hook-state.test.ts
@@ -1,0 +1,267 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// We need a unique temp dir for each test run
+let tempDir: string;
+
+// Mock env-paths before importing the module
+vi.mock('../env-paths', () => ({
+  get DATA_DIR() {
+    return tempDir;
+  },
+  IS_DEV: true,
+}));
+vi.mock('../logger', () => ({
+  Logger: class {
+    debug() {}
+    info() {}
+    warn() {}
+    error() {}
+  },
+}));
+
+describe('HookState', () => {
+  let hookState: typeof import('./hook-state').hookState;
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-state-test-'));
+    vi.resetModules();
+    vi.useFakeTimers();
+
+    const mod = await import('./hook-state');
+    hookState = mod.hookState;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    // Clean up temp dir
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  // ── TodoGuard state ──
+
+  describe('incrementTodoGuard', () => {
+    it('should increase count on each call', () => {
+      const r1 = hookState.incrementTodoGuard('sess-1');
+      expect(r1.count).toBe(1);
+      expect(r1.todoExists).toBe(false);
+
+      const r2 = hookState.incrementTodoGuard('sess-1');
+      expect(r2.count).toBe(2);
+    });
+
+    it('should track sessions independently', () => {
+      hookState.incrementTodoGuard('sess-1');
+      hookState.incrementTodoGuard('sess-1');
+      hookState.incrementTodoGuard('sess-2');
+
+      const s1 = hookState.getTodoGuardState('sess-1');
+      const s2 = hookState.getTodoGuardState('sess-2');
+      expect(s1?.count).toBe(2);
+      expect(s2?.count).toBe(1);
+    });
+  });
+
+  describe('markTodoExists', () => {
+    it('should set todoExists to true', () => {
+      hookState.markTodoExists('sess-1');
+      const state = hookState.getTodoGuardState('sess-1');
+      expect(state?.todoExists).toBe(true);
+    });
+
+    it('should preserve count when marking', () => {
+      hookState.incrementTodoGuard('sess-1');
+      hookState.incrementTodoGuard('sess-1');
+      hookState.markTodoExists('sess-1');
+
+      const state = hookState.getTodoGuardState('sess-1');
+      expect(state?.count).toBe(2);
+      expect(state?.todoExists).toBe(true);
+    });
+  });
+
+  // ── Session cleanup ──
+
+  describe('cleanupSession', () => {
+    it('should remove all session data', () => {
+      hookState.incrementTodoGuard('sess-1');
+      hookState.markTodoExists('sess-1');
+      hookState.recordCallStart('sess-1', {
+        toolName: 'Task',
+        callId: 'c1',
+        startTime: new Date().toISOString(),
+        epoch: Math.floor(Date.now() / 1000),
+        description: 'test',
+      });
+
+      hookState.cleanupSession('sess-1');
+
+      expect(hookState.getTodoGuardState('sess-1')).toBeUndefined();
+    });
+
+    it('should not affect other sessions', () => {
+      hookState.incrementTodoGuard('sess-1');
+      hookState.incrementTodoGuard('sess-2');
+
+      hookState.cleanupSession('sess-1');
+
+      expect(hookState.getTodoGuardState('sess-1')).toBeUndefined();
+      expect(hookState.getTodoGuardState('sess-2')?.count).toBe(1);
+    });
+  });
+
+  // ── Call tracking ──
+
+  describe('recordCallStart/End', () => {
+    it('should create a log entry with FIFO matching', () => {
+      const startTime = new Date('2026-04-10T10:00:00Z');
+      vi.setSystemTime(startTime);
+
+      hookState.recordCallStart('sess-1', {
+        toolName: 'Task',
+        callId: 'c1',
+        startTime: startTime.toISOString(),
+        epoch: Math.floor(startTime.getTime() / 1000),
+        description: 'first call',
+      });
+
+      vi.advanceTimersByTime(1000);
+
+      const entry = hookState.recordCallEnd('sess-1', 'Task', 'ok');
+      expect(entry).not.toBeNull();
+      expect(entry?.callId).toBe('c1');
+      expect(entry?.toolName).toBe('Task');
+      expect(entry?.description).toBe('first call');
+      expect(entry?.status).toBe('ok');
+      expect(entry?.durationMs).toBeGreaterThanOrEqual(1000);
+    });
+
+    it('should return null for recordCallEnd without matching start', () => {
+      const entry = hookState.recordCallEnd('sess-1', 'Task', 'ok');
+      expect(entry).toBeNull();
+    });
+
+    it('should use FIFO order for multiple pending calls', () => {
+      hookState.recordCallStart('sess-1', {
+        toolName: 'Task',
+        callId: 'c1',
+        startTime: new Date().toISOString(),
+        epoch: Math.floor(Date.now() / 1000),
+        description: 'first',
+      });
+
+      hookState.recordCallStart('sess-1', {
+        toolName: 'Task',
+        callId: 'c2',
+        startTime: new Date().toISOString(),
+        epoch: Math.floor(Date.now() / 1000),
+        description: 'second',
+      });
+
+      const entry1 = hookState.recordCallEnd('sess-1', 'Task', 'ok');
+      expect(entry1?.callId).toBe('c1');
+      expect(entry1?.description).toBe('first');
+
+      const entry2 = hookState.recordCallEnd('sess-1', 'Task', 'ok');
+      expect(entry2?.callId).toBe('c2');
+      expect(entry2?.description).toBe('second');
+    });
+  });
+
+  // ── Call log cap ──
+
+  describe('callLog cap', () => {
+    it('should trim call log at 1000 entries', () => {
+      for (let i = 0; i < 1010; i++) {
+        hookState.recordCallStart('sess-1', {
+          toolName: 'Task',
+          callId: `c${i}`,
+          startTime: new Date().toISOString(),
+          epoch: Math.floor(Date.now() / 1000),
+          description: `call ${i}`,
+        });
+        hookState.recordCallEnd('sess-1', 'Task', 'ok');
+      }
+
+      const log = hookState.getCallLog();
+      expect(log.length).toBeLessThanOrEqual(1000);
+      // Should keep the most recent entries
+      expect(log[log.length - 1].callId).toBe('c1009');
+    });
+  });
+
+  // ── Stale cleanup ──
+
+  describe('cleanupStale', () => {
+    it('should remove entries older than 24 hours', () => {
+      const now = new Date('2026-04-10T12:00:00Z');
+      vi.setSystemTime(now);
+
+      hookState.incrementTodoGuard('sess-old');
+
+      // Advance 25 hours
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000);
+
+      hookState.cleanupStale();
+
+      expect(hookState.getTodoGuardState('sess-old')).toBeUndefined();
+    });
+
+    it('should keep entries within 24 hours', () => {
+      const now = new Date('2026-04-10T12:00:00Z');
+      vi.setSystemTime(now);
+
+      hookState.incrementTodoGuard('sess-recent');
+
+      // Advance 23 hours
+      vi.advanceTimersByTime(23 * 60 * 60 * 1000);
+
+      hookState.cleanupStale();
+
+      expect(hookState.getTodoGuardState('sess-recent')).not.toBeUndefined();
+    });
+  });
+
+  // ── Persistence ──
+
+  describe('load/save', () => {
+    it('should persist and reload state via JSON file', async () => {
+      hookState.incrementTodoGuard('sess-persist');
+      hookState.incrementTodoGuard('sess-persist');
+      hookState.markTodoExists('sess-persist');
+
+      // Force synchronous write
+      hookState.flushSync();
+
+      const stateFile = path.join(tempDir, 'hook-state.json');
+      expect(fs.existsSync(stateFile)).toBe(true);
+
+      // Verify file content
+      const data = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+      expect(data.todoGuard['sess-persist']).toBeDefined();
+      expect(data.todoGuard['sess-persist'].count).toBe(2);
+      expect(data.todoGuard['sess-persist'].todoExists).toBe(true);
+    });
+
+    it('should start fresh on corrupted state file', async () => {
+      // Write corrupted data
+      const stateFile = path.join(tempDir, 'hook-state.json');
+      fs.writeFileSync(stateFile, 'not valid json{{{');
+
+      // Re-import to trigger load
+      vi.resetModules();
+      const mod = await import('./hook-state');
+      const freshState = mod.hookState;
+
+      // Should work without error — started fresh
+      const result = freshState.incrementTodoGuard('sess-new');
+      expect(result.count).toBe(1);
+    });
+  });
+});

--- a/src/hooks/hook-state.ts
+++ b/src/hooks/hook-state.ts
@@ -1,0 +1,269 @@
+/**
+ * Hook state — in-memory Map + JSON file persistence.
+ * Same pattern as session-registry.ts: temp→rename atomic save with debounce.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { DATA_DIR } from '../env-paths';
+import { Logger } from '../logger';
+
+const logger = new Logger('HookState');
+const STATE_FILE = path.join(DATA_DIR, 'hook-state.json');
+const SAVE_DEBOUNCE_MS = 500;
+const STALE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const CALL_LOG_CAP = 1000;
+
+// ── Types ──
+
+interface TodoGuardEntry {
+  count: number;
+  todoExists: boolean;
+  updatedAt: string;
+}
+
+export interface CallState {
+  toolName: string;
+  callId: string;
+  startTime: string;
+  epoch: number;
+  description: string;
+}
+
+export interface CallLogEntry {
+  callId: string;
+  sessionId: string;
+  toolName: string;
+  description: string;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+  status: string;
+}
+
+interface PersistedState {
+  todoGuard: Record<string, TodoGuardEntry>;
+  pendingCalls: Record<string, CallState[]>;
+  callLog: CallLogEntry[];
+}
+
+// ── HookState class ──
+
+class HookState {
+  private todoGuard: Map<string, TodoGuardEntry> = new Map();
+  private pendingCalls: Map<string, CallState[]> = new Map();
+  private callLog: CallLogEntry[] = [];
+  private saveTimer: ReturnType<typeof setTimeout> | null = null;
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+  private cleanupInitialized = false;
+
+  constructor() {
+    this.load();
+  }
+
+  // ── TodoGuard ──
+
+  incrementTodoGuard(sessionId: string): { count: number; todoExists: boolean } {
+    const existing = this.todoGuard.get(sessionId) || { count: 0, todoExists: false, updatedAt: '' };
+    existing.count++;
+    existing.updatedAt = new Date().toISOString();
+    this.todoGuard.set(sessionId, existing);
+    this.save();
+    return { count: existing.count, todoExists: existing.todoExists };
+  }
+
+  markTodoExists(sessionId: string): void {
+    const existing = this.todoGuard.get(sessionId) || { count: 0, todoExists: false, updatedAt: '' };
+    existing.todoExists = true;
+    existing.updatedAt = new Date().toISOString();
+    this.todoGuard.set(sessionId, existing);
+    this.save();
+  }
+
+  getTodoGuardState(sessionId: string): TodoGuardEntry | undefined {
+    return this.todoGuard.get(sessionId);
+  }
+
+  // ── Call tracking ──
+
+  recordCallStart(sessionId: string, callState: CallState): void {
+    const key = `${sessionId}:${callState.toolName}`;
+    const queue = this.pendingCalls.get(key) || [];
+    queue.push(callState);
+    this.pendingCalls.set(key, queue);
+    this.save();
+  }
+
+  recordCallEnd(sessionId: string, toolName: string, status: string): CallLogEntry | null {
+    const key = `${sessionId}:${toolName}`;
+    const queue = this.pendingCalls.get(key);
+    if (!queue || queue.length === 0) return null;
+
+    // FIFO: take the oldest pending call
+    const call = queue.shift() as CallState;
+    if (queue.length === 0) {
+      this.pendingCalls.delete(key);
+    }
+
+    const endTime = new Date().toISOString();
+    const startEpoch = new Date(call.startTime).getTime();
+    const endEpoch = Date.now();
+
+    const entry: CallLogEntry = {
+      callId: call.callId,
+      sessionId,
+      toolName,
+      description: call.description,
+      startTime: call.startTime,
+      endTime,
+      durationMs: endEpoch - startEpoch,
+      status,
+    };
+
+    this.callLog.push(entry);
+
+    // Enforce cap
+    if (this.callLog.length > CALL_LOG_CAP) {
+      this.callLog = this.callLog.slice(-CALL_LOG_CAP);
+    }
+
+    this.save();
+    return entry;
+  }
+
+  getCallLog(sessionId?: string): CallLogEntry[] {
+    if (!sessionId) return [...this.callLog];
+    return this.callLog.filter((e) => e.sessionId === sessionId);
+  }
+
+  // ── Session cleanup ──
+
+  cleanupSession(sessionId: string): void {
+    this.todoGuard.delete(sessionId);
+
+    // Remove all pending calls for this session
+    for (const key of [...this.pendingCalls.keys()]) {
+      if (key.startsWith(`${sessionId}:`)) {
+        this.pendingCalls.delete(key);
+      }
+    }
+
+    this.save();
+    logger.debug('Cleaned up session', { sessionId });
+  }
+
+  // ── Persistence ──
+
+  save(): void {
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer);
+    }
+    this.saveTimer = setTimeout(() => {
+      this.writeFile();
+      this.saveTimer = null;
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  load(): void {
+    try {
+      if (!fs.existsSync(STATE_FILE)) return;
+
+      const raw = fs.readFileSync(STATE_FILE, 'utf-8');
+      const data: PersistedState = JSON.parse(raw);
+
+      this.todoGuard = new Map(Object.entries(data.todoGuard || {}));
+      this.pendingCalls = new Map(Object.entries(data.pendingCalls || {}));
+      this.callLog = data.callLog || [];
+
+      logger.debug('Loaded hook state', {
+        todoGuardEntries: this.todoGuard.size,
+        pendingCallKeys: this.pendingCalls.size,
+        callLogEntries: this.callLog.length,
+      });
+    } catch (error) {
+      logger.warn('Failed to load hook state, starting fresh', error);
+    }
+  }
+
+  flushSync(): void {
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer);
+      this.saveTimer = null;
+    }
+    this.writeFile();
+  }
+
+  // ── Stale cleanup ──
+
+  cleanupStale(): void {
+    const now = Date.now();
+    let removed = 0;
+
+    for (const [sessionId, entry] of this.todoGuard) {
+      const updatedAt = new Date(entry.updatedAt).getTime();
+      if (now - updatedAt > STALE_TTL_MS) {
+        this.todoGuard.delete(sessionId);
+        removed++;
+      }
+    }
+
+    // Clean stale pending calls (by epoch)
+    for (const [key, queue] of this.pendingCalls) {
+      const filtered = queue.filter((c) => now - c.epoch * 1000 < STALE_TTL_MS);
+      if (filtered.length === 0) {
+        this.pendingCalls.delete(key);
+      } else if (filtered.length !== queue.length) {
+        this.pendingCalls.set(key, filtered);
+      }
+    }
+
+    if (removed > 0) {
+      logger.info(`Cleaned up ${removed} stale hook state entries`);
+      this.save();
+    }
+  }
+
+  startCleanupTimer(): void {
+    if (this.cleanupInitialized) return;
+    this.cleanupInitialized = true;
+
+    this.cleanupTimer = setInterval(() => {
+      this.cleanupStale();
+    }, CLEANUP_INTERVAL_MS);
+
+    // Unref so it doesn't keep the process alive
+    if (this.cleanupTimer && typeof this.cleanupTimer.unref === 'function') {
+      this.cleanupTimer.unref();
+    }
+
+    logger.debug('Hook state cleanup timer started');
+  }
+
+  // ── Private ──
+
+  private writeFile(): void {
+    try {
+      if (!fs.existsSync(DATA_DIR)) {
+        fs.mkdirSync(DATA_DIR, { recursive: true });
+      }
+
+      const data: PersistedState = {
+        todoGuard: Object.fromEntries(this.todoGuard),
+        pendingCalls: Object.fromEntries(this.pendingCalls),
+        callLog: this.callLog,
+      };
+
+      const json = JSON.stringify(data, null, 2);
+      const tmpFile = `${STATE_FILE}.tmp.${process.pid}`;
+
+      fs.writeFileSync(tmpFile, json);
+      fs.renameSync(tmpFile, STATE_FILE);
+    } catch (error) {
+      logger.error('Failed to write hook state', error);
+    }
+  }
+}
+
+// Export singleton
+export const hookState = new HookState();

--- a/src/hooks/index.test.ts
+++ b/src/hooks/index.test.ts
@@ -1,0 +1,183 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock env-paths and logger before importing modules
+vi.mock('../env-paths', () => ({
+  DATA_DIR: '/tmp/test-hooks-index',
+  IS_DEV: true,
+}));
+vi.mock('../logger', () => ({
+  Logger: class {
+    debug() {}
+    info() {}
+    warn() {}
+    error() {}
+  },
+}));
+
+// Mock fs to prevent file I/O during tests
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue('{}'),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+describe('Hook routes (integration)', () => {
+  let server: FastifyInstance;
+  let hookState: typeof import('./hook-state').hookState;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    server = Fastify({ logger: false });
+
+    const { registerHookRoutes } = await import('./index');
+    const stateModule = await import('./hook-state');
+    hookState = stateModule.hookState;
+
+    await registerHookRoutes(server);
+    await server.ready();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('POST /api/hooks/v1/pre_tool_use with normal tool returns 200', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/hooks/v1/pre_tool_use',
+      payload: {
+        session_id: 'sess-1',
+        tool_name: 'Read',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.action).toBe('pass');
+  });
+
+  it('POST /api/hooks/v1/pre_tool_use over threshold returns 403 with message', async () => {
+    // First, fill up to threshold
+    for (let i = 0; i < 5; i++) {
+      await server.inject({
+        method: 'POST',
+        url: '/api/hooks/v1/pre_tool_use',
+        payload: {
+          session_id: 'sess-block',
+          tool_name: 'Bash',
+        },
+      });
+    }
+
+    // This should be blocked (6th call, count is already at 5+)
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/hooks/v1/pre_tool_use',
+      payload: {
+        session_id: 'sess-block',
+        tool_name: 'Bash',
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    const body = JSON.parse(res.body);
+    expect(body.message).toContain('TodoWrite');
+  });
+
+  it('POST /api/hooks/v1/post_tool_use returns 200', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/hooks/v1/post_tool_use',
+      payload: {
+        session_id: 'sess-1',
+        tool_name: 'Task',
+        tool_response: 'done',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('ok');
+  });
+
+  it('POST /api/hooks/v1/cleanup returns 200 and cleans session', async () => {
+    // Set up some state first
+    hookState.incrementTodoGuard('sess-cleanup');
+    expect(hookState.getTodoGuardState('sess-cleanup')).toBeDefined();
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/hooks/v1/cleanup',
+      payload: {
+        session_id: 'sess-cleanup',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('ok');
+
+    // State should be cleaned
+    expect(hookState.getTodoGuardState('sess-cleanup')).toBeUndefined();
+  });
+
+  it('should fail-open on internal error (returns 200)', async () => {
+    // Send request with no body — the handler wraps try/catch
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/hooks/v1/pre_tool_use',
+      payload: {},
+    });
+
+    // Should still return 200 (fail-open behavior)
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('POST /api/hooks/v1/pre_tool_use with exempt tool (ToolSearch) returns pass', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/hooks/v1/pre_tool_use',
+      payload: {
+        session_id: 'sess-1',
+        tool_name: 'ToolSearch',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.action).toBe('pass');
+  });
+
+  it('POST /api/hooks/v1/pre_tool_use tracks Task tool pre-call', async () => {
+    await server.inject({
+      method: 'POST',
+      url: '/api/hooks/v1/pre_tool_use',
+      payload: {
+        session_id: 'sess-track',
+        tool_name: 'Task',
+        tool_input: { description: 'agent subtask' },
+      },
+    });
+
+    // Complete the call
+    await server.inject({
+      method: 'POST',
+      url: '/api/hooks/v1/post_tool_use',
+      payload: {
+        session_id: 'sess-track',
+        tool_name: 'Task',
+        tool_response: 'completed',
+      },
+    });
+
+    const log = hookState.getCallLog('sess-track');
+    expect(log).toHaveLength(1);
+    expect(log[0].toolName).toBe('Task');
+    expect(log[0].description).toBe('agent subtask');
+    expect(log[0].status).toBe('ok');
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,82 @@
+/**
+ * Hook routes — Fastify plugin for Claude Code hook handlers.
+ * Registered at /api/hooks/v1/ (no auth — localhost only).
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { Logger } from '../logger';
+import { trackPostCall, trackPreCall } from './call-tracker';
+import { hookState } from './hook-state';
+import { handlePreToolUse } from './todo-guard';
+
+const logger = new Logger('HookRoutes');
+
+interface HookBody {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  tool_response?: string;
+}
+
+export async function registerHookRoutes(server: FastifyInstance): Promise<void> {
+  // Start periodic stale-entry cleanup
+  hookState.startCleanupTimer();
+
+  // ── Pre-tool-use ──
+  server.post<{ Body: HookBody }>('/api/hooks/v1/pre_tool_use', async (request, reply) => {
+    try {
+      const body = request.body || {};
+
+      // Guard check FIRST — don't track calls that will be blocked
+      const result = handlePreToolUse(body);
+      if (result.blocked) {
+        logger.info('Tool call blocked by TodoGuard', {
+          sessionId: body.session_id,
+          toolName: body.tool_name,
+        });
+        return reply.status(403).send({ message: result.message });
+      }
+
+      // Track the call only after guard passes (avoids ghost entries)
+      trackPreCall(body);
+
+      reply.send({ action: 'pass' });
+    } catch (error) {
+      logger.error('pre_tool_use handler error', error);
+      // Fail-open: don't block on internal errors
+      reply.send({ decision: 'approve' });
+    }
+  });
+
+  // ── Post-tool-use ──
+  server.post<{ Body: HookBody }>('/api/hooks/v1/post_tool_use', async (request, reply) => {
+    try {
+      const body = request.body || {};
+      trackPostCall(body);
+      reply.send({ status: 'ok' });
+    } catch (error) {
+      logger.error('post_tool_use handler error', error);
+      reply.send({ status: 'ok' });
+    }
+  });
+
+  // ── Cleanup ──
+  server.post<{ Body: { session_id?: string } }>('/api/hooks/v1/cleanup', async (request, reply) => {
+    try {
+      const sessionId = request.body?.session_id;
+      if (sessionId) {
+        hookState.cleanupSession(sessionId);
+        logger.info('Session cleaned up via hook', { sessionId });
+      }
+      reply.send({ status: 'ok' });
+    } catch (error) {
+      logger.error('cleanup handler error', error);
+      reply.send({ status: 'ok' });
+    }
+  });
+
+  logger.info('Hook routes registered at /api/hooks/v1/');
+}
+
+// Re-export for convenience
+export { hookState } from './hook-state';

--- a/src/hooks/todo-guard.test.ts
+++ b/src/hooks/todo-guard.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock env-paths and logger before importing modules
+vi.mock('../env-paths', () => ({
+  DATA_DIR: '/tmp/test-hooks-todo-guard',
+  IS_DEV: true,
+}));
+vi.mock('../logger', () => ({
+  Logger: class {
+    debug() {}
+    info() {}
+    warn() {}
+    error() {}
+  },
+}));
+
+// Mock fs to prevent file I/O during tests
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue('{}'),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+describe('todo-guard', () => {
+  let handlePreToolUse: typeof import('./todo-guard').handlePreToolUse;
+  let hookState: typeof import('./hook-state').hookState;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+
+    const stateModule = await import('./hook-state');
+    hookState = stateModule.hookState;
+
+    const guardModule = await import('./todo-guard');
+    handlePreToolUse = guardModule.handlePreToolUse;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not block exempt tool (ToolSearch)', () => {
+    const result = handlePreToolUse({
+      session_id: 'sess-1',
+      tool_name: 'ToolSearch',
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it('should not block TodoWrite and set marker via handlePreToolUse', () => {
+    // TodoWrite is handled BEFORE exempt check to set the marker.
+    // The shell proxy forwards TodoWrite specifically for this purpose.
+    const result = handlePreToolUse({
+      session_id: 'sess-1',
+      tool_name: 'TodoWrite',
+      tool_input: { todos: [{ content: 'task 1', status: 'pending' }] },
+    });
+    expect(result.blocked).toBe(false);
+
+    // Marker IS set via handlePreToolUse (TodoWrite handled before exempt check)
+    const state = hookState.getTodoGuardState('sess-1');
+    expect(state?.todoExists).toBe(true);
+  });
+
+  it('should not block TodoWrite with empty todos and not set marker', () => {
+    const result = handlePreToolUse({
+      session_id: 'sess-1',
+      tool_name: 'TodoWrite',
+      tool_input: { todos: [] },
+    });
+    expect(result.blocked).toBe(false);
+
+    // Marker should NOT be set
+    const state = hookState.getTodoGuardState('sess-1');
+    expect(state).toBeUndefined();
+  });
+
+  it('should not block when no session_id (fail-open)', () => {
+    const result = handlePreToolUse({
+      tool_name: 'Bash',
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it('should not block when under threshold and increment count', () => {
+    for (let i = 0; i < 4; i++) {
+      const result = handlePreToolUse({
+        session_id: 'sess-1',
+        tool_name: 'Bash',
+      });
+      expect(result.blocked).toBe(false);
+    }
+
+    const state = hookState.getTodoGuardState('sess-1');
+    expect(state?.count).toBe(4);
+  });
+
+  it('should block at threshold (5 calls)', () => {
+    // Make 5 calls to reach threshold
+    for (let i = 0; i < 4; i++) {
+      handlePreToolUse({
+        session_id: 'sess-1',
+        tool_name: 'Bash',
+      });
+    }
+
+    const result = handlePreToolUse({
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+    });
+    expect(result.blocked).toBe(true);
+    expect(result.message).toBeDefined();
+    expect(result.message).toContain('TodoWrite');
+  });
+
+  it('should not block after TodoWrite marker is set (via hookState) regardless of count', () => {
+    // Make 4 calls first
+    for (let i = 0; i < 4; i++) {
+      handlePreToolUse({
+        session_id: 'sess-1',
+        tool_name: 'Bash',
+      });
+    }
+
+    // Set TodoWrite marker directly (as the shell proxy does)
+    hookState.markTodoExists('sess-1');
+
+    // Next calls should not be blocked even though count >= threshold
+    const result = handlePreToolUse({
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it('should track sessions independently', () => {
+    // Fill session 1 to threshold
+    for (let i = 0; i < 5; i++) {
+      handlePreToolUse({
+        session_id: 'sess-1',
+        tool_name: 'Bash',
+      });
+    }
+
+    // Session 2 should still be under threshold
+    const result = handlePreToolUse({
+      session_id: 'sess-2',
+      tool_name: 'Bash',
+    });
+    expect(result.blocked).toBe(false);
+
+    const state1 = hookState.getTodoGuardState('sess-1');
+    const state2 = hookState.getTodoGuardState('sess-2');
+    expect(state1?.count).toBe(5);
+    expect(state2?.count).toBe(1);
+  });
+});

--- a/src/hooks/todo-guard.ts
+++ b/src/hooks/todo-guard.ts
@@ -1,0 +1,50 @@
+import { isExemptTool } from './hook-policy';
+import { hookState } from './hook-state';
+
+const THRESHOLD = parseInt(process.env.TODO_GUARD_THRESHOLD || '5', 10);
+
+interface HookInput {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: { todos?: unknown[] };
+}
+
+interface GuardResult {
+  blocked: boolean;
+  message?: string;
+}
+
+export function handlePreToolUse(input: HookInput): GuardResult {
+  const { session_id, tool_name, tool_input } = input;
+
+  // TodoWrite: set marker BEFORE exempt check — the proxy forwards TodoWrite
+  // specifically so the service can set the marker. Must not be short-circuited.
+  if (tool_name === 'TodoWrite') {
+    const todos = tool_input?.todos;
+    if (session_id && Array.isArray(todos) && todos.length > 0) {
+      hookState.markTodoExists(session_id);
+    }
+    return { blocked: false };
+  }
+
+  // Policy check (defense in depth — shell also checks)
+  if (isExemptTool(tool_name || '')) return { blocked: false };
+
+  // No session_id → pass (fail-open)
+  if (!session_id) return { blocked: false };
+
+  // Already has todos → pass
+  const state = hookState.getTodoGuardState(session_id);
+  if (state?.todoExists) return { blocked: false };
+
+  // Increment and check threshold
+  const updated = hookState.incrementTodoGuard(session_id);
+  if (updated.count >= THRESHOLD) {
+    return {
+      blocked: true,
+      message: `\u26a0\ufe0f TodoWrite \uc5c6\uc774 ${THRESHOLD}\ud68c \uc774\uc0c1 tool call\uc774 \uac10\uc9c0\ub418\uc5c8\uc2b5\ub2c8\ub2e4.\n\uba3c\uc800 TodoWrite\ub85c \ud0dc\uc2a4\ud06c\ub97c \ub4f1\ub85d\ud558\uc138\uc694.\n\nTodoWrite \uc608\uc2dc:\n  TodoWrite({ todos: [{ content: "\uc791\uc5c5 \ub0b4\uc6a9", status: "pending", activeForm: "\uc791\uc5c5 \uc911" }] })`,
+    };
+  }
+
+  return { blocked: false };
+}

--- a/src/local/hooks/hook-proxy.sh
+++ b/src/local/hooks/hook-proxy.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# hook-proxy.sh — Thin HTTP proxy for Claude Code hooks
+# Routes hook events to soma-work Fastify service.
+# All business logic lives in the service; this script only forwards.
+#
+# Usage: hook-proxy.sh <pre_tool_use|post_tool_use|cleanup>
+# Exit codes: 0 = pass, 2 = blocked (pre_tool_use only)
+#
+# Safety: fail-open on ALL errors (network, timeout, parse failure)
+
+set -uo pipefail
+
+EVENT="${1:-}"
+
+if [[ -z "$EVENT" ]]; then
+  echo "Usage: hook-proxy.sh <pre_tool_use|post_tool_use|cleanup>" >&2
+  exit 0
+fi
+
+# ── Rollback: disabled proxy → delegate to legacy scripts ──
+if [[ "${HOOKS_PROXY_ENABLED:-true}" != "true" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  if [[ -t 0 ]]; then
+    HOOK_INPUT="{}"
+  else
+    HOOK_INPUT=$(cat 2>/dev/null || echo "{}")
+  fi
+  case "$EVENT" in
+    pre_tool_use)
+      echo "$HOOK_INPUT" | "$SCRIPT_DIR/todo-guard.sh"
+      TODO_EXIT=$?
+      TOOL_NAME=$(echo "$HOOK_INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+      case "$TOOL_NAME" in
+        Task|mcp__*) echo "$HOOK_INPUT" | "$SCRIPT_DIR/call-tracker.sh" pre ;;
+      esac
+      exit $TODO_EXIT
+      ;;
+    post_tool_use)
+      TOOL_NAME=$(echo "$HOOK_INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+      case "$TOOL_NAME" in
+        Task|mcp__*) echo "$HOOK_INPUT" | "$SCRIPT_DIR/call-tracker.sh" post ;;
+      esac
+      exit 0
+      ;;
+    cleanup)
+      echo "$HOOK_INPUT" | "$SCRIPT_DIR/todo-guard-cleanup.sh"
+      exit 0
+      ;;
+  esac
+  exit 0
+fi
+
+# ── Read hook input from stdin ──
+if [[ -t 0 ]]; then
+  HOOK_INPUT="{}"
+else
+  HOOK_INPUT=$(cat 2>/dev/null || echo "{}")
+fi
+
+# ── Extract tool name ──
+TOOL_NAME=$(echo "$HOOK_INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# ── Exempt tools: exit immediately, no HTTP, no state ──
+# These must never be blocked or counted. Shell short-circuits before
+# any I/O to prevent deadlock (ToolSearch → load TodoWrite schema).
+case "$TOOL_NAME" in
+  ToolSearch)
+    exit 0
+    ;;
+  TodoWrite)
+    if [[ "$EVENT" == "pre_tool_use" ]]; then
+      # Sync POST to set marker — never blocks (exit 0 regardless)
+      curl -s --max-time 0.3 --connect-timeout 0.1 \
+        -X POST "http://127.0.0.1:${SOMA_HOOK_PORT:-${CONVERSATION_VIEWER_PORT:-33000}}/api/hooks/v1/${EVENT}" \
+        -H "Content-Type: application/json" \
+        -d "$HOOK_INPUT" >/dev/null 2>&1 || true
+    fi
+    exit 0
+    ;;
+esac
+
+# ── Determine service port ──
+# Priority: SOMA_HOOK_PORT > CONVERSATION_VIEWER_PORT > 33000 (dev default)
+PORT="${SOMA_HOOK_PORT:-${CONVERSATION_VIEWER_PORT:-33000}}"
+
+# ── Forward to service ──
+RESPONSE=$(curl -s --max-time 0.5 --connect-timeout 0.15 \
+  -w "\n%{http_code}" \
+  -X POST "http://127.0.0.1:${PORT}/api/hooks/v1/${EVENT}" \
+  -H "Content-Type: application/json" \
+  -d "$HOOK_INPUT" 2>/dev/null) || {
+  # curl failed — fail-open
+  exit 0
+}
+
+# ── Parse response ──
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+case "$HTTP_CODE" in
+  200|202)
+    exit 0
+    ;;
+  403)
+    # Blocked by service — extract message and emit to stderr
+    MSG=$(echo "$BODY" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "$MSG" ]]; then
+      echo "$MSG" >&2
+    fi
+    exit 2
+    ;;
+  *)
+    # Unknown status — fail-open
+    echo "⚠️ hook-proxy: unexpected status $HTTP_CODE, passing" >&2
+    exit 0
+    ;;
+esac

--- a/src/local/hooks/hooks.json
+++ b/src/local/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "ohmyclaude hooks: Ralph Wiggum stop hook + auto call tracking + todo guard",
+  "description": "ohmyclaude hooks: HTTP proxy to soma-work service + Ralph Wiggum stop hook",
   "hooks": {
     "Stop": [
       {
@@ -10,7 +10,7 @@
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/todo-guard-cleanup.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/hook-proxy.sh cleanup"
           }
         ]
       }
@@ -21,45 +21,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/todo-guard.sh"
-          }
-        ]
-      },
-      {
-        "matcher": "Task",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/call-tracker.sh pre"
-          }
-        ]
-      },
-      {
-        "matcher": "mcp__.*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/call-tracker.sh pre"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/hook-proxy.sh pre_tool_use"
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Task",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/call-tracker.sh post"
-          }
-        ]
-      },
-      {
-        "matcher": "mcp__.*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/call-tracker.sh post"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/hook-proxy.sh post_tool_use"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Shell hooks 비즈니스 로직을 Fastify 서비스로 이동
- 단일 thin HTTP proxy (hook-proxy.sh)로 교체
- /tmp/claude-calls/ 파일 기반 상태 제거

## Design
- ToolSearch: exit 0 (deadlock 방지)
- TodoWrite: 동기 POST 0.3s + exit 0
- Fail-open, Rollback: HOOKS_PROXY_ENABLED=false

## Tests: 55 passing, codex 95/100

Closes #415