### PR TITLE
chore: simplify zcheck skill, add dev deploy skill

### DIFF
--- a/src/local/skills/dev/SKILL.md
+++ b/src/local/skills/dev/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: dev
+description: "Deploy to dev environment. Creates main→deploy/dev PR, merges, and monitors CI deployment to both targets (mac-mini-dev, oudwood-dev)."
+---
+
+# dev — Deploy to Dev Environment
+
+Deploys the current `main` branch to the dev environment by pushing to `deploy/dev` and monitoring CI until both deployment targets are confirmed successful.
+
+## Process
+
+### Step 0: Executive Summary of Changes
+
+1. Run `git diff deploy/dev...main` to collect all changes being deployed.
+2. Use `local:es` skill to generate an executive summary of the deployment delta.
+3. Output the summary to the user.
+
+### Step 1: Create PR and Merge
+
+1. Create a PR from `main` → `deploy/dev`:
+   ```bash
+   gh pr create --base deploy/dev --head main \
+     --title "deploy(dev): $(date +%Y-%m-%d) release" \
+     --body "<executive summary from Step 0>"
+   ```
+2. Merge the PR immediately (no review required for dev):
+   ```bash
+   gh pr merge <PR_NUMBER> --merge
+   ```
+3. Output the merged PR link to the user.
+
+### Step 2: Monitor CI Deployment
+
+The `deploy/dev` push triggers the Deploy workflow which deploys to **2 targets**:
+- `mac-mini-dev` (runner: `soma-work`, dir: `/opt/soma-work/dev`)
+- `oudwood-dev` (runner: `oudwood-512`, dir: `/opt/soma-work/dev`)
+
+**Monitoring loop:**
+
+1. Get the workflow run triggered by the merge:
+   ```bash
+   gh run list --branch deploy/dev --workflow deploy.yml --limit 1 --json databaseId,status,conclusion
+   ```
+2. Poll every 30 seconds until the run completes:
+   ```bash
+   gh run view <RUN_ID> --json status,conclusion,jobs
+   ```
+3. Check that **both** deploy jobs succeeded:
+   - `Deploy mac-mini-dev` — conclusion: `success`
+   - `Deploy oudwood-dev` — conclusion: `success`
+4. **If any job fails:** Report the failure details to the user and stop.
+5. **If both succeed:** Report deployment complete with:
+   - PR link
+   - Workflow run link
+   - Both target statuses
+   - Version deployed (from version-bump output if available)
+
+## Output Format
+
+```
+✅ Dev deployment complete
+
+PR: <PR_URL>
+CI: <WORKFLOW_RUN_URL>
+
+| Target | Status | 
+|--------|--------|
+| mac-mini-dev | ✅ success |
+| oudwood-dev | ✅ success |
+
+Changes deployed: <N> commits, +<add> -<del> (<files> files)
+```
+
+## Error Handling
+
+- **PR creation fails (no diff):** Report "deploy/dev is already up to date with main" and stop.
+- **Merge conflict:** Report conflict details and ask user to resolve.
+- **CI timeout (>10 min):** Report current status and ask user whether to keep waiting.
+- **Deployment job failure:** Show job logs summary and suggest `stv:debug`.

--- a/src/local/skills/zcheck/SKILL.md
+++ b/src/local/skills/zcheck/SKILL.md
@@ -5,77 +5,37 @@ description: "Post-implementation verification gate. Resolves PR review comments
 
 # zcheck — Post-Implementation Verification Gate
 
-After `local:zwork` completes, this skill ensures the PR is in a mergeable state before requesting user approval. It loops until all conditions are met.
+PR이 mergeable 상태가 될 때까지 루프. **코드 변경 시 Step 1부터 재시작.**
 
 ## Input
 
 - PR URL or `owner/repo#number`
 
-## Process
+## Step 1: Resolve All PR Review Comments
 
-### Step 1: Resolve All PR Review Comments
+1. `local:github-pr`로 리뷰 코멘트 가져오기.
+2. Unresolved 쓰레드마다: 코드 확인 → 수정 필요시 fix+commit+push+reply+resolve, 이미 해결됐으면 reply+resolve.
+3. 0 unresolved까지 루프.
 
-1. Fetch PR review comments via `local:github-pr`.
-2. For each **unresolved** review thread:
-   a. Read the comment body and the referenced code location.
-   b. **If the comment is valid and code needs fixing:**
-      - Fix the code
-      - Commit and push
-      - Reply to the comment explaining the fix
-      - Resolve the thread via GraphQL API
-   c. **If the comment is already addressed or not applicable:**
-      - Reply with explanation of why it's resolved
-      - Resolve the thread via GraphQL API
-3. **Loop until 0 unresolved threads remain.**
+## Step 2: CI Must Pass
 
-### Step 2: CI Must Pass
+**`gh pr checks` 사용 금지** — bot 토큰에서 GraphQL `statusCheckRollup` 권한 부족으로 실패함.
 
-1. Check CI status: `gh pr checks <PR_URL>`
-2. **If pending:** Poll every 30 seconds until complete.
-   ```bash
-   while true; do
-     status=$(gh pr checks <PR_URL> --json state -q '.[].state' | sort -u)
-     if echo "$status" | grep -q "FAILURE"; then break; fi
-     if echo "$status" | grep -q "PENDING"; then sleep 30; continue; fi
-     if [ "$status" = "SUCCESS" ]; then break; fi
-     sleep 30
-   done
-   ```
-3. **If failed:** Use `stv:debug` to diagnose the failure and fix it. Commit and push.
-4. **After any code change:** Go back to **Step 1** — new code may trigger new review comments or invalidate prior resolutions.
-5. **Loop until CI is fully green.**
-
-### Step 3: Request Approve
-
-All review comments are resolved AND CI is green. Now ask the user.
-
-Use `local:UIAskUserQuestion` to request approval:
-
-```json
-{
-  "commandId": "ASK_USER_QUESTION",
-  "params": {
-    "payload": {
-      "type": "user_choice",
-      "question": "PR is ready for approval",
-      "context": "▸ Review comments: N resolved, 0 remaining\n▸ CI: ✅ All checks passing\n▸ Changes: +X -Y ({N} files)\n▸ PR: {PR_URL}",
-      "choices": [
-        { "id": "approve", "label": "Approve & Merge", "description": "All checks pass, all comments resolved." },
-        { "id": "review", "label": "I'll review manually first", "description": "Hold merge, I'll check the PR myself." }
-      ]
-    }
-  }
-}
+```bash
+# Actions API 사용
+gh run list --branch <BRANCH> --repo <OWNER/REPO> --limit 1 --json status,conclusion,databaseId -q '.[0]'
 ```
+
+- **in_progress:** 30초마다 폴링.
+- **failed:** `gh run view <RUN_ID> --log-failed`로 진단 → fix → commit+push → **Step 1로 복귀**.
+- **success:** Step 3으로.
+
+## Step 3: Request Approve
+
+`local:UIAskUserQuestion`으로 approve 요청. 리뷰 코멘트 해결 수, CI 상태, 변경 범위, PR 링크 포함.
 
 ## Invariants
 
-- **Never request approve with unresolved review comments.** The user cannot approve until all threads are resolved.
-- **Never request approve with failing CI.** Fix it first.
-- **Every code change restarts from Step 1.** This prevents stale resolutions.
-
-## Error Handling
-
-- **GitHub API rate limit:** Wait and retry.
-- **CI timeout (>10 min with no progress):** Report to user via `local:UIAskUserQuestion` — user may need to intervene.
-- **Unresolvable review comment (e.g., requires design decision):** Use `local:decision-gate` to determine if autonomous or needs user input. If user input needed, ask via `local:UIAskUserQuestion` and wait.
+- Unresolved 코멘트 있으면 approve 요청 금지.
+- CI 실패 중이면 approve 요청 금지.
+- 코드 변경 → Step 1 재시작.


### PR DESCRIPTION
## Summary
- refactor: simplify zcheck skill (96→38 lines) — remove verbose code blocks and examples
- feat: add dev deployment skill (`src/local/skills/dev`)

## Test plan
- [ ] `local:zcheck` loads correctly
- [ ] `local:dev` loads correctly