### PR TITLE
feat: Telegram/Discord/TUI platform view adapter stubs (#414)

### DIFF
--- a/src/view/discord/discord-view-adapter.test.ts
+++ b/src/view/discord/discord-view-adapter.test.ts
@@ -1,0 +1,262 @@
+/**
+ * DiscordViewAdapter tests (Issue #414)
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ContentBlock } from '../types.js';
+import {
+  type DiscordClientApi,
+  type DiscordMessageRef,
+  DiscordViewAdapter,
+  discordMessageHandle,
+  discordTarget,
+  extractDiscordRef,
+} from './discord-view-adapter.js';
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function createMockClient(): DiscordClientApi {
+  return {
+    sendMessage: vi.fn().mockResolvedValue({ id: 'msg-42' }),
+    editMessage: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+    createThread: vi.fn().mockResolvedValue({ id: 'thread-99' }),
+    addReaction: vi.fn().mockResolvedValue(undefined),
+    removeReaction: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue('modal-1'),
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe('DiscordViewAdapter', () => {
+  it('reports platform as discord', () => {
+    const adapter = new DiscordViewAdapter();
+    expect(adapter.platform).toBe('discord');
+  });
+
+  describe('ref helpers', () => {
+    it('creates and extracts conversation ref', () => {
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+      const ref = extractDiscordRef(target);
+
+      expect(ref.guildId).toBe('guild-1');
+      expect(ref.channelId).toBe('ch-1');
+      expect(ref.threadId).toBeUndefined();
+      expect(target.userId).toBe('U001');
+    });
+
+    it('creates ref with threadId', () => {
+      const target = discordTarget('guild-1', 'ch-1', 'U001', 'thread-1');
+      const ref = extractDiscordRef(target);
+
+      expect(ref.threadId).toBe('thread-1');
+    });
+
+    it('creates message handle', () => {
+      const handle = discordMessageHandle('ch-1', 'msg-1');
+
+      expect(handle.platform).toBe('discord');
+      expect((handle.ref as DiscordMessageRef).channelId).toBe('ch-1');
+      expect((handle.ref as DiscordMessageRef).messageId).toBe('msg-1');
+    });
+  });
+
+  describe('featuresFor', () => {
+    it('returns full capabilities', () => {
+      const adapter = new DiscordViewAdapter();
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+      const features = adapter.featuresFor(target);
+
+      expect(features.canEdit).toBe(true);
+      expect(features.canThread).toBe(true);
+      expect(features.canReact).toBe(true);
+      expect(features.canModal).toBe(true);
+      expect(features.canUploadFile).toBe(true);
+      expect(features.canEphemeral).toBe(true);
+      expect(features.maxMessageLength).toBe(2000);
+      expect(features.maxFileSize).toBe(25 * 1024 * 1024);
+    });
+  });
+
+  describe('postMessage', () => {
+    it('sends message via client API', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Hello Discord!' }];
+
+      const handle = await adapter.postMessage(target, blocks);
+
+      expect(client.sendMessage).toHaveBeenCalledWith('ch-1', 'Hello Discord!');
+      expect(handle.platform).toBe('discord');
+      expect((handle.ref as DiscordMessageRef).messageId).toBe('msg-42');
+    });
+
+    it('sends to thread channel when threadId is set', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const target = discordTarget('guild-1', 'ch-1', 'U001', 'thread-5');
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'In thread' }];
+
+      await adapter.postMessage(target, blocks);
+
+      expect(client.sendMessage).toHaveBeenCalledWith('thread-5', 'In thread');
+    });
+
+    it('returns stub handle without client', async () => {
+      const adapter = new DiscordViewAdapter();
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Hello' }];
+
+      const handle = await adapter.postMessage(target, blocks);
+
+      expect(handle.platform).toBe('discord');
+      expect((handle.ref as DiscordMessageRef).messageId).toBe('0');
+    });
+  });
+
+  describe('beginResponse', () => {
+    it('collects text and posts on complete', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+
+      const session = adapter.beginResponse(target);
+      session.appendText('Hello ');
+      session.appendText('Discord');
+      const handle = await session.complete();
+
+      expect(client.sendMessage).toHaveBeenCalledWith('ch-1', 'Hello Discord');
+      expect(handle.platform).toBe('discord');
+    });
+
+    it('does not append text after abort', () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+
+      const session = adapter.beginResponse(target);
+      session.appendText('Hello');
+      session.abort('cancelled');
+      session.appendText(' world');
+
+      expect(client.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Editable', () => {
+    it('edits message via client API', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const handle = discordMessageHandle('ch-1', 'msg-42');
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Updated' }];
+
+      await adapter.updateMessage(handle, blocks);
+
+      expect(client.editMessage).toHaveBeenCalledWith('ch-1', 'msg-42', 'Updated');
+    });
+
+    it('deletes message via client API', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const handle = discordMessageHandle('ch-1', 'msg-42');
+
+      await adapter.deleteMessage(handle);
+
+      expect(client.deleteMessage).toHaveBeenCalledWith('ch-1', 'msg-42');
+    });
+  });
+
+  describe('Threadable', () => {
+    it('creates thread via client API', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+
+      const threadTarget = await adapter.createThread(target, [{ type: 'text', text: 'Start thread' }]);
+
+      expect(client.createThread).toHaveBeenCalledWith('ch-1', 'Start thread');
+      const ref = extractDiscordRef(threadTarget);
+      expect(ref.threadId).toBe('thread-99');
+      expect(ref.guildId).toBe('guild-1');
+      expect(threadTarget.userId).toBe('U001');
+    });
+
+    it('returns stub thread without client', async () => {
+      const adapter = new DiscordViewAdapter();
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+
+      const threadTarget = await adapter.createThread(target, []);
+      const ref = extractDiscordRef(threadTarget);
+
+      expect(ref.threadId).toMatch(/^thread-/);
+    });
+  });
+
+  describe('Reactable', () => {
+    it('adds reaction via client API', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const handle = discordMessageHandle('ch-1', 'msg-42');
+
+      await adapter.addReaction(handle, '👍');
+
+      expect(client.addReaction).toHaveBeenCalledWith('ch-1', 'msg-42', '👍');
+    });
+
+    it('removes reaction via client API', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const handle = discordMessageHandle('ch-1', 'msg-42');
+
+      await adapter.removeReaction(handle, '👍');
+
+      expect(client.removeReaction).toHaveBeenCalledWith('ch-1', 'msg-42', '👍');
+    });
+
+    it('is safe to call without client', async () => {
+      const adapter = new DiscordViewAdapter();
+      const handle = discordMessageHandle('ch-1', 'msg-42');
+
+      await adapter.addReaction(handle, '🎉');
+      await adapter.removeReaction(handle, '🎉');
+    });
+  });
+
+  describe('HasModals', () => {
+    it('opens form and returns formId', async () => {
+      const client = createMockClient();
+      const adapter = new DiscordViewAdapter(client);
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+
+      const formId = await adapter.openForm(target, {
+        title: 'Settings',
+        fields: [{ id: 'name', fieldType: 'text', label: 'Name' }],
+      });
+
+      expect(formId).toMatch(/^discord-form-/);
+      expect(client.showModal).toHaveBeenCalled();
+    });
+
+    it('returns formId without client', async () => {
+      const adapter = new DiscordViewAdapter();
+      const target = discordTarget('guild-1', 'ch-1', 'U001');
+
+      const formId = await adapter.openForm(target, {
+        title: 'Test',
+        fields: [],
+      });
+
+      expect(formId).toMatch(/^discord-form-/);
+    });
+
+    it('updateForm and closeForm are safe no-ops', async () => {
+      const adapter = new DiscordViewAdapter();
+
+      // Should not throw
+      await adapter.updateForm('form-1', { title: 'T', fields: [] });
+      await adapter.closeForm('form-1');
+    });
+  });
+});

--- a/src/view/discord/discord-view-adapter.ts
+++ b/src/view/discord/discord-view-adapter.ts
@@ -1,0 +1,242 @@
+/**
+ * DiscordViewAdapter — Discord Bot view surface stub (Issue #414)
+ *
+ * Implements full ViewSurface hierarchy: ViewSurfaceCore & Editable & Threadable & Reactable & HasModals.
+ * Discord supports all capabilities: message editing, threads, reactions, and modals.
+ *
+ * Streaming approach: edit-polling (throttled editMessage calls).
+ *
+ * Implementation wraps the Discord.js Client API via DiscordClientApi
+ * interface for dependency injection. No discord.js dependency required
+ * until the adapter is wired to the real bot.
+ */
+
+import type { ResponseSession } from '../response-session.js';
+import type { Editable, HasModals, Reactable, Threadable, ViewSurfaceCore } from '../surface.js';
+import type { ContentBlock, ConversationTarget, FeatureSet, FormSpec, MessageHandle, Platform } from '../types.js';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** Discord conversation reference. */
+export interface DiscordConversationRef {
+  readonly guildId: string;
+  readonly channelId: string;
+  readonly threadId?: string;
+}
+
+/** Discord message reference. */
+export interface DiscordMessageRef {
+  readonly channelId: string;
+  readonly messageId: string;
+}
+
+/** Minimal Discord client interface for dependency injection. */
+export interface DiscordClientApi {
+  sendMessage(channelId: string, content: string): Promise<{ id: string }>;
+  editMessage(channelId: string, messageId: string, content: string): Promise<void>;
+  deleteMessage(channelId: string, messageId: string): Promise<void>;
+  createThread(channelId: string, name: string, messageId?: string): Promise<{ id: string }>;
+  addReaction(channelId: string, messageId: string, emoji: string): Promise<void>;
+  removeReaction(channelId: string, messageId: string, emoji: string): Promise<void>;
+  showModal(interactionId: string, modal: Record<string, unknown>): Promise<string>;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Extract typed DiscordConversationRef from a ConversationTarget. */
+export function extractDiscordRef(target: ConversationTarget): DiscordConversationRef {
+  if (target.platform !== 'discord') {
+    throw new Error(`Expected discord platform target, got ${target.platform}`);
+  }
+  return target.ref as DiscordConversationRef;
+}
+
+/** Create a Discord ConversationTarget. */
+export function discordTarget(
+  guildId: string,
+  channelId: string,
+  userId: string,
+  threadId?: string,
+): ConversationTarget {
+  const ref: DiscordConversationRef = threadId ? { guildId, channelId, threadId } : { guildId, channelId };
+  return { platform: 'discord', ref, userId };
+}
+
+/** Create a Discord MessageHandle. */
+export function discordMessageHandle(channelId: string, messageId: string): MessageHandle {
+  const ref: DiscordMessageRef = { channelId, messageId };
+  return { platform: 'discord', ref };
+}
+
+/** Extract typed DiscordMessageRef from a MessageHandle. */
+export function extractDiscordMessageRef(handle: MessageHandle): DiscordMessageRef {
+  if (handle.platform !== 'discord') {
+    throw new Error(`Expected discord platform handle, got ${handle.platform}`);
+  }
+  return handle.ref as DiscordMessageRef;
+}
+
+// ─── Implementation ─────────────────────────────────────────────
+
+export class DiscordViewAdapter implements ViewSurfaceCore, Editable, Threadable, Reactable, HasModals {
+  readonly platform: Platform = 'discord';
+
+  constructor(private client?: DiscordClientApi) {}
+
+  // ─── ViewSurfaceCore ──────────────────────────────────────
+
+  async postMessage(target: ConversationTarget, blocks: readonly ContentBlock[]): Promise<MessageHandle> {
+    const ref = extractDiscordRef(target);
+    const text = this.blocksToText(blocks);
+    const targetChannel = ref.threadId ?? ref.channelId;
+
+    if (this.client) {
+      const result = await this.client.sendMessage(targetChannel, text);
+      return discordMessageHandle(targetChannel, result.id);
+    }
+
+    // Stub: return placeholder handle
+    return discordMessageHandle(targetChannel, '0');
+  }
+
+  beginResponse(target: ConversationTarget): ResponseSession {
+    const ref = extractDiscordRef(target);
+    const targetChannel = ref.threadId ?? ref.channelId;
+    const adapter = this;
+    let text = '';
+    let completed = false;
+
+    return {
+      appendText(delta: string) {
+        if (!completed) text += delta;
+      },
+      setStatus(_phase: string) {
+        // Discord uses "typing" indicator
+      },
+      replacePart(_partId: string, _content: ContentBlock) {
+        // Not supported in simple stub mode
+      },
+      attachFile(_file) {
+        // Will use message attachments in full implementation
+      },
+      async complete() {
+        if (completed) {
+          return discordMessageHandle(targetChannel, '0');
+        }
+        completed = true;
+        const handle = await adapter.postMessage(target, [{ type: 'text', text }]);
+        return handle;
+      },
+      abort(_reason?: string) {
+        completed = true;
+      },
+    };
+  }
+
+  featuresFor(_target: ConversationTarget): FeatureSet {
+    return {
+      canEdit: true,
+      canThread: true,
+      canReact: true,
+      canModal: true,
+      canUploadFile: true,
+      canEphemeral: true,
+      maxMessageLength: 2000,
+      maxFileSize: 25 * 1024 * 1024, // 25MB (Nitro: 100MB, but base is 25MB)
+    };
+  }
+
+  // ─── Editable ─────────────────────────────────────────────
+
+  async updateMessage(handle: MessageHandle, blocks: readonly ContentBlock[]): Promise<void> {
+    const ref = extractDiscordMessageRef(handle);
+    const text = this.blocksToText(blocks);
+
+    if (this.client) {
+      await this.client.editMessage(ref.channelId, ref.messageId, text);
+    }
+  }
+
+  async deleteMessage(handle: MessageHandle): Promise<void> {
+    const ref = extractDiscordMessageRef(handle);
+    if (this.client) {
+      await this.client.deleteMessage(ref.channelId, ref.messageId);
+    }
+  }
+
+  // ─── Threadable ───────────────────────────────────────────
+
+  async createThread(target: ConversationTarget, rootBlocks: readonly ContentBlock[]): Promise<ConversationTarget> {
+    const ref = extractDiscordRef(target);
+    const threadName = this.blocksToText(rootBlocks).slice(0, 100) || 'Thread';
+
+    if (this.client) {
+      const result = await this.client.createThread(ref.channelId, threadName);
+      return discordTarget(ref.guildId, ref.channelId, target.userId, result.id);
+    }
+
+    // Stub: return target with a placeholder threadId
+    return discordTarget(ref.guildId, ref.channelId, target.userId, `thread-${Date.now()}`);
+  }
+
+  // ─── Reactable ────────────────────────────────────────────
+
+  async addReaction(handle: MessageHandle, emoji: string): Promise<void> {
+    const ref = extractDiscordMessageRef(handle);
+    if (this.client) {
+      await this.client.addReaction(ref.channelId, ref.messageId, emoji);
+    }
+  }
+
+  async removeReaction(handle: MessageHandle, emoji: string): Promise<void> {
+    const ref = extractDiscordMessageRef(handle);
+    if (this.client) {
+      await this.client.removeReaction(ref.channelId, ref.messageId, emoji);
+    }
+  }
+
+  // ─── HasModals ────────────────────────────────────────────
+
+  async openForm(_target: ConversationTarget, form: FormSpec): Promise<string> {
+    const formId = `discord-form-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    if (this.client) {
+      // Discord modals require an interaction ID; stub uses placeholder
+      await this.client.showModal('stub-interaction', {
+        custom_id: formId,
+        title: form.title,
+        components: form.fields.map((f) => ({
+          type: 4, // TextInput
+          custom_id: f.id,
+          label: f.label,
+          style: f.fieldType === 'textarea' ? 2 : 1,
+        })),
+      });
+    }
+
+    return formId;
+  }
+
+  async updateForm(_formId: string, _form: FormSpec): Promise<void> {
+    // Discord doesn't support updating modals after opening.
+    // This is a no-op but the interface requires it.
+  }
+
+  async closeForm(_formId: string): Promise<void> {
+    // Discord modals are closed by the user or interaction response.
+    // No-op in this adapter.
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────
+
+  private blocksToText(blocks: readonly ContentBlock[]): string {
+    return blocks
+      .map((b) => {
+        if (b.type === 'text') return b.text;
+        if (b.type === 'status') return `*${b.phase}*`;
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+}

--- a/src/view/discord/index.ts
+++ b/src/view/discord/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Discord View Module — Discord Bot view adapter (Issue #414)
+ */
+
+export {
+  type DiscordClientApi,
+  type DiscordConversationRef,
+  type DiscordMessageRef,
+  DiscordViewAdapter,
+  discordMessageHandle,
+  discordTarget,
+  extractDiscordRef,
+} from './discord-view-adapter.js';

--- a/src/view/telegram/index.ts
+++ b/src/view/telegram/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Telegram View Module — Telegram Bot view adapter (Issue #414)
+ */
+
+export {
+  type TelegramBotApi,
+  type TelegramConversationRef,
+  type TelegramMessageRef,
+  TelegramViewAdapter,
+} from './telegram-view-adapter.js';

--- a/src/view/telegram/telegram-view-adapter.test.ts
+++ b/src/view/telegram/telegram-view-adapter.test.ts
@@ -1,0 +1,156 @@
+/**
+ * TelegramViewAdapter tests (Issue #414)
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ContentBlock, ConversationTarget, MessageHandle } from '../types.js';
+import {
+  type TelegramBotApi,
+  type TelegramConversationRef,
+  type TelegramMessageRef,
+  TelegramViewAdapter,
+} from './telegram-view-adapter.js';
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function telegramTarget(chatId: string | number, userId = 'U001'): ConversationTarget {
+  const ref: TelegramConversationRef = { chatId };
+  return { platform: 'telegram', ref, userId };
+}
+
+function telegramHandle(chatId: string | number, messageId: number): MessageHandle {
+  const ref: TelegramMessageRef = { chatId, messageId };
+  return { platform: 'telegram', ref };
+}
+
+function createMockBot(): TelegramBotApi {
+  return {
+    sendMessage: vi.fn().mockResolvedValue({ message_id: 42 }),
+    editMessageText: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+    sendChatAction: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe('TelegramViewAdapter', () => {
+  it('reports platform as telegram', () => {
+    const adapter = new TelegramViewAdapter();
+    expect(adapter.platform).toBe('telegram');
+  });
+
+  describe('featuresFor', () => {
+    it('returns correct capabilities', () => {
+      const adapter = new TelegramViewAdapter();
+      const features = adapter.featuresFor(telegramTarget(123));
+
+      expect(features.canEdit).toBe(true);
+      expect(features.canThread).toBe(false);
+      expect(features.canReact).toBe(false);
+      expect(features.canModal).toBe(false);
+      expect(features.canUploadFile).toBe(true);
+      expect(features.canEphemeral).toBe(false);
+      expect(features.maxMessageLength).toBe(4096);
+      expect(features.maxFileSize).toBe(50 * 1024 * 1024);
+    });
+  });
+
+  describe('postMessage', () => {
+    it('sends message via bot API', async () => {
+      const bot = createMockBot();
+      const adapter = new TelegramViewAdapter(bot);
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Hello Telegram!' }];
+
+      const handle = await adapter.postMessage(telegramTarget(123), blocks);
+
+      expect(bot.sendMessage).toHaveBeenCalledWith(123, 'Hello Telegram!', { parse_mode: 'MarkdownV2' });
+      expect(handle.platform).toBe('telegram');
+      expect((handle.ref as TelegramMessageRef).messageId).toBe(42);
+    });
+
+    it('returns stub handle without bot', async () => {
+      const adapter = new TelegramViewAdapter();
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Hello' }];
+
+      const handle = await adapter.postMessage(telegramTarget(123), blocks);
+
+      expect(handle.platform).toBe('telegram');
+      expect((handle.ref as TelegramMessageRef).messageId).toBe(0);
+    });
+  });
+
+  describe('beginResponse', () => {
+    it('returns a ResponseSession that collects text', async () => {
+      const bot = createMockBot();
+      const adapter = new TelegramViewAdapter(bot);
+      const session = adapter.beginResponse(telegramTarget(123));
+
+      session.appendText('Hello ');
+      session.appendText('world');
+      const handle = await session.complete();
+
+      expect(bot.sendMessage).toHaveBeenCalledWith(123, 'Hello world', { parse_mode: 'MarkdownV2' });
+      expect(handle.platform).toBe('telegram');
+    });
+
+    it('sends typing action on setStatus', () => {
+      const bot = createMockBot();
+      const adapter = new TelegramViewAdapter(bot);
+      const session = adapter.beginResponse(telegramTarget(456));
+
+      session.setStatus('Thinking');
+
+      expect(bot.sendChatAction).toHaveBeenCalledWith(456, 'typing');
+    });
+
+    it('does not append text after abort', async () => {
+      const bot = createMockBot();
+      const adapter = new TelegramViewAdapter(bot);
+      const session = adapter.beginResponse(telegramTarget(123));
+
+      session.appendText('Hello');
+      session.abort('cancelled');
+      session.appendText(' world');
+
+      // No message should be sent since we aborted before complete
+      expect(bot.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Editable', () => {
+    it('edits message via bot API', async () => {
+      const bot = createMockBot();
+      const adapter = new TelegramViewAdapter(bot);
+      const handle = telegramHandle(123, 42);
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Updated text' }];
+
+      await adapter.updateMessage(handle, blocks);
+
+      expect(bot.editMessageText).toHaveBeenCalledWith('Updated text', {
+        chat_id: 123,
+        message_id: 42,
+        parse_mode: 'MarkdownV2',
+      });
+    });
+
+    it('deletes message via bot API', async () => {
+      const bot = createMockBot();
+      const adapter = new TelegramViewAdapter(bot);
+      const handle = telegramHandle(123, 42);
+
+      await adapter.deleteMessage(handle);
+
+      expect(bot.deleteMessage).toHaveBeenCalledWith(123, 42);
+    });
+
+    it('is safe to call without bot', async () => {
+      const adapter = new TelegramViewAdapter();
+      const handle = telegramHandle(123, 42);
+
+      // Should not throw
+      await adapter.updateMessage(handle, [{ type: 'text', text: 'x' }]);
+      await adapter.deleteMessage(handle);
+    });
+  });
+});

--- a/src/view/telegram/telegram-view-adapter.ts
+++ b/src/view/telegram/telegram-view-adapter.ts
@@ -1,0 +1,174 @@
+/**
+ * TelegramViewAdapter — Telegram Bot API view surface stub (Issue #414)
+ *
+ * Implements ViewSurfaceCore & Editable for Telegram.
+ * Telegram supports message editing but NOT threading, reactions, or modals.
+ *
+ * Streaming approach: edit-polling (same as Slack).
+ * Telegram's editMessageText API is used to simulate streaming.
+ *
+ * Implementation will wrap the Telegram Bot API (node-telegram-bot-api
+ * or telegraf) when the dependency is added.
+ */
+
+import type { ResponseSession } from '../response-session.js';
+import type { Editable, ViewSurfaceCore } from '../surface.js';
+import type { ContentBlock, ConversationTarget, FeatureSet, MessageHandle, Platform } from '../types.js';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** Telegram conversation reference. */
+export interface TelegramConversationRef {
+  readonly chatId: string | number;
+  readonly topicId?: number;
+}
+
+/** Telegram message reference. */
+export interface TelegramMessageRef {
+  readonly chatId: string | number;
+  readonly messageId: number;
+}
+
+/** Minimal Telegram Bot API interface for dependency injection. */
+export interface TelegramBotApi {
+  sendMessage(
+    chatId: string | number,
+    text: string,
+    options?: Record<string, unknown>,
+  ): Promise<{ message_id: number }>;
+  editMessageText(
+    text: string,
+    options: { chat_id: string | number; message_id: number; parse_mode?: string },
+  ): Promise<void>;
+  deleteMessage(chatId: string | number, messageId: number): Promise<void>;
+  sendChatAction(chatId: string | number, action: string): Promise<void>;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Extract typed TelegramConversationRef from a ConversationTarget. */
+export function extractTelegramRef(target: ConversationTarget): TelegramConversationRef {
+  if (target.platform !== 'telegram') {
+    throw new Error(`Expected telegram platform target, got ${target.platform}`);
+  }
+  return target.ref as TelegramConversationRef;
+}
+
+/** Extract typed TelegramMessageRef from a MessageHandle. */
+export function extractTelegramMessageRef(handle: MessageHandle): TelegramMessageRef {
+  if (handle.platform !== 'telegram') {
+    throw new Error(`Expected telegram platform handle, got ${handle.platform}`);
+  }
+  return handle.ref as TelegramMessageRef;
+}
+
+// ─── Implementation ─────────────────────────────────────────────
+
+export class TelegramViewAdapter implements ViewSurfaceCore, Editable {
+  readonly platform: Platform = 'telegram';
+
+  constructor(private bot?: TelegramBotApi) {}
+
+  async postMessage(target: ConversationTarget, blocks: readonly ContentBlock[]): Promise<MessageHandle> {
+    const ref = extractTelegramRef(target);
+    const text = this.blocksToText(blocks);
+
+    if (this.bot) {
+      const result = await this.bot.sendMessage(ref.chatId, text, { parse_mode: 'MarkdownV2' });
+      return {
+        platform: 'telegram',
+        ref: { chatId: ref.chatId, messageId: result.message_id } as TelegramMessageRef,
+      };
+    }
+
+    // Stub: return placeholder handle
+    return {
+      platform: 'telegram',
+      ref: { chatId: ref.chatId, messageId: 0 } as TelegramMessageRef,
+    };
+  }
+
+  beginResponse(target: ConversationTarget): ResponseSession {
+    // Will use edit-polling similar to Slack (throttled editMessageText calls)
+    // For now, return a minimal stub that collects text
+    const ref = extractTelegramRef(target);
+    const adapter = this;
+    let text = '';
+    let completed = false;
+
+    return {
+      appendText(delta: string) {
+        if (!completed) text += delta;
+      },
+      setStatus(_phase: string) {
+        // Telegram uses sendChatAction('typing') for status
+        adapter.bot?.sendChatAction(ref.chatId, 'typing').catch(() => {});
+      },
+      replacePart(_partId: string, _content: ContentBlock) {
+        // Not supported in simple mode
+      },
+      attachFile(_file) {
+        // Will use sendDocument in full implementation
+      },
+      async complete() {
+        if (completed) {
+          return { platform: 'telegram' as Platform, ref: { chatId: ref.chatId, messageId: 0 } as TelegramMessageRef };
+        }
+        completed = true;
+        const handle = await adapter.postMessage(target, [{ type: 'text', text }]);
+        return handle;
+      },
+      abort(_reason?: string) {
+        completed = true;
+      },
+    };
+  }
+
+  featuresFor(_target: ConversationTarget): FeatureSet {
+    return {
+      canEdit: true,
+      canThread: false,
+      canReact: false,
+      canModal: false,
+      canUploadFile: true,
+      canEphemeral: false,
+      maxMessageLength: 4096,
+      maxFileSize: 50 * 1024 * 1024, // 50MB
+    };
+  }
+
+  // ─── Editable ─────────────────────────────────────────────
+
+  async updateMessage(handle: MessageHandle, blocks: readonly ContentBlock[]): Promise<void> {
+    const ref = extractTelegramMessageRef(handle);
+    const text = this.blocksToText(blocks);
+
+    if (this.bot) {
+      await this.bot.editMessageText(text, {
+        chat_id: ref.chatId,
+        message_id: ref.messageId,
+        parse_mode: 'MarkdownV2',
+      });
+    }
+  }
+
+  async deleteMessage(handle: MessageHandle): Promise<void> {
+    const ref = extractTelegramMessageRef(handle);
+    if (this.bot) {
+      await this.bot.deleteMessage(ref.chatId, ref.messageId);
+    }
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────
+
+  private blocksToText(blocks: readonly ContentBlock[]): string {
+    return blocks
+      .map((b) => {
+        if (b.type === 'text') return b.text;
+        if (b.type === 'status') return `_${b.phase}_`;
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+}

--- a/src/view/tui/index.ts
+++ b/src/view/tui/index.ts
@@ -1,0 +1,11 @@
+/**
+ * TUI View Module — Terminal UI view adapter (Issue #414)
+ */
+
+export {
+  type TuiConversationRef,
+  type TuiMessageRef,
+  type TuiOutput,
+  TuiViewAdapter,
+  tuiTarget,
+} from './tui-view-adapter.js';

--- a/src/view/tui/tui-view-adapter.test.ts
+++ b/src/view/tui/tui-view-adapter.test.ts
@@ -1,0 +1,189 @@
+/**
+ * TuiViewAdapter tests (Issue #414)
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ContentBlock } from '../types.js';
+import { type TuiMessageRef, type TuiOutput, TuiViewAdapter, tuiTarget } from './tui-view-adapter.js';
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function createMockOutput(): TuiOutput & { buffer: string } {
+  const output = {
+    buffer: '',
+    write(text: string) {
+      output.buffer += text;
+    },
+  };
+  return output;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe('TuiViewAdapter', () => {
+  it('reports platform as tui', () => {
+    const output = createMockOutput();
+    const adapter = new TuiViewAdapter(output);
+    expect(adapter.platform).toBe('tui');
+  });
+
+  describe('tuiTarget', () => {
+    it('creates target with default pid', () => {
+      const target = tuiTarget('U001');
+      expect(target.platform).toBe('tui');
+      expect(target.userId).toBe('U001');
+    });
+
+    it('creates target with custom pid', () => {
+      const target = tuiTarget('U001', 12345);
+      expect((target.ref as { pid: number }).pid).toBe(12345);
+    });
+  });
+
+  describe('featuresFor', () => {
+    it('returns minimal capabilities', () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const target = tuiTarget('U001');
+      const features = adapter.featuresFor(target);
+
+      expect(features.canEdit).toBe(false);
+      expect(features.canThread).toBe(false);
+      expect(features.canReact).toBe(false);
+      expect(features.canModal).toBe(false);
+      expect(features.canUploadFile).toBe(false);
+      expect(features.canEphemeral).toBe(false);
+      expect(features.maxMessageLength).toBe(0); // Unlimited
+    });
+  });
+
+  describe('postMessage', () => {
+    it('writes text to output', async () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const target = tuiTarget('U001');
+      const blocks: ContentBlock[] = [{ type: 'text', text: 'Hello TUI!' }];
+
+      const handle = await adapter.postMessage(target, blocks);
+
+      expect(output.buffer).toBe('Hello TUI!\n');
+      expect(handle.platform).toBe('tui');
+    });
+
+    it('renders multiple blocks', async () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const target = tuiTarget('U001');
+      const blocks: ContentBlock[] = [
+        { type: 'text', text: 'Line 1' },
+        { type: 'status', phase: 'Processing' },
+        { type: 'text', text: 'Line 2' },
+      ];
+
+      await adapter.postMessage(target, blocks);
+
+      expect(output.buffer).toBe('Line 1\n[Processing]\nLine 2\n');
+    });
+
+    it('renders attachment blocks as file name', async () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const target = tuiTarget('U001');
+      const blocks: ContentBlock[] = [{ type: 'attachment', name: 'data.csv', data: 'content', mimeType: 'text/csv' }];
+
+      await adapter.postMessage(target, blocks);
+
+      expect(output.buffer).toBe('[File: data.csv]\n');
+    });
+
+    it('increments line counter', async () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const target = tuiTarget('U001');
+
+      const h1 = await adapter.postMessage(target, [{ type: 'text', text: 'First' }]);
+      const h2 = await adapter.postMessage(target, [{ type: 'text', text: 'Second' }]);
+
+      expect((h1.ref as TuiMessageRef).lineNumber).toBe(1);
+      expect((h2.ref as TuiMessageRef).lineNumber).toBe(2);
+    });
+  });
+
+  describe('beginResponse', () => {
+    it('streams text deltas to output', async () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const target = tuiTarget('U001');
+
+      const session = adapter.beginResponse(target);
+      session.appendText('Hello ');
+      session.appendText('world');
+      await session.complete();
+
+      expect(output.buffer).toBe('Hello world\n');
+    });
+
+    it('shows status inline', () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const session = adapter.beginResponse(tuiTarget('U001'));
+
+      session.setStatus('Thinking');
+
+      expect(output.buffer).toContain('[Thinking]');
+    });
+
+    it('shows file attachment notification', () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const session = adapter.beginResponse(tuiTarget('U001'));
+
+      session.attachFile({ name: 'output.txt', data: 'content', mimeType: 'text/plain' });
+
+      expect(output.buffer).toContain('[File: output.txt]');
+    });
+
+    it('does not append text after complete', async () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const session = adapter.beginResponse(tuiTarget('U001'));
+
+      session.appendText('Hello');
+      await session.complete();
+      session.appendText(' world');
+
+      expect(output.buffer).toBe('Hello\n');
+    });
+
+    it('shows abort reason', () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const session = adapter.beginResponse(tuiTarget('U001'));
+
+      session.appendText('Start');
+      session.abort('error occurred');
+
+      expect(output.buffer).toContain('[Aborted: error occurred]');
+    });
+
+    it('shows generic abort without reason', () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const session = adapter.beginResponse(tuiTarget('U001'));
+
+      session.abort();
+
+      expect(output.buffer).toContain('[Aborted]');
+    });
+
+    it('replaces part with text content', () => {
+      const output = createMockOutput();
+      const adapter = new TuiViewAdapter(output);
+      const session = adapter.beginResponse(tuiTarget('U001'));
+
+      session.replacePart('tool-output', { type: 'text', text: 'Tool result here' });
+
+      expect(output.buffer).toContain('Tool result here');
+    });
+  });
+});

--- a/src/view/tui/tui-view-adapter.ts
+++ b/src/view/tui/tui-view-adapter.ts
@@ -1,0 +1,136 @@
+/**
+ * TuiViewAdapter — Terminal UI view surface stub (Issue #414)
+ *
+ * Implements ViewSurfaceCore only (minimal adapter).
+ * TUI does NOT support editing, threading, reactions, or modals.
+ *
+ * Streaming approach: native stdout (direct write, no polling).
+ * ResponseSession writes text to stdout as deltas arrive.
+ *
+ * This is designed for CLI/REPL usage where the only output
+ * channel is the terminal. No external dependencies required.
+ */
+
+import type { ResponseSession } from '../response-session.js';
+import type { ViewSurfaceCore } from '../surface.js';
+import type { ContentBlock, ConversationTarget, FeatureSet, MessageHandle, Platform } from '../types.js';
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** TUI conversation reference. */
+export interface TuiConversationRef {
+  readonly pid: number;
+}
+
+/** TUI message reference (output has no persistent handles). */
+export interface TuiMessageRef {
+  readonly lineNumber: number;
+}
+
+/**
+ * Writable output interface for dependency injection.
+ * Defaults to process.stdout in production, replaceable in tests.
+ */
+export interface TuiOutput {
+  write(text: string): void;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Create a TUI ConversationTarget. */
+export function tuiTarget(userId: string, pid?: number): ConversationTarget {
+  const ref: TuiConversationRef = { pid: pid ?? process.pid };
+  return { platform: 'tui', ref, userId };
+}
+
+// ─── Implementation ─────────────────────────────────────────────
+
+export class TuiViewAdapter implements ViewSurfaceCore {
+  readonly platform: Platform = 'tui';
+  private lineCounter = 0;
+
+  constructor(private output: TuiOutput = process.stdout) {}
+
+  async postMessage(_target: ConversationTarget, blocks: readonly ContentBlock[]): Promise<MessageHandle> {
+    const text = this.blocksToText(blocks);
+    this.output.write(`${text}\n`);
+    this.lineCounter++;
+
+    return {
+      platform: 'tui',
+      ref: { lineNumber: this.lineCounter } as TuiMessageRef,
+    };
+  }
+
+  beginResponse(_target: ConversationTarget): ResponseSession {
+    const adapter = this;
+    let completed = false;
+
+    return {
+      appendText(delta: string) {
+        if (!completed) {
+          adapter.output.write(delta);
+        }
+      },
+      setStatus(phase: string) {
+        if (!completed) {
+          adapter.output.write(`\r[${phase}]`);
+        }
+      },
+      replacePart(_partId: string, content: ContentBlock) {
+        if (!completed && content.type === 'text') {
+          adapter.output.write(`\n${content.text}`);
+        }
+      },
+      attachFile(file) {
+        if (!completed) {
+          adapter.output.write(`\n[File: ${file.name}]\n`);
+        }
+      },
+      async complete() {
+        completed = true;
+        adapter.output.write('\n');
+        adapter.lineCounter++;
+        return {
+          platform: 'tui' as Platform,
+          ref: { lineNumber: adapter.lineCounter } as TuiMessageRef,
+        };
+      },
+      abort(reason?: string) {
+        completed = true;
+        if (reason) {
+          adapter.output.write(`\n[Aborted: ${reason}]\n`);
+        } else {
+          adapter.output.write('\n[Aborted]\n');
+        }
+      },
+    };
+  }
+
+  featuresFor(_target: ConversationTarget): FeatureSet {
+    return {
+      canEdit: false,
+      canThread: false,
+      canReact: false,
+      canModal: false,
+      canUploadFile: false,
+      canEphemeral: false,
+      maxMessageLength: 0, // Unlimited (terminal has no hard limit)
+      maxFileSize: 0,
+    };
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────
+
+  private blocksToText(blocks: readonly ContentBlock[]): string {
+    return blocks
+      .map((b) => {
+        if (b.type === 'text') return b.text;
+        if (b.type === 'status') return `[${b.phase}]`;
+        if (b.type === 'attachment') return `[File: ${b.name}]`;
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+}


### PR DESCRIPTION
## Summary

- **Telegram adapter**: `ViewSurfaceCore & Editable` — edit-polling via `editMessageText`, 4096 char limit, `TelegramBotApi` DI interface
- **Discord adapter**: Full `ViewSurfaceCore & Editable & Threadable & Reactable & HasModals` — `DiscordClientApi` DI interface, 2000 char limit, ephemeral support
- **TUI adapter**: Minimal `ViewSurfaceCore` — stdout streaming, no edit/thread/react/modal capabilities
- 45 new tests (10 Telegram + 20 Discord + 15 TUI), all passing
- tsc clean, 2991 total tests passing, zero regressions

Closes #414

## Platform Capability Matrix

| Capability | Telegram | Discord | TUI |
|---|---|---|---|
| Edit | ✅ | ✅ | ❌ |
| Thread | ❌ | ✅ | ❌ |
| React | ❌ | ✅ | ❌ |
| Modal | ❌ | ✅ | ❌ |
| File Upload | ✅ | ✅ | ❌ |
| Ephemeral | ❌ | ✅ | ❌ |
| Max Message | 4096 | 2000 | ∞ |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/view/telegram/` — 10 tests pass
- [x] `npx vitest run src/view/discord/` — 20 tests pass
- [x] `npx vitest run src/view/tui/` — 15 tests pass
- [x] Full regression `npx vitest run` — 2991 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <hyperbolic@gmail.com>