### PR TITLE
feat: WebViewAdapter — Dashboard view with native WebSocket streaming

### DIFF
--- a/src/view/web/index.ts
+++ b/src/view/web/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Web View Module — Dashboard view adapter (Issue #412)
+ */
+
+// Input adapter (stub)
+export { WebInputAdapter } from './web-input-adapter.js';
+export type { WebConversationRef, WebMessageRef } from './web-refs.js';
+// Opaque reference types
+export { extractWebMessageRef, extractWebRef, webMessageHandle, webTarget } from './web-refs.js';
+// Response session (native WebSocket streaming)
+export { WebResponseSession, type WebSocketBroadcaster } from './web-response-session.js';
+// View adapter
+export { WebViewAdapter } from './web-view-adapter.js';

--- a/src/view/web/web-input-adapter.ts
+++ b/src/view/web/web-input-adapter.ts
@@ -1,0 +1,30 @@
+/**
+ * WebInputAdapter — HTTP/WebSocket input adapter stub (Issue #412)
+ *
+ * Translates Web Dashboard user actions into normalized InputEvents.
+ * Full implementation will wire into Fastify routes in a future phase.
+ *
+ * Sources:
+ * - POST /api/dashboard/session/:key/command → message events
+ * - WebSocket messages → command/action events
+ * - Form submissions → form_submit events
+ */
+
+import type { InputAdapter, InputHandler } from '../input.js';
+import type { Platform } from '../types.js';
+
+export class WebInputAdapter implements InputAdapter {
+  readonly platform: Platform = 'web';
+
+  onInput(_handler: InputHandler): void {
+    // Will store handler when Fastify routes are wired in Phase 7
+  }
+
+  async start(): Promise<void> {
+    // Will register Fastify routes and WebSocket handlers in Phase 7
+  }
+
+  async stop(): Promise<void> {
+    // Will clean up handler when Fastify routes are wired in Phase 7
+  }
+}

--- a/src/view/web/web-refs.test.ts
+++ b/src/view/web/web-refs.test.ts
@@ -1,0 +1,39 @@
+/**
+ * WebRefs tests (Issue #412)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { extractWebMessageRef, extractWebRef, webMessageHandle, webTarget } from './web-refs.js';
+
+describe('WebRefs', () => {
+  describe('webTarget', () => {
+    it('creates a web ConversationTarget', () => {
+      const target = webTarget('C123:root', 'U456');
+
+      expect(target.platform).toBe('web');
+      expect(target.userId).toBe('U456');
+      const ref = extractWebRef(target);
+      expect(ref.sessionKey).toBe('C123:root');
+      expect(ref.userId).toBe('U456');
+    });
+
+    it('supports threadId', () => {
+      const target = webTarget('C123:root', 'U456', 'thread-1');
+
+      const ref = extractWebRef(target);
+      expect(ref.threadId).toBe('thread-1');
+    });
+  });
+
+  describe('webMessageHandle', () => {
+    it('creates a web MessageHandle', () => {
+      const handle = webMessageHandle('C123:root', 'msg-abc');
+
+      expect(handle.platform).toBe('web');
+      const ref = extractWebMessageRef(handle);
+      expect(ref.sessionKey).toBe('C123:root');
+      expect(ref.messageId).toBe('msg-abc');
+      expect(ref.timestamp).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/view/web/web-refs.ts
+++ b/src/view/web/web-refs.ts
@@ -1,0 +1,64 @@
+/**
+ * WebRefs — Opaque reference types for Web Dashboard (Issue #412)
+ *
+ * Web Dashboard uses session-based references instead of Slack's
+ * channel/thread model. Each conversation is identified by a
+ * session key (matching SessionRegistry) and optional thread ID.
+ */
+
+import type { ConversationTarget, MessageHandle, Platform } from '../types.js';
+
+// ─── Ref Types ──────────────────────────────────────────────────
+
+/** Web conversation reference (opaque to the Controller). */
+export interface WebConversationRef {
+  readonly sessionKey: string;
+  readonly userId: string;
+  readonly threadId?: string;
+}
+
+/** Web message reference (opaque to the Controller). */
+export interface WebMessageRef {
+  readonly sessionKey: string;
+  readonly messageId: string;
+  readonly timestamp: number;
+}
+
+// ─── Factory Functions ──────────────────────────────────────────
+
+/** Create a ConversationTarget for Web Dashboard. */
+export function webTarget(sessionKey: string, userId: string, threadId?: string): ConversationTarget {
+  const ref: WebConversationRef = { sessionKey, userId, threadId };
+  return {
+    platform: 'web' as Platform,
+    ref,
+    userId,
+  };
+}
+
+/** Create a MessageHandle for a Web message. */
+export function webMessageHandle(sessionKey: string, messageId: string): MessageHandle {
+  const ref: WebMessageRef = { sessionKey, messageId, timestamp: Date.now() };
+  return {
+    platform: 'web' as Platform,
+    ref,
+  };
+}
+
+// ─── Extractors ─────────────────────────────────────────────────
+
+/** Extract WebConversationRef from a ConversationTarget. */
+export function extractWebRef(target: ConversationTarget): WebConversationRef {
+  if (target.platform !== 'web') {
+    throw new Error(`Expected web platform target, got ${target.platform}`);
+  }
+  return target.ref as WebConversationRef;
+}
+
+/** Extract WebMessageRef from a MessageHandle. */
+export function extractWebMessageRef(handle: MessageHandle): WebMessageRef {
+  if (handle.platform !== 'web') {
+    throw new Error(`Expected web platform handle, got ${handle.platform}`);
+  }
+  return handle.ref as WebMessageRef;
+}

--- a/src/view/web/web-response-session.test.ts
+++ b/src/view/web/web-response-session.test.ts
@@ -1,0 +1,132 @@
+/**
+ * WebResponseSession tests (Issue #412)
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { WebResponseSession, type WebSocketBroadcaster } from './web-response-session.js';
+
+function createMockBroadcaster(): WebSocketBroadcaster & {
+  messages: Array<{ key: string; msg: Record<string, unknown> }>;
+} {
+  const messages: Array<{ key: string; msg: Record<string, unknown> }> = [];
+  return {
+    messages,
+    send: vi.fn((key: string, msg: Record<string, unknown>) => {
+      messages.push({ key, msg });
+    }),
+  };
+}
+
+describe('WebResponseSession', () => {
+  it('sends response_start on construction', () => {
+    const broadcaster = createMockBroadcaster();
+    new WebResponseSession('sess-1', broadcaster);
+
+    expect(broadcaster.send).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({
+        type: 'response_start',
+        sessionKey: 'sess-1',
+      }),
+    );
+  });
+
+  it('sends text deltas immediately (native streaming)', () => {
+    const broadcaster = createMockBroadcaster();
+    const session = new WebResponseSession('sess-1', broadcaster);
+
+    session.appendText('Hello ');
+    session.appendText('world!');
+
+    const textMessages = broadcaster.messages.filter((m) => m.msg.type === 'response_text');
+    expect(textMessages).toHaveLength(2);
+    expect(textMessages[0].msg.delta).toBe('Hello ');
+    expect(textMessages[1].msg.delta).toBe('world!');
+  });
+
+  it('sends status updates', () => {
+    const broadcaster = createMockBroadcaster();
+    const session = new WebResponseSession('sess-1', broadcaster);
+
+    session.setStatus('thinking', { context: 'analyzing code' });
+
+    const statusMessages = broadcaster.messages.filter((m) => m.msg.type === 'response_status');
+    expect(statusMessages).toHaveLength(1);
+    expect(statusMessages[0].msg.phase).toBe('thinking');
+    expect(statusMessages[0].msg.detail).toEqual({ context: 'analyzing code' });
+  });
+
+  it('sends part replacements', () => {
+    const broadcaster = createMockBroadcaster();
+    const session = new WebResponseSession('sess-1', broadcaster);
+
+    session.replacePart('tool-1', { type: 'status', phase: 'running', tool: 'Bash' });
+
+    const replaceMessages = broadcaster.messages.filter((m) => m.msg.type === 'response_replace');
+    expect(replaceMessages).toHaveLength(1);
+    expect(replaceMessages[0].msg.partId).toBe('tool-1');
+  });
+
+  it('sends file metadata', () => {
+    const broadcaster = createMockBroadcaster();
+    const session = new WebResponseSession('sess-1', broadcaster);
+
+    session.attachFile({
+      name: 'output.txt',
+      mimeType: 'text/plain',
+      data: Buffer.from('hello'),
+    });
+
+    const fileMessages = broadcaster.messages.filter((m) => m.msg.type === 'response_file');
+    expect(fileMessages).toHaveLength(1);
+    expect(fileMessages[0].msg.name).toBe('output.txt');
+    expect(fileMessages[0].msg.size).toBe(5);
+  });
+
+  it('sends response_complete and returns handle', async () => {
+    const broadcaster = createMockBroadcaster();
+    const session = new WebResponseSession('sess-1', broadcaster);
+
+    session.appendText('Done');
+    const handle = await session.complete();
+
+    const completeMessages = broadcaster.messages.filter((m) => m.msg.type === 'response_complete');
+    expect(completeMessages).toHaveLength(1);
+    expect(completeMessages[0].msg.textLength).toBe(4);
+    expect(handle.platform).toBe('web');
+  });
+
+  it('sends response_abort with reason', () => {
+    const broadcaster = createMockBroadcaster();
+    const session = new WebResponseSession('sess-1', broadcaster);
+
+    session.abort('API error');
+
+    const abortMessages = broadcaster.messages.filter((m) => m.msg.type === 'response_abort');
+    expect(abortMessages).toHaveLength(1);
+    expect(abortMessages[0].msg.reason).toBe('API error');
+  });
+
+  it('ignores calls after complete', async () => {
+    const broadcaster = createMockBroadcaster();
+    const session = new WebResponseSession('sess-1', broadcaster);
+
+    await session.complete();
+    session.appendText('ignored');
+    session.setStatus('ignored');
+
+    const textMessages = broadcaster.messages.filter((m) => m.msg.type === 'response_text');
+    expect(textMessages).toHaveLength(0);
+  });
+
+  it('ignores calls after abort', () => {
+    const broadcaster = createMockBroadcaster();
+    const session = new WebResponseSession('sess-1', broadcaster);
+
+    session.abort('error');
+    session.appendText('ignored');
+
+    const textMessages = broadcaster.messages.filter((m) => m.msg.type === 'response_text');
+    expect(textMessages).toHaveLength(0);
+  });
+});

--- a/src/view/web/web-response-session.ts
+++ b/src/view/web/web-response-session.ts
@@ -1,0 +1,136 @@
+/**
+ * WebResponseSession — WebSocket-based native streaming (Issue #412)
+ *
+ * Unlike Slack/Telegram/Discord which use edit-polling (throttled message edits),
+ * the Web Dashboard supports true streaming via WebSocket.
+ *
+ * Each `appendText` call is sent immediately as a WebSocket message.
+ * The frontend reconstructs the full response by accumulating deltas.
+ *
+ * Protocol:
+ *   { type: 'response_start', sessionKey }
+ *   { type: 'response_text', sessionKey, delta }
+ *   { type: 'response_status', sessionKey, phase, detail? }
+ *   { type: 'response_replace', sessionKey, partId, content }
+ *   { type: 'response_file', sessionKey, name, mimeType }
+ *   { type: 'response_complete', sessionKey, messageId }
+ *   { type: 'response_abort', sessionKey, reason? }
+ */
+
+import { Logger } from '../../logger.js';
+import type { ResponseSession, StatusDetail } from '../response-session.js';
+import type { ContentBlock, FileData, MessageHandle } from '../types.js';
+import { webMessageHandle } from './web-refs.js';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** Minimal interface for broadcasting to WebSocket clients. */
+export interface WebSocketBroadcaster {
+  /** Send a typed message to all connected clients for a session. */
+  send(sessionKey: string, message: Record<string, unknown>): void;
+}
+
+// ─── Implementation ─────────────────────────────────────────────
+
+export class WebResponseSession implements ResponseSession {
+  private logger = new Logger('WebResponseSession');
+  private completed = false;
+  private aborted = false;
+  private messageId: string;
+  private textLength = 0;
+
+  constructor(
+    private sessionKey: string,
+    private broadcaster: WebSocketBroadcaster,
+  ) {
+    this.messageId = `web-msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    this.broadcaster.send(this.sessionKey, {
+      type: 'response_start',
+      sessionKey: this.sessionKey,
+      messageId: this.messageId,
+    });
+  }
+
+  appendText(delta: string): void {
+    if (this.completed || this.aborted) return;
+    this.textLength += delta.length;
+
+    this.broadcaster.send(this.sessionKey, {
+      type: 'response_text',
+      sessionKey: this.sessionKey,
+      delta,
+    });
+  }
+
+  setStatus(phase: string, detail?: StatusDetail): void {
+    if (this.completed || this.aborted) return;
+
+    this.broadcaster.send(this.sessionKey, {
+      type: 'response_status',
+      sessionKey: this.sessionKey,
+      phase,
+      ...(detail && { detail }),
+    });
+  }
+
+  replacePart(partId: string, content: ContentBlock): void {
+    if (this.completed || this.aborted) return;
+
+    this.broadcaster.send(this.sessionKey, {
+      type: 'response_replace',
+      sessionKey: this.sessionKey,
+      partId,
+      content,
+    });
+  }
+
+  attachFile(file: FileData): void {
+    if (this.completed || this.aborted) return;
+
+    this.broadcaster.send(this.sessionKey, {
+      type: 'response_file',
+      sessionKey: this.sessionKey,
+      name: file.name,
+      mimeType: file.mimeType,
+      size: file.data instanceof Buffer ? file.data.length : file.data.length,
+    });
+  }
+
+  async complete(): Promise<MessageHandle> {
+    if (this.completed || this.aborted) {
+      return webMessageHandle(this.sessionKey, this.messageId);
+    }
+
+    this.completed = true;
+    this.broadcaster.send(this.sessionKey, {
+      type: 'response_complete',
+      sessionKey: this.sessionKey,
+      messageId: this.messageId,
+      textLength: this.textLength,
+    });
+
+    this.logger.debug('Response completed', {
+      sessionKey: this.sessionKey,
+      textLength: this.textLength,
+    });
+
+    return webMessageHandle(this.sessionKey, this.messageId);
+  }
+
+  abort(reason?: string): void {
+    if (this.completed || this.aborted) return;
+
+    this.aborted = true;
+    this.broadcaster.send(this.sessionKey, {
+      type: 'response_abort',
+      sessionKey: this.sessionKey,
+      reason,
+    });
+
+    this.logger.debug('Response aborted', {
+      sessionKey: this.sessionKey,
+      reason,
+    });
+  }
+}

--- a/src/view/web/web-view-adapter.test.ts
+++ b/src/view/web/web-view-adapter.test.ts
@@ -1,0 +1,222 @@
+/**
+ * WebViewAdapter tests (Issue #412)
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ContentBlock } from '../types.js';
+import { extractWebRef, webMessageHandle, webTarget } from './web-refs.js';
+import type { WebSocketBroadcaster } from './web-response-session.js';
+import { WebViewAdapter } from './web-view-adapter.js';
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function createMockBroadcaster(): WebSocketBroadcaster & {
+  messages: Array<{ key: string; msg: Record<string, unknown> }>;
+} {
+  const messages: Array<{ key: string; msg: Record<string, unknown> }> = [];
+  return {
+    messages,
+    send: vi.fn((key: string, msg: Record<string, unknown>) => {
+      messages.push({ key, msg });
+    }),
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe('WebViewAdapter', () => {
+  it('reports platform as web', () => {
+    const broadcaster = createMockBroadcaster();
+    const adapter = new WebViewAdapter(broadcaster);
+    expect(adapter.platform).toBe('web');
+  });
+
+  describe('featuresFor', () => {
+    it('returns full capabilities', () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const target = webTarget('sess-1', 'U123');
+
+      const features = adapter.featuresFor(target);
+
+      expect(features.canEdit).toBe(true);
+      expect(features.canThread).toBe(true);
+      expect(features.canReact).toBe(true);
+      expect(features.canModal).toBe(true);
+      expect(features.canUploadFile).toBe(true);
+      expect(features.canEphemeral).toBe(false);
+      expect(features.maxMessageLength).toBe(0); // Unlimited
+    });
+  });
+
+  describe('postMessage', () => {
+    it('broadcasts message to session', async () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const target = webTarget('sess-1', 'U123');
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Hello web!' }];
+
+      const handle = await adapter.postMessage(target, blocks);
+
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          type: 'message',
+          sessionKey: 'sess-1',
+          blocks,
+        }),
+      );
+      expect(handle.platform).toBe('web');
+    });
+  });
+
+  describe('beginResponse', () => {
+    it('returns a WebResponseSession', () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const target = webTarget('sess-1', 'U123');
+
+      const session = adapter.beginResponse(target);
+
+      expect(session).toBeDefined();
+      expect(session.appendText).toBeDefined();
+      expect(session.complete).toBeDefined();
+      // Should have sent response_start
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          type: 'response_start',
+        }),
+      );
+    });
+  });
+
+  describe('Editable', () => {
+    it('broadcasts message update', async () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const handle = webMessageHandle('sess-1', 'msg-1');
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Updated' }];
+
+      await adapter.updateMessage(handle, blocks);
+
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          type: 'message_update',
+          messageId: 'msg-1',
+          blocks,
+        }),
+      );
+    });
+
+    it('broadcasts message delete', async () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const handle = webMessageHandle('sess-1', 'msg-1');
+
+      await adapter.deleteMessage(handle);
+
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          type: 'message_delete',
+          messageId: 'msg-1',
+        }),
+      );
+    });
+  });
+
+  describe('Threadable', () => {
+    it('creates thread and returns new target', async () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const target = webTarget('sess-1', 'U123');
+
+      const threadTarget = await adapter.createThread(target, []);
+
+      expect(threadTarget.platform).toBe('web');
+      expect(threadTarget.userId).toBe('U123');
+      const ref = extractWebRef(threadTarget);
+      expect(ref.sessionKey).toBe('sess-1');
+      expect(ref.threadId).toMatch(/^thread-/);
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          type: 'thread_created',
+        }),
+      );
+    });
+  });
+
+  describe('Reactable', () => {
+    it('broadcasts reaction add', async () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const handle = webMessageHandle('sess-1', 'msg-1');
+
+      await adapter.addReaction(handle, 'thumbsup');
+
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          type: 'reaction_add',
+          emoji: 'thumbsup',
+        }),
+      );
+    });
+
+    it('broadcasts reaction remove', async () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const handle = webMessageHandle('sess-1', 'msg-1');
+
+      await adapter.removeReaction(handle, 'thumbsup');
+
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          type: 'reaction_remove',
+          emoji: 'thumbsup',
+        }),
+      );
+    });
+  });
+
+  describe('HasModals', () => {
+    it('opens form and returns formId', async () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+      const target = webTarget('sess-1', 'U123');
+
+      const formId = await adapter.openForm(target, {
+        title: 'Settings',
+        fields: [{ id: 'name', fieldType: 'text', label: 'Name' }],
+      });
+
+      expect(formId).toMatch(/^form-/);
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          type: 'form_open',
+          formId,
+        }),
+      );
+    });
+
+    it('closes form', async () => {
+      const broadcaster = createMockBroadcaster();
+      const adapter = new WebViewAdapter(broadcaster);
+
+      await adapter.closeForm('form-123');
+
+      expect(broadcaster.send).toHaveBeenCalledWith(
+        '*',
+        expect.objectContaining({
+          type: 'form_close',
+          formId: 'form-123',
+        }),
+      );
+    });
+  });
+});

--- a/src/view/web/web-view-adapter.ts
+++ b/src/view/web/web-view-adapter.ts
@@ -1,0 +1,159 @@
+/**
+ * WebViewAdapter — Web Dashboard view surface (Issue #412)
+ *
+ * Implements the full ViewSurface hierarchy for Web Dashboard.
+ * Web is the superset platform — supports all capabilities.
+ *
+ * Key difference from Slack:
+ * - Native streaming via WebSocket (no edit-polling)
+ * - Unlimited message length
+ * - Unlimited file size (server-dependent)
+ * - Full modal/form support via React components
+ *
+ * This is a thin adapter over the existing dashboard.ts broadcast
+ * functions. It does NOT restructure dashboard internals —
+ * that's a separate refactoring task.
+ */
+
+import type { ResponseSession } from '../response-session.js';
+import type { Editable, HasModals, Reactable, Threadable, ViewSurfaceCore } from '../surface.js';
+import type { ContentBlock, ConversationTarget, FeatureSet, FormSpec, MessageHandle, Platform } from '../types.js';
+import { extractWebMessageRef, extractWebRef, webMessageHandle, webTarget } from './web-refs.js';
+import { WebResponseSession, type WebSocketBroadcaster } from './web-response-session.js';
+
+// ─── Implementation ─────────────────────────────────────────────
+
+export class WebViewAdapter implements ViewSurfaceCore, Editable, Threadable, Reactable, HasModals {
+  readonly platform: Platform = 'web';
+
+  constructor(private broadcaster: WebSocketBroadcaster) {}
+
+  // ─── ViewSurfaceCore ──────────────────────────────────────
+
+  async postMessage(target: ConversationTarget, blocks: readonly ContentBlock[]): Promise<MessageHandle> {
+    const ref = extractWebRef(target);
+    const messageId = `web-msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    this.broadcaster.send(ref.sessionKey, {
+      type: 'message',
+      sessionKey: ref.sessionKey,
+      messageId,
+      blocks,
+    });
+
+    return webMessageHandle(ref.sessionKey, messageId);
+  }
+
+  beginResponse(target: ConversationTarget): ResponseSession {
+    const ref = extractWebRef(target);
+    return new WebResponseSession(ref.sessionKey, this.broadcaster);
+  }
+
+  featuresFor(_target: ConversationTarget): FeatureSet {
+    // Web Dashboard supports everything — it's the superset platform.
+    return {
+      canEdit: true,
+      canThread: true,
+      canReact: true,
+      canModal: true,
+      canUploadFile: true,
+      canEphemeral: false, // Web doesn't have user-scoped visibility
+      maxMessageLength: 0, // Unlimited
+      maxFileSize: 0, // Server-dependent, not limited by platform
+    };
+  }
+
+  // ─── Editable ─────────────────────────────────────────────
+
+  async updateMessage(handle: MessageHandle, blocks: readonly ContentBlock[]): Promise<void> {
+    const ref = extractWebMessageRef(handle);
+
+    this.broadcaster.send(ref.sessionKey, {
+      type: 'message_update',
+      sessionKey: ref.sessionKey,
+      messageId: ref.messageId,
+      blocks,
+    });
+  }
+
+  async deleteMessage(handle: MessageHandle): Promise<void> {
+    const ref = extractWebMessageRef(handle);
+
+    this.broadcaster.send(ref.sessionKey, {
+      type: 'message_delete',
+      sessionKey: ref.sessionKey,
+      messageId: ref.messageId,
+    });
+  }
+
+  // ─── Threadable ───────────────────────────────────────────
+
+  async createThread(target: ConversationTarget, _rootBlocks: readonly ContentBlock[]): Promise<ConversationTarget> {
+    const ref = extractWebRef(target);
+    const threadId = `thread-${Date.now()}`;
+
+    this.broadcaster.send(ref.sessionKey, {
+      type: 'thread_created',
+      sessionKey: ref.sessionKey,
+      threadId,
+    });
+
+    return webTarget(ref.sessionKey, target.userId, threadId);
+  }
+
+  // ─── Reactable ────────────────────────────────────────────
+
+  async addReaction(handle: MessageHandle, emoji: string): Promise<void> {
+    const ref = extractWebMessageRef(handle);
+
+    this.broadcaster.send(ref.sessionKey, {
+      type: 'reaction_add',
+      sessionKey: ref.sessionKey,
+      messageId: ref.messageId,
+      emoji,
+    });
+  }
+
+  async removeReaction(handle: MessageHandle, emoji: string): Promise<void> {
+    const ref = extractWebMessageRef(handle);
+
+    this.broadcaster.send(ref.sessionKey, {
+      type: 'reaction_remove',
+      sessionKey: ref.sessionKey,
+      messageId: ref.messageId,
+      emoji,
+    });
+  }
+
+  // ─── HasModals ────────────────────────────────────────────
+
+  async openForm(target: ConversationTarget, form: FormSpec): Promise<string> {
+    const ref = extractWebRef(target);
+    const formId = `form-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    this.broadcaster.send(ref.sessionKey, {
+      type: 'form_open',
+      sessionKey: ref.sessionKey,
+      formId,
+      form,
+    });
+
+    return formId;
+  }
+
+  async updateForm(formId: string, form: FormSpec): Promise<void> {
+    // Extract sessionKey from formId pattern or broadcast to all
+    this.broadcaster.send('*', {
+      type: 'form_update',
+      formId,
+      form,
+    });
+  }
+
+  async closeForm(formId: string): Promise<void> {
+    this.broadcaster.send('*', {
+      type: 'form_close',
+      formId,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- **Phase 5** of MVC refactoring (closes #412)
- Full ViewSurface implementation for Web Dashboard: ViewSurfaceCore & Editable & Threadable & Reactable & HasModals
- Native WebSocket streaming via WebResponseSession — text deltas sent immediately (no edit-polling)
- 23 tests covering all capabilities and streaming lifecycle

## Test plan
- [x] tsc --noEmit — zero type errors
- [x] vitest run src/view/web/ — 23/23 passed
- [x] npm test — 2946/2946 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)