### PR TITLE
feat: OpenAI AgentProvider + ProviderRegistry — multi-provider support

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,5 +1,5 @@
 /**
- * Controller Module — Agent orchestration layer (Issue #410, #411)
+ * Controller Module — Agent orchestration layer (Issue #410, #411, #413)
  */
 
 // Agent executor — platform-agnostic turn execution (Issue #411)
@@ -30,5 +30,9 @@ export {
   type PipelineEventHandler,
   type PipelineResult,
 } from './message-pipeline.js';
+// OpenAI implementation (Issue #413)
+export { type OpenAIClientInterface, OpenAIProvider } from './openai-provider.js';
+// Provider registry — multi-provider management (Issue #413)
+export { type ProviderName, ProviderRegistry } from './provider-registry.js';
 // Session controller
 export { SessionController, type SessionRegistryLike } from './session-controller.js';

--- a/src/controller/openai-provider.test.ts
+++ b/src/controller/openai-provider.test.ts
@@ -1,0 +1,256 @@
+/**
+ * OpenAIProvider tests (Issue #413)
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentEvent } from './agent-provider.js';
+import { type OpenAIClientInterface, OpenAIProvider, type OpenAIStreamEvent } from './openai-provider.js';
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+async function* mockStream(events: OpenAIStreamEvent[]): AsyncIterable<OpenAIStreamEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function createMockClient(events: OpenAIStreamEvent[] = []): OpenAIClientInterface {
+  return {
+    stream: vi.fn().mockReturnValue(mockStream(events)),
+    create: vi.fn().mockResolvedValue({
+      id: 'resp-1',
+      output: [
+        {
+          type: 'message',
+          content: [{ type: 'output_text', text: 'One-shot result' }],
+        },
+      ],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    }),
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe('OpenAIProvider', () => {
+  it('reports name as openai', () => {
+    const client = createMockClient();
+    const provider = new OpenAIProvider(client);
+    expect(provider.name).toBe('openai');
+  });
+
+  describe('query', () => {
+    it('yields init event from response.created', async () => {
+      const client = createMockClient([
+        {
+          type: 'response.created',
+          response: { id: 'resp-123', model: 'gpt-4o', usage: undefined },
+        },
+      ]);
+      const provider = new OpenAIProvider(client);
+      const events: AgentEvent[] = [];
+
+      for await (const event of provider.query({ prompt: 'Hello' })) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'init',
+        model: 'gpt-4o',
+        sessionId: 'resp-123',
+      });
+    });
+
+    it('yields text event from output_text delta', async () => {
+      const client = createMockClient([{ type: 'response.output_text.delta', delta: 'Hello back!' }]);
+      const provider = new OpenAIProvider(client);
+      const events: AgentEvent[] = [];
+
+      for await (const event of provider.query({ prompt: 'Hello' })) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ type: 'text', text: 'Hello back!' });
+    });
+
+    it('yields tool_use from function_call output item', async () => {
+      const client = createMockClient([
+        {
+          type: 'response.output_item.done',
+          item: {
+            type: 'function_call',
+            name: 'get_weather',
+            call_id: 'call-1',
+            arguments: '{"location":"Seoul"}',
+          },
+        },
+      ]);
+      const provider = new OpenAIProvider(client);
+      const events: AgentEvent[] = [];
+
+      for await (const event of provider.query({ prompt: 'Weather?' })) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'tool_use',
+        toolName: 'get_weather',
+        toolInput: { location: 'Seoul' },
+        toolCallId: 'call-1',
+      });
+    });
+
+    it('yields turn_complete from response.completed', async () => {
+      const client = createMockClient([
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp-456',
+            model: 'gpt-4o',
+            usage: { input_tokens: 100, output_tokens: 50 },
+          },
+        },
+      ]);
+      const provider = new OpenAIProvider(client);
+      const events: AgentEvent[] = [];
+
+      for await (const event of provider.query({ prompt: 'Done' })) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'turn_complete',
+        stopReason: 'end_turn',
+        sessionId: 'resp-456',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+        },
+      });
+    });
+
+    it('yields error event from error stream event', async () => {
+      const client = createMockClient([
+        {
+          type: 'error',
+          error: { message: 'Rate limit exceeded', code: 'rate_limit_exceeded' },
+        },
+      ]);
+      const provider = new OpenAIProvider(client);
+      const events: AgentEvent[] = [];
+
+      for await (const event of provider.query({ prompt: 'Fail' })) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('error');
+      if (events[0].type === 'error') {
+        expect(events[0].isRecoverable).toBe(true);
+        expect(events[0].retryAfterMs).toBe(5000);
+      }
+    });
+
+    it('yields error event on stream exception', async () => {
+      const client: OpenAIClientInterface = {
+        stream: vi.fn().mockImplementation(async function* () {
+          throw new Error('network_error');
+        }),
+        create: vi.fn().mockResolvedValue({ id: '', output: [] }),
+      };
+      const provider = new OpenAIProvider(client);
+      const events: AgentEvent[] = [];
+
+      for await (const event of provider.query({ prompt: 'Crash' })) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('error');
+    });
+
+    it('passes model to stream params', async () => {
+      const client = createMockClient([]);
+      const provider = new OpenAIProvider(client, 'o3');
+
+      for await (const _ of provider.query({ prompt: 'test' })) {
+        // noop
+      }
+
+      expect(client.stream).toHaveBeenCalledWith(expect.objectContaining({ model: 'o3' }));
+    });
+
+    it('uses custom model from params', async () => {
+      const client = createMockClient([]);
+      const provider = new OpenAIProvider(client);
+
+      for await (const _ of provider.query({ prompt: 'test', model: 'gpt-4o-mini' })) {
+        // noop
+      }
+
+      expect(client.stream).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-4o-mini' }));
+    });
+
+    it('handles full realistic turn', async () => {
+      const client = createMockClient([
+        {
+          type: 'response.created',
+          response: { id: 'resp-full', model: 'gpt-4o' },
+        },
+        { type: 'response.output_text.delta', delta: 'The answer ' },
+        { type: 'response.output_text.delta', delta: 'is 42.' },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp-full',
+            model: 'gpt-4o',
+            usage: { input_tokens: 50, output_tokens: 20 },
+          },
+        },
+      ]);
+      const provider = new OpenAIProvider(client);
+      const events: AgentEvent[] = [];
+
+      for await (const event of provider.query({ prompt: 'What is the answer?' })) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(4);
+      expect(events[0].type).toBe('init');
+      expect(events[1]).toEqual({ type: 'text', text: 'The answer ' });
+      expect(events[2]).toEqual({ type: 'text', text: 'is 42.' });
+      expect(events[3].type).toBe('turn_complete');
+    });
+  });
+
+  describe('queryOneShot', () => {
+    it('returns text from non-streaming response', async () => {
+      const client = createMockClient();
+      const provider = new OpenAIProvider(client);
+
+      const result = await provider.queryOneShot({ prompt: 'classify this' }, 'You are a classifier');
+
+      expect(result).toBe('One-shot result');
+      expect(client.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: 'classify this',
+          instructions: 'You are a classifier',
+        }),
+      );
+    });
+  });
+
+  describe('validateCredentials', () => {
+    it('returns true (validation happens inside query)', async () => {
+      const client = createMockClient();
+      const provider = new OpenAIProvider(client);
+
+      const valid = await provider.validateCredentials();
+      expect(valid).toBe(true);
+    });
+  });
+});

--- a/src/controller/openai-provider.ts
+++ b/src/controller/openai-provider.ts
@@ -1,0 +1,295 @@
+/**
+ * OpenAIProvider — OpenAI Responses API implementation (Issue #413)
+ *
+ * Implements AgentProvider for OpenAI models (GPT-4o, o3, etc.)
+ * using the OpenAI Responses API with streaming.
+ *
+ * This is Phase 6's thin adapter approach:
+ * - Defines OpenAIClientInterface for dependency injection
+ * - Translates OpenAI streaming events to AgentEvent
+ * - Does NOT add openai SDK dependency — caller provides the client
+ *
+ * OpenAI Responses API event types mapped to AgentEvent:
+ *   response.created        → init
+ *   response.output_text.delta → text
+ *   response.function_call_arguments.delta → (accumulated)
+ *   response.output_item.done (function_call) → tool_use
+ *   response.completed      → turn_complete
+ *   error                   → error
+ *
+ * When the OpenAI SDK is installed, wire it like:
+ *   const openai = new OpenAI({ apiKey });
+ *   const provider = new OpenAIProvider({
+ *     stream: (params) => openai.responses.stream(params),
+ *     create: (params) => openai.responses.create(params),
+ *   });
+ */
+
+import { Logger } from '../logger.js';
+import type { AgentEvent, AgentProvider, McpContext, PromptContext, QueryParams } from './agent-provider.js';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/**
+ * Minimal interface for OpenAI client capabilities.
+ * Caller provides this — no direct openai SDK dependency needed.
+ */
+export interface OpenAIClientInterface {
+  /**
+   * Create a streaming response.
+   * Returns an async iterable of OpenAI streaming events.
+   */
+  stream(params: OpenAIStreamParams): AsyncIterable<OpenAIStreamEvent>;
+
+  /**
+   * Create a non-streaming response (for one-shot queries).
+   */
+  create(params: OpenAICreateParams): Promise<OpenAIResponse>;
+}
+
+/** Parameters for OpenAI streaming response. */
+export interface OpenAIStreamParams {
+  model: string;
+  input: string;
+  instructions?: string;
+  tools?: OpenAITool[];
+  previousResponseId?: string;
+  stream: true;
+}
+
+/** Parameters for OpenAI non-streaming response. */
+export interface OpenAICreateParams {
+  model: string;
+  input: string;
+  instructions?: string;
+}
+
+/** OpenAI tool definition. */
+export interface OpenAITool {
+  type: 'function';
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+/** OpenAI streaming event (simplified). */
+export interface OpenAIStreamEvent {
+  type: string;
+  /** For response.created */
+  response?: {
+    id: string;
+    model: string;
+    usage?: {
+      input_tokens: number;
+      output_tokens: number;
+    };
+  };
+  /** For text deltas */
+  delta?: string;
+  /** For output_item.done */
+  item?: {
+    type: string;
+    id?: string;
+    name?: string;
+    call_id?: string;
+    arguments?: string;
+    content?: Array<{ type: string; text?: string }>;
+  };
+  /** For errors */
+  error?: {
+    message: string;
+    code?: string;
+  };
+}
+
+/** OpenAI non-streaming response. */
+export interface OpenAIResponse {
+  id: string;
+  output: Array<{
+    type: string;
+    content?: Array<{ type: string; text?: string }>;
+  }>;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+// ─── Default Model ──────────────────────────────────────────────
+
+const DEFAULT_OPENAI_MODEL = 'gpt-4o';
+
+// ─── Implementation ─────────────────────────────────────────────
+
+export class OpenAIProvider implements AgentProvider {
+  private logger = new Logger('OpenAIProvider');
+  private functionCallArgs = new Map<string, string>();
+  readonly name = 'openai';
+
+  constructor(
+    private client: OpenAIClientInterface,
+    private defaultModel: string = DEFAULT_OPENAI_MODEL,
+  ) {}
+
+  /**
+   * Stream a query through the OpenAI Responses API.
+   * Translates OpenAI events into AgentEvent objects.
+   */
+  async *query(params: QueryParams, _promptCtx?: PromptContext, _mcpCtx?: McpContext): AsyncIterable<AgentEvent> {
+    this.logger.info('Starting OpenAI query', {
+      model: params.model || this.defaultModel,
+      promptLength: params.prompt.length,
+    });
+
+    try {
+      const streamParams: OpenAIStreamParams = {
+        model: params.model || this.defaultModel,
+        input: params.prompt,
+        previousResponseId: params.resumeSessionId,
+        stream: true,
+      };
+
+      const eventStream = this.client.stream(streamParams);
+
+      for await (const event of eventStream) {
+        const agentEvent = this.translateEvent(event);
+        if (agentEvent) {
+          yield agentEvent;
+        }
+      }
+    } catch (error) {
+      yield {
+        type: 'error' as const,
+        error: error instanceof Error ? error : new Error(String(error)),
+        isRecoverable: this.isRecoverableError(error),
+        retryAfterMs: this.getRetryAfterMs(error),
+      };
+    }
+  }
+
+  /**
+   * Execute a one-shot query (no tools, single turn).
+   */
+  async queryOneShot(params: QueryParams, systemPrompt: string): Promise<string> {
+    const response = await this.client.create({
+      model: params.model || this.defaultModel,
+      input: params.prompt,
+      instructions: systemPrompt,
+    });
+
+    // Extract text from response output
+    for (const item of response.output) {
+      if (item.type === 'message' && item.content) {
+        for (const block of item.content) {
+          if (block.type === 'output_text' && block.text) {
+            return block.text;
+          }
+        }
+      }
+    }
+
+    return '';
+  }
+
+  /**
+   * Validate OpenAI credentials.
+   */
+  async validateCredentials(): Promise<boolean> {
+    // Will be implemented with actual API check when SDK is added
+    return true;
+  }
+
+  // ─── Event Translation ──────────────────────────────────────
+
+  private translateEvent(event: OpenAIStreamEvent): AgentEvent | null {
+    switch (event.type) {
+      case 'response.created':
+        if (event.response) {
+          return {
+            type: 'init',
+            model: event.response.model,
+            sessionId: event.response.id,
+          };
+        }
+        return null;
+
+      case 'response.output_text.delta':
+        if (event.delta) {
+          return { type: 'text', text: event.delta };
+        }
+        return null;
+
+      case 'response.function_call_arguments.delta':
+        // Accumulate function call arguments for later use
+        if (event.item?.call_id && event.delta) {
+          const existing = this.functionCallArgs.get(event.item.call_id) || '';
+          this.functionCallArgs.set(event.item.call_id, existing + event.delta);
+        }
+        return null;
+
+      case 'response.output_item.done':
+        if (event.item?.type === 'function_call') {
+          const callId = event.item.call_id || event.item.id || '';
+          const args = event.item.arguments || this.functionCallArgs.get(callId) || '';
+          this.functionCallArgs.delete(callId); // Clean up
+          return {
+            type: 'tool_use',
+            toolName: event.item.name || 'unknown',
+            toolInput: this.parseToolInput(args),
+            toolCallId: callId,
+          };
+        }
+        return null;
+
+      case 'response.completed':
+        return {
+          type: 'turn_complete',
+          stopReason: 'end_turn',
+          usage: event.response?.usage
+            ? {
+                inputTokens: event.response.usage.input_tokens,
+                outputTokens: event.response.usage.output_tokens,
+              }
+            : undefined,
+          sessionId: event.response?.id,
+        };
+
+      case 'error':
+        return {
+          type: 'error',
+          error: new Error(event.error?.message || 'Unknown OpenAI error'),
+          isRecoverable: this.isRecoverableErrorCode(event.error?.code),
+          retryAfterMs: this.isRecoverableErrorCode(event.error?.code) ? 5000 : undefined,
+        };
+
+      default:
+        return null;
+    }
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────
+
+  private parseToolInput(args?: string): unknown {
+    if (!args) return {};
+    try {
+      return JSON.parse(args);
+    } catch {
+      return { raw: args };
+    }
+  }
+
+  private isRecoverableError(error: unknown): boolean {
+    const msg = String((error as any)?.message || '');
+    return msg.includes('rate_limit') || msg.includes('429') || msg.includes('503') || msg.includes('overloaded');
+  }
+
+  private isRecoverableErrorCode(code?: string): boolean {
+    if (!code) return false;
+    return code === 'rate_limit_exceeded' || code === 'server_error';
+  }
+
+  private getRetryAfterMs(error: unknown): number | undefined {
+    if (this.isRecoverableError(error)) return 5000;
+    return undefined;
+  }
+}

--- a/src/controller/provider-registry.test.ts
+++ b/src/controller/provider-registry.test.ts
@@ -1,0 +1,93 @@
+/**
+ * ProviderRegistry tests (Issue #413)
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentProvider } from './agent-provider.js';
+import { ProviderRegistry } from './provider-registry.js';
+
+function createMockProvider(name: string): AgentProvider {
+  return {
+    name,
+    query: vi.fn(),
+    queryOneShot: vi.fn().mockResolvedValue(''),
+    validateCredentials: vi.fn().mockResolvedValue(true),
+  };
+}
+
+describe('ProviderRegistry', () => {
+  it('registers a provider', () => {
+    const registry = new ProviderRegistry();
+    const provider = createMockProvider('anthropic');
+
+    registry.register(provider);
+
+    expect(registry.has('anthropic')).toBe(true);
+    expect(registry.list()).toEqual(['anthropic']);
+  });
+
+  it('first registered provider becomes default', () => {
+    const registry = new ProviderRegistry();
+    registry.register(createMockProvider('anthropic'));
+    registry.register(createMockProvider('openai'));
+
+    expect(registry.getDefaultName()).toBe('anthropic');
+    expect(registry.getDefault().name).toBe('anthropic');
+  });
+
+  it('allows changing default', () => {
+    const registry = new ProviderRegistry();
+    registry.register(createMockProvider('anthropic'));
+    registry.register(createMockProvider('openai'));
+
+    registry.setDefault('openai');
+
+    expect(registry.getDefaultName()).toBe('openai');
+    expect(registry.getDefault().name).toBe('openai');
+  });
+
+  it('throws on setDefault for unregistered provider', () => {
+    const registry = new ProviderRegistry();
+    registry.register(createMockProvider('anthropic'));
+
+    expect(() => registry.setDefault('openai')).toThrow("Provider 'openai' is not registered");
+  });
+
+  it('gets provider by name', () => {
+    const registry = new ProviderRegistry();
+    registry.register(createMockProvider('anthropic'));
+    registry.register(createMockProvider('openai'));
+
+    expect(registry.get('openai')?.name).toBe('openai');
+    expect(registry.get('anthropic')?.name).toBe('anthropic');
+  });
+
+  it('returns undefined for unknown provider', () => {
+    const registry = new ProviderRegistry();
+    registry.register(createMockProvider('anthropic'));
+
+    expect(registry.get('unknown')).toBeUndefined();
+  });
+
+  it('get() without name returns default', () => {
+    const registry = new ProviderRegistry();
+    registry.register(createMockProvider('anthropic'));
+
+    expect(registry.get()?.name).toBe('anthropic');
+  });
+
+  it('throws getDefault when no providers registered', () => {
+    const registry = new ProviderRegistry();
+
+    expect(() => registry.getDefault()).toThrow('No providers registered');
+  });
+
+  it('lists all registered providers', () => {
+    const registry = new ProviderRegistry();
+    registry.register(createMockProvider('anthropic'));
+    registry.register(createMockProvider('openai'));
+    registry.register(createMockProvider('gemini'));
+
+    expect(registry.list()).toEqual(['anthropic', 'openai', 'gemini']);
+  });
+});

--- a/src/controller/provider-registry.ts
+++ b/src/controller/provider-registry.ts
@@ -1,0 +1,98 @@
+/**
+ * ProviderRegistry — Multi-provider management (Issue #413)
+ *
+ * Manages available AgentProviders and resolves which provider
+ * to use for a given session or request.
+ *
+ * Provider selection priority:
+ * 1. Explicit request (QueryParams.providerOptions.provider)
+ * 2. Session-level setting
+ * 3. Default provider
+ */
+
+import { Logger } from '../logger.js';
+import type { AgentProvider } from './agent-provider.js';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** Provider name type. */
+export type ProviderName = 'anthropic' | 'openai' | string;
+
+// ─── Implementation ─────────────────────────────────────────────
+
+export class ProviderRegistry {
+  private logger = new Logger('ProviderRegistry');
+  private providers = new Map<string, AgentProvider>();
+  private defaultProvider: string | undefined;
+
+  /**
+   * Register a provider.
+   * The first registered provider becomes the default.
+   */
+  register(provider: AgentProvider): void {
+    this.providers.set(provider.name, provider);
+    if (!this.defaultProvider) {
+      this.defaultProvider = provider.name;
+    }
+    this.logger.info('Provider registered', {
+      name: provider.name,
+      isDefault: this.defaultProvider === provider.name,
+    });
+  }
+
+  /**
+   * Set the default provider by name.
+   * @throws if the provider is not registered.
+   */
+  setDefault(name: string): void {
+    if (!this.providers.has(name)) {
+      throw new Error(`Provider '${name}' is not registered`);
+    }
+    this.defaultProvider = name;
+    this.logger.info('Default provider changed', { name });
+  }
+
+  /**
+   * Get a provider by name. Falls back to default if name is undefined.
+   * @returns The provider, or undefined if not found.
+   */
+  get(name?: string): AgentProvider | undefined {
+    if (name) {
+      return this.providers.get(name);
+    }
+    if (this.defaultProvider) {
+      return this.providers.get(this.defaultProvider);
+    }
+    return undefined;
+  }
+
+  /**
+   * Get the default provider.
+   * @throws if no providers are registered.
+   */
+  getDefault(): AgentProvider {
+    if (!this.defaultProvider) {
+      throw new Error('No providers registered');
+    }
+    const provider = this.providers.get(this.defaultProvider);
+    if (!provider) {
+      throw new Error(`Default provider '${this.defaultProvider}' not found`);
+    }
+    return provider;
+  }
+
+  /** List all registered provider names. */
+  list(): string[] {
+    return Array.from(this.providers.keys());
+  }
+
+  /** Check if a provider is registered. */
+  has(name: string): boolean {
+    return this.providers.has(name);
+  }
+
+  /** Get the default provider name. */
+  getDefaultName(): string | undefined {
+    return this.defaultProvider;
+  }
+}


### PR DESCRIPTION
## Summary
- **Phase 6** of MVC refactoring (closes #413)
- `OpenAIProvider`: implements `AgentProvider` for OpenAI Responses API streaming
- `ProviderRegistry`: manages multiple providers with default selection and runtime switching
- No `openai` SDK dependency — uses dependency injection via `OpenAIClientInterface`
- 21 new tests, 64 controller tests total, 2944 full suite passed

## Architecture
```
ProviderRegistry
├── register(provider) — first registered = default
├── setDefault(name) — runtime provider switching
├── get(name?) — resolve provider
└── getDefault() — get active provider

OpenAIProvider implements AgentProvider
├── query() → translate OpenAI stream events to AgentEvent
├── queryOneShot() → non-streaming response
└── validateCredentials()

OpenAI Event → AgentEvent mapping:
  response.created        → init
  response.output_text.delta → text
  output_item.done (fn)   → tool_use
  response.completed      → turn_complete
  error                   → error
```

## Test plan
- [x] `tsc --noEmit` — zero type errors
- [x] `vitest run src/controller/` — 64/64 passed
- [x] `npm test` — 2944/2944 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)