### PR TITLE
fix: enforce per-user directory isolation and fix bypass CWD scoping

### DIFF
--- a/src/agent-session/__tests__/v1-query-adapter-abort.test.ts
+++ b/src/agent-session/__tests__/v1-query-adapter-abort.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TurnResultCollector } from '../turn-result-collector.js';
+import type { StreamExecutorLike } from '../v1-query-adapter.js';
 import { V1QueryAdapter } from '../v1-query-adapter.js';
 
 // Trace: Ghost Session Fix, Scenario 1 — AbortController Unification (P0)
@@ -47,7 +48,7 @@ describe('V1QueryAdapter — AbortController Unification (Ghost Session Fix #99)
     const originalController = params.abortController;
 
     const adapter = new V1QueryAdapter({
-      streamExecutor: mockExecutor as any,
+      streamExecutor: mockExecutor as StreamExecutorLike,
       executeParams: params,
     });
 
@@ -62,7 +63,7 @@ describe('V1QueryAdapter — AbortController Unification (Ghost Session Fix #99)
   it('continue() should pass the SAME abortController from baseParams to executor', async () => {
     const params = createMockExecuteParams();
     const adapter = new V1QueryAdapter({
-      streamExecutor: mockExecutor as any,
+      streamExecutor: mockExecutor as StreamExecutorLike,
       executeParams: params,
     });
 
@@ -84,7 +85,7 @@ describe('V1QueryAdapter — AbortController Unification (Ghost Session Fix #99)
     const registeredController = params.abortController;
 
     const adapter = new V1QueryAdapter({
-      streamExecutor: mockExecutor as any,
+      streamExecutor: mockExecutor as StreamExecutorLike,
       executeParams: params,
     });
 
@@ -107,7 +108,7 @@ describe('V1QueryAdapter — AbortController Unification (Ghost Session Fix #99)
     const params = createMockExecuteParams();
 
     const adapter = new V1QueryAdapter({
-      streamExecutor: mockExecutor as any,
+      streamExecutor: mockExecutor as StreamExecutorLike,
       executeParams: params,
     });
 

--- a/src/agent-session/__tests__/v1-query-adapter-continuation.test.ts
+++ b/src/agent-session/__tests__/v1-query-adapter-continuation.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ContinuationHandler } from '../agent-session-types.js';
 import { TurnResultCollector } from '../turn-result-collector.js';
-import type { StreamExecutorLike } from '../v1-query-adapter.js';
 import { V1QueryAdapter } from '../v1-query-adapter.js';
 
 // Trace: Scenario 2 — V1QueryAdapter.startWithContinuation()
@@ -32,13 +31,8 @@ function createCollectorWithContinuation(continuation: any = null) {
 }
 
 describe('V1QueryAdapter.startWithContinuation', () => {
-  let mockExecutor: StreamExecutorLike;
-  let mockRunner: {
-    begin: ReturnType<typeof vi.fn>;
-    update: ReturnType<typeof vi.fn>;
-    finish: ReturnType<typeof vi.fn>;
-    fail: ReturnType<typeof vi.fn>;
-  };
+  let mockExecutor: any;
+  let mockRunner: any;
 
   beforeEach(() => {
     mockRunner = {

--- a/src/agent-session/__tests__/v1-query-adapter-continuation.test.ts
+++ b/src/agent-session/__tests__/v1-query-adapter-continuation.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ContinuationHandler } from '../agent-session-types.js';
 import { TurnResultCollector } from '../turn-result-collector.js';
+import type { StreamExecutorLike } from '../v1-query-adapter.js';
 import { V1QueryAdapter } from '../v1-query-adapter.js';
 
 // Trace: Scenario 2 — V1QueryAdapter.startWithContinuation()
@@ -31,8 +32,13 @@ function createCollectorWithContinuation(continuation: any = null) {
 }
 
 describe('V1QueryAdapter.startWithContinuation', () => {
-  let mockExecutor: any;
-  let mockRunner: any;
+  let mockExecutor: StreamExecutorLike;
+  let mockRunner: {
+    begin: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    finish: ReturnType<typeof vi.fn>;
+    fail: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     mockRunner = {

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -14,7 +14,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { isAdminUser } from './admin-utils';
 import { isCrossUserAccess, isDangerousCommand, isSshCommand } from './dangerous-command-filter';
-import { isSafePathSegment, normalizeTmpPath } from './path-utils';
 import { CONFIG_FILE } from './env-paths';
 import { Logger } from './logger';
 import type { McpManager } from './mcp-manager';
@@ -26,6 +25,7 @@ import {
   loadMcpToolPermissions,
   resolveGatedTool,
 } from './mcp-tool-permission-config';
+import { isSafePathSegment, normalizeTmpPath } from './path-utils';
 import type { SdkPluginPath } from './plugin/types';
 import type {
   ActivityState,

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -751,7 +751,7 @@ export class ClaudeHandler {
       // permission prompts even in bypass mode, because SDK treats only cwd as allowed.
       if (slackContext?.user && isSafePathSegment(slackContext.user)) {
         const userRootDir = normalizeTmpPath(path.join('/tmp', slackContext.user));
-        options.additionalDirectories = [userRootDir];
+        options.additionalDirectories = [...(options.additionalDirectories || []), userRootDir];
       }
     }
 

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -13,7 +13,8 @@ import {
 import * as fs from 'fs';
 import * as path from 'path';
 import { isAdminUser } from './admin-utils';
-import { isDangerousCommand, isSshCommand } from './dangerous-command-filter';
+import { isCrossUserAccess, isDangerousCommand, isSshCommand } from './dangerous-command-filter';
+import { isSafePathSegment, normalizeTmpPath } from './path-utils';
 import { CONFIG_FILE } from './env-paths';
 import { Logger } from './logger';
 import type { McpManager } from './mcp-manager';
@@ -557,6 +558,34 @@ export class ClaudeHandler {
         });
       }
 
+      // Cross-user directory isolation: deny Bash commands that access another user's
+      // /tmp/{userId}/ directory. Always enforced regardless of bypass mode.
+      preToolUseHooks.push({
+        matcher: 'Bash',
+        hooks: [
+          async (input: HookInput): Promise<HookJSONOutput> => {
+            const { tool_input } = input as { tool_input: unknown };
+            const toolRecord = tool_input as Record<string, unknown> | undefined;
+            const command = typeof toolRecord?.command === 'string' ? toolRecord.command : '';
+
+            if (isCrossUserAccess(command, slackContext.user)) {
+              this.logger.warn('Cross-user directory access denied', {
+                command: command.substring(0, 100),
+                user: slackContext.user,
+              });
+              return {
+                hookSpecificOutput: {
+                  hookEventName: 'PreToolUse',
+                  permissionDecision: 'deny',
+                },
+              };
+            }
+
+            return { continue: true };
+          },
+        ],
+      });
+
       // Dangerous command interceptor: escalate to Slack permission UI in bypass mode
       if (mcpConfig.userBypass) {
         preToolUseHooks.push({
@@ -715,6 +744,14 @@ export class ClaudeHandler {
       }
       if (fs.existsSync(workingDirectory)) {
         options.cwd = workingDirectory;
+      }
+
+      // Expand SDK's allowed directory scope to user's root /tmp/{userId} directory.
+      // Without this, sibling directories (e.g., /tmp/{userId}/soma-work_xxx/) trigger
+      // permission prompts even in bypass mode, because SDK treats only cwd as allowed.
+      if (slackContext?.user && isSafePathSegment(slackContext.user)) {
+        const userRootDir = normalizeTmpPath(path.join('/tmp', slackContext.user));
+        options.additionalDirectories = [userRootDir];
       }
     }
 

--- a/src/dangerous-command-filter.test.ts
+++ b/src/dangerous-command-filter.test.ts
@@ -129,6 +129,9 @@ describe('isCrossUserAccess', () => {
       ['git clone repo /tmp/U09F1M5MML1/repo', 'clone into another user dir'],
       ['cp /tmp/U094E5L4A15/a.txt /tmp/U09F1M5MML1/b.txt', 'copy to another user dir'],
       ['ls /private/tmp/U09F1M5MML1/', 'macOS /private/tmp path'],
+      ['cat /tmp/U094E5L4A15/../U09F1M5MML1/file.txt', 'path traversal via ..'],
+      ['ls /tmp/U094E5L4A15/../../etc/passwd', 'traversal out of /tmp entirely'],
+      ['cat /private/tmp/U094E5L4A15/../U09F1M5MML1/secret', 'macOS path traversal'],
     ])('detects: %s (%s)', (command) => {
       expect(isCrossUserAccess(command, CURRENT_USER)).toBe(true);
     });

--- a/src/dangerous-command-filter.test.ts
+++ b/src/dangerous-command-filter.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  checkDangerousCommand,
-  isCrossUserAccess,
-  isDangerousCommand,
-  isSshCommand,
-} from './dangerous-command-filter';
+import { checkDangerousCommand, isCrossUserAccess, isDangerousCommand, isSshCommand } from './dangerous-command-filter';
 
 describe('isDangerousCommand', () => {
   describe('detects dangerous patterns', () => {
@@ -168,8 +163,6 @@ describe('isCrossUserAccess', () => {
   });
 
   it('allows when all paths belong to current user', () => {
-    expect(
-      isCrossUserAccess('cp /tmp/U094E5L4A15/a.txt /tmp/U094E5L4A15/b.txt', CURRENT_USER),
-    ).toBe(false);
+    expect(isCrossUserAccess('cp /tmp/U094E5L4A15/a.txt /tmp/U094E5L4A15/b.txt', CURRENT_USER)).toBe(false);
   });
 });

--- a/src/dangerous-command-filter.test.ts
+++ b/src/dangerous-command-filter.test.ts
@@ -132,6 +132,7 @@ describe('isCrossUserAccess', () => {
       ['cat /tmp/U094E5L4A15/../U09F1M5MML1/file.txt', 'path traversal via ..'],
       ['ls /tmp/U094E5L4A15/../../etc/passwd', 'traversal out of /tmp entirely'],
       ['cat /private/tmp/U094E5L4A15/../U09F1M5MML1/secret', 'macOS path traversal'],
+      ['ls /tmp/W012ABC3DEF/files', 'Enterprise Grid W-prefixed user ID'],
     ])('detects: %s (%s)', (command) => {
       expect(isCrossUserAccess(command, CURRENT_USER)).toBe(true);
     });

--- a/src/dangerous-command-filter.test.ts
+++ b/src/dangerous-command-filter.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { checkDangerousCommand, isDangerousCommand, isSshCommand } from './dangerous-command-filter';
+import {
+  checkDangerousCommand,
+  isCrossUserAccess,
+  isDangerousCommand,
+  isSshCommand,
+} from './dangerous-command-filter';
 
 describe('isDangerousCommand', () => {
   describe('detects dangerous patterns', () => {
@@ -110,5 +115,57 @@ describe('checkDangerousCommand', () => {
     const result = checkDangerousCommand('git status');
     expect(result.isDangerous).toBe(false);
     expect(result.matchedPatterns).toHaveLength(0);
+  });
+});
+
+describe('isCrossUserAccess', () => {
+  const CURRENT_USER = 'U094E5L4A15';
+
+  describe('detects cross-user directory access', () => {
+    it.each([
+      ['cd /tmp/U09F1M5MML1/session_123', 'cd into another user dir'],
+      ['cat /tmp/U09F1M5MML1/file.txt', 'read another user file'],
+      ['mkdir -p /tmp/UOTHER123/workdir', 'create dir under another user'],
+      ['git clone repo /tmp/U09F1M5MML1/repo', 'clone into another user dir'],
+      ['cp /tmp/U094E5L4A15/a.txt /tmp/U09F1M5MML1/b.txt', 'copy to another user dir'],
+      ['ls /private/tmp/U09F1M5MML1/', 'macOS /private/tmp path'],
+    ])('detects: %s (%s)', (command) => {
+      expect(isCrossUserAccess(command, CURRENT_USER)).toBe(true);
+    });
+  });
+
+  describe('allows same-user directory access', () => {
+    it.each([
+      ['cd /tmp/U094E5L4A15/session_123', 'cd into own session dir'],
+      ['mkdir -p /tmp/U094E5L4A15/soma-work_xxx', 'create sibling dir'],
+      ['cat /tmp/U094E5L4A15/file.txt', 'read own file'],
+      ['ls /private/tmp/U094E5L4A15/', 'macOS /private/tmp own path'],
+      ['cp /tmp/U094E5L4A15/a.txt /tmp/U094E5L4A15/b.txt', 'copy within own dir'],
+    ])('allows: %s (%s)', (command) => {
+      expect(isCrossUserAccess(command, CURRENT_USER)).toBe(false);
+    });
+  });
+
+  describe('allows commands without /tmp user paths', () => {
+    it.each([
+      ['git status', 'git status'],
+      ['npm install', 'npm install'],
+      ['ls -la /home/user', 'non-tmp path'],
+      ['cat /etc/hosts', 'system file'],
+      ['echo hello', 'echo'],
+      ['mkdir -p /tmp/workdir', 'tmp without user ID pattern'],
+    ])('allows: %s (%s)', (command) => {
+      expect(isCrossUserAccess(command, CURRENT_USER)).toBe(false);
+    });
+  });
+
+  it('detects cross-user in compound commands', () => {
+    expect(isCrossUserAccess('cd /tmp/U094E5L4A15 && cat /tmp/U09F1M5MML1/file', CURRENT_USER)).toBe(true);
+  });
+
+  it('allows when all paths belong to current user', () => {
+    expect(
+      isCrossUserAccess('cp /tmp/U094E5L4A15/a.txt /tmp/U094E5L4A15/b.txt', CURRENT_USER),
+    ).toBe(false);
   });
 });

--- a/src/dangerous-command-filter.ts
+++ b/src/dangerous-command-filter.ts
@@ -59,6 +59,25 @@ export function isDangerousCommand(command: string): boolean {
 }
 
 /**
+ * Cross-user directory access detection.
+ * Detects commands that reference another user's /tmp/{userId}/ directory.
+ * Enforces per-user filesystem isolation — always deny, regardless of bypass mode.
+ *
+ * Matches both /tmp/{userId} and /private/tmp/{userId} (macOS normalization).
+ * Slack user IDs follow pattern: U + uppercase alphanumeric (e.g., U094E5L4A15).
+ */
+export function isCrossUserAccess(command: string, currentUserId: string): boolean {
+  const tmpPathPattern = /(?:\/private)?\/tmp\/(U[A-Z0-9]+)\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = tmpPathPattern.exec(command)) !== null) {
+    if (match[1] !== currentUserId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * SSH command patterns — matches `ssh`, `scp`, `sftp`, `rsync` over SSH.
  * These commands allow remote server access and must be restricted to admin users.
  */

--- a/src/dangerous-command-filter.ts
+++ b/src/dangerous-command-filter.ts
@@ -67,6 +67,12 @@ export function isDangerousCommand(command: string): boolean {
  * Slack user IDs follow pattern: U + uppercase alphanumeric (e.g., U094E5L4A15).
  */
 export function isCrossUserAccess(command: string, currentUserId: string): boolean {
+  // Reject any /tmp/ path containing traversal segments — prevents escaping
+  // own directory via /tmp/U094E5L4A15/../U09F1M5MML1/
+  if (/(?:\/private)?\/tmp\/[^\s]*\.\./.test(command)) {
+    return true;
+  }
+
   const tmpPathPattern = /(?:\/private)?\/tmp\/(U[A-Z0-9]+)\b/g;
   let match: RegExpExecArray | null;
   while ((match = tmpPathPattern.exec(command)) !== null) {

--- a/src/dangerous-command-filter.ts
+++ b/src/dangerous-command-filter.ts
@@ -64,7 +64,8 @@ export function isDangerousCommand(command: string): boolean {
  * Enforces per-user filesystem isolation — always deny, regardless of bypass mode.
  *
  * Matches both /tmp/{userId} and /private/tmp/{userId} (macOS normalization).
- * Slack user IDs follow pattern: U + uppercase alphanumeric (e.g., U094E5L4A15).
+ * Slack user IDs follow pattern: [UW] + uppercase alphanumeric (e.g., U094E5L4A15).
+ * Enterprise Grid uses W-prefixed IDs — both must be covered.
  */
 export function isCrossUserAccess(command: string, currentUserId: string): boolean {
   // Reject any /tmp/ path containing traversal segments — prevents escaping
@@ -73,7 +74,7 @@ export function isCrossUserAccess(command: string, currentUserId: string): boole
     return true;
   }
 
-  const tmpPathPattern = /(?:\/private)?\/tmp\/(U[A-Z0-9]+)\b/g;
+  const tmpPathPattern = /(?:\/private)?\/tmp\/([UW][A-Z0-9]+)\b/g;
   let match: RegExpExecArray | null;
   while ((match = tmpPathPattern.exec(command)) !== null) {
     if (match[1] !== currentUserId) {


### PR DESCRIPTION
## Summary
- **Fix bypass permission prompts**: Add `additionalDirectories` to SDK options so sibling dirs under `/tmp/{userId}/` are within allowed scope. Fixes bypass users getting permission prompts for their own directories.
- **Block cross-user access**: Add `isCrossUserAccess()` detection + PreToolUse hook that hard-denies Bash commands accessing other users' `/tmp/{otherId}/` directories. Always enforced regardless of bypass mode.
- **Test coverage**: 18 new test cases covering cross-user detection, same-user allowance, macOS `/private/tmp` normalization, compound commands.

## Changes
| File | What |
|------|------|
| `src/claude-handler.ts` | `additionalDirectories` option + cross-user PreToolUse hook |
| `src/dangerous-command-filter.ts` | `isCrossUserAccess()` function |
| `src/dangerous-command-filter.test.ts` | 18 test cases for cross-user detection |

## Test plan
- [x] `npx vitest run src/dangerous-command-filter.test.ts` — 73 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] Deploy and verify bypass users no longer see permission prompts for sibling dirs
- [ ] Verify cross-user directory access is immediately denied (not asked)

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <z@2lab.ai>