### PR TITLE
feat(opus): migrate to Claude Opus 4.7 + SDK 0.2.111 + xhigh effort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "somalib"
       ],
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.97",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.111",
         "@anthropic-ai/sdk": "^0.86.1",
         "@clickhouse/client": "^1.18.2",
         "@fastify/websocket": "^11.2.0",
@@ -39,13 +39,13 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.97",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.97.tgz",
-      "integrity": "sha512-754teaU0nfrn9BC0YWzPjSbJj253GfPUtuUnkrde7LGsaKtFSjEEuQJq5skJvpozqcn+B8frrtWVPkvFdnupTw==",
+      "version": "0.2.111",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.111.tgz",
+      "integrity": "sha512-DwXyJpVL8JXB8L2toSw1by7uIt1p8hPGi0P+hqr5tL+Ae7DcK9O3tUd6XcGown3LZ49zNCUAIpqX3wDmOhqp0Q==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.80.0",
-        "@modelcontextprotocol/sdk": "^1.27.1"
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
-      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -1178,9 +1178,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "mapping:sync": "tsx scripts/update-slack-jira-mapping.ts sync",
     "mapping:add": "tsx scripts/update-slack-jira-mapping.ts add"
   },
-  "workspaces": ["somalib"],
+  "workspaces": [
+    "somalib"
+  ],
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -32,7 +34,7 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.97",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.111",
     "@anthropic-ai/sdk": "^0.86.1",
     "@clickhouse/client": "^1.18.2",
     "@fastify/websocket": "^11.2.0",

--- a/src/claude-handler.test.ts
+++ b/src/claude-handler.test.ts
@@ -11,9 +11,10 @@ describe('buildThinkingOption', () => {
     expect(buildThinkingOption(true, false)).toEqual({ type: 'adaptive', display: 'omitted' });
   });
 
-  it('returns disabled when thinkingEnabled=false', () => {
+  it('returns disabled when thinkingEnabled=false (regardless of showSummary)', () => {
     expect(buildThinkingOption(false, true)).toEqual({ type: 'disabled' });
     expect(buildThinkingOption(false, false)).toEqual({ type: 'disabled' });
+    expect(buildThinkingOption(false)).toEqual({ type: 'disabled' });
   });
 
   it('defaults (thinkingEnabled=true, showSummary=true) yield adaptive+summarized', () => {

--- a/src/claude-handler.test.ts
+++ b/src/claude-handler.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildBetaHeaders, buildThinkingOption } from './claude-handler';
+import { DEFAULT_SHOW_THINKING, DEFAULT_THINKING_ENABLED } from './user-settings-store';
+
+describe('buildThinkingOption', () => {
+  it('returns adaptive+summarized when thinkingEnabled=true and showSummary=true', () => {
+    expect(buildThinkingOption(true, true)).toEqual({ type: 'adaptive', display: 'summarized' });
+  });
+
+  it('returns adaptive+omitted when thinkingEnabled=true and showSummary=false', () => {
+    expect(buildThinkingOption(true, false)).toEqual({ type: 'adaptive', display: 'omitted' });
+  });
+
+  it('returns disabled when thinkingEnabled=false', () => {
+    expect(buildThinkingOption(false, true)).toEqual({ type: 'disabled' });
+    expect(buildThinkingOption(false, false)).toEqual({ type: 'disabled' });
+  });
+
+  it('defaults (thinkingEnabled=true, showSummary=true) yield adaptive+summarized', () => {
+    // Validates the behaviour that the handler applies when no slackContext.user is
+    // present: it falls back to DEFAULT_THINKING_ENABLED and DEFAULT_SHOW_THINKING.
+    expect(DEFAULT_THINKING_ENABLED).toBe(true);
+    expect(DEFAULT_SHOW_THINKING).toBe(true);
+    expect(buildThinkingOption(DEFAULT_THINKING_ENABLED, DEFAULT_SHOW_THINKING)).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+    });
+  });
+});
+
+describe('buildBetaHeaders', () => {
+  it('returns undefined when no API key', () => {
+    expect(buildBetaHeaders('claude-sonnet-4-5-20250929', false)).toBeUndefined();
+  });
+
+  it('omits 1M beta for Opus 4.7 (1M GA)', () => {
+    const betas = buildBetaHeaders('claude-opus-4-7', true);
+    expect(betas).toBeUndefined();
+  });
+
+  it('omits 1M beta for Opus 4.6 (1M GA)', () => {
+    const betas = buildBetaHeaders('claude-opus-4-6', true);
+    expect(betas).toBeUndefined();
+  });
+
+  it('omits 1M beta for Sonnet 4.6 (1M GA)', () => {
+    const betas = buildBetaHeaders('claude-sonnet-4-6', true);
+    expect(betas).toBeUndefined();
+  });
+
+  it('includes 1M beta for Sonnet 4.5 (still needs header)', () => {
+    const betas = buildBetaHeaders('claude-sonnet-4-5-20250929', true);
+    expect(betas).toBeDefined();
+    expect(betas).toContain('context-1m-2025-08-07');
+  });
+
+  it('includes 1M beta for Haiku 4.5 (still needs header)', () => {
+    const betas = buildBetaHeaders('claude-haiku-4-5-20251001', true);
+    expect(betas).toBeDefined();
+    expect(betas).toContain('context-1m-2025-08-07');
+  });
+
+  it('includes 1M beta for unknown / empty model name (conservative default)', () => {
+    expect(buildBetaHeaders(undefined, true)).toContain('context-1m-2025-08-07');
+    expect(buildBetaHeaders('', true)).toContain('context-1m-2025-08-07');
+  });
+});

--- a/src/claude-handler.test.ts
+++ b/src/claude-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildBetaHeaders, buildThinkingOption } from './claude-handler';
+import { buildBetaHeaders, buildThinkingOption, resolveShowSummary } from './claude-handler';
 import { DEFAULT_SHOW_THINKING, DEFAULT_THINKING_ENABLED } from './user-settings-store';
 
 describe('buildThinkingOption', () => {
@@ -63,5 +63,24 @@ describe('buildBetaHeaders', () => {
   it('includes 1M beta for unknown / empty model name (conservative default)', () => {
     expect(buildBetaHeaders(undefined, true)).toContain('context-1m-2025-08-07');
     expect(buildBetaHeaders('', true)).toContain('context-1m-2025-08-07');
+  });
+});
+
+describe('resolveShowSummary', () => {
+  it('session override wins over user default (session=true, user=false)', () => {
+    expect(resolveShowSummary(true, false)).toBe(true);
+  });
+
+  it('session override wins over user default (session=false, user=true)', () => {
+    expect(resolveShowSummary(false, true)).toBe(false);
+  });
+
+  it('falls back to user default when no session override', () => {
+    expect(resolveShowSummary(undefined, false)).toBe(false);
+    expect(resolveShowSummary(undefined, true)).toBe(true);
+  });
+
+  it('falls back to DEFAULT_SHOW_THINKING when both undefined', () => {
+    expect(resolveShowSummary(undefined, undefined)).toBe(DEFAULT_SHOW_THINKING);
   });
 });

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -97,6 +97,22 @@ export function buildBetaHeaders(
   return needs1mBeta ? ['context-1m-2025-08-07'] : undefined;
 }
 
+/**
+ * Resolve the effective `showSummary` value for a turn.
+ *
+ * Precedence matches the rest of the stack (see stream-executor.ts):
+ *   session override → per-user default → DEFAULT_SHOW_THINKING.
+ *
+ * Extracted so that the session-level `%thinking_summary on|off` override is
+ * honored when building the `thinking` option for the SDK.
+ */
+export function resolveShowSummary(
+  sessionShowThinking: boolean | undefined,
+  userShowThinking: boolean | undefined,
+): boolean {
+  return sessionShowThinking ?? userShowThinking ?? DEFAULT_SHOW_THINKING;
+}
+
 export class ClaudeHandler {
   private logger = new Logger('ClaudeHandler');
   private mcpManager: McpManager;
@@ -812,9 +828,10 @@ export class ClaudeHandler {
         options.thinking = buildThinkingOption(false, false);
         this.logger.debug('Thinking disabled for session');
       } else {
-        const showSummary = slackContext?.user
+        const userShowThinking = slackContext?.user
           ? userSettingsStore.getUserShowThinking(slackContext.user)
-          : DEFAULT_SHOW_THINKING;
+          : undefined;
+        const showSummary = resolveShowSummary(session?.showThinking, userShowThinking);
         options.thinking = buildThinkingOption(true, showSummary);
         this.logger.debug('Thinking adaptive', { display: showSummary ? 'summarized' : 'omitted' });
       }

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -59,10 +59,43 @@ import { ensureValidCredentials, getCredentialStatus } from './credentials-manag
 import { McpConfigBuilder, type SlackContext } from './mcp-config-builder';
 import { getAvailablePersonas, PromptBuilder } from './prompt-builder';
 import { type CrashRecoveredSession, SessionExpiryCallbacks, SessionRegistry } from './session-registry';
-import { userSettingsStore } from './user-settings-store';
+import { DEFAULT_SHOW_THINKING, DEFAULT_THINKING_ENABLED, userSettingsStore } from './user-settings-store';
 
 // Re-export for backward compatibility
 export { getAvailablePersonas, SessionExpiryCallbacks };
+
+/**
+ * Build the `thinking` option value for a query.
+ *
+ * Opus 4.7 API default is `display: 'omitted'` — we must explicitly opt in to
+ * `'summarized'` to preserve Slack thinking-summary UX (stream-processor.ts:414
+ * filters out empty thinking blocks).
+ */
+export function buildThinkingOption(thinkingEnabled: boolean, showSummary: boolean): NonNullable<Options['thinking']> {
+  if (!thinkingEnabled) {
+    return { type: 'disabled' };
+  }
+  return { type: 'adaptive', display: showSummary ? 'summarized' : 'omitted' };
+}
+
+/**
+ * Build the `betas` header list for a query.
+ *
+ * 1M context window is GA on Opus 4.7, Opus 4.6, and Sonnet 4.6 — no beta header
+ * needed there. Still required for older Sonnet 4.5 / Haiku 4.5 when using
+ * API-key auth. Returns `undefined` when no beta headers are needed (or when
+ * using OAuth/subscription auth, which does not support the 1M beta header).
+ */
+export function buildBetaHeaders(
+  model: string | undefined,
+  hasApiKey: boolean,
+): NonNullable<Options['betas']> | undefined {
+  if (!hasApiKey) return undefined;
+  const activeModel = model || '';
+  const needs1mBeta =
+    !activeModel.includes('opus-4-7') && !activeModel.includes('opus-4-6') && !activeModel.includes('sonnet-4-6');
+  return needs1mBeta ? ['context-1m-2025-08-07'] : undefined;
+}
 
 export class ClaudeHandler {
   private logger = new Logger('ClaudeHandler');
@@ -761,22 +794,30 @@ export class ClaudeHandler {
       this.logger.debug('Using user default model', { model: userModel, user: slackContext.user });
     }
 
-    // Set effort level only when explicitly configured (max is Opus 4.6 only)
+    // Set effort level only when explicitly configured
     if (session?.effort) {
       options.effort = session.effort;
       this.logger.debug('Using session effort', { effort: session.effort });
     }
 
-    // Set thinking config (adaptive reasoning toggle)
+    // Set thinking config (adaptive reasoning toggle).
+    // Opus 4.7 API default is `display: 'omitted'` — we must explicitly opt in to
+    // `'summarized'` to preserve Slack thinking-summary UX (stream-processor.ts:414
+    // filters out empty thinking blocks).
     {
       const thinkingEnabled =
         session?.thinkingEnabled ??
-        (slackContext?.user ? userSettingsStore.getUserThinkingEnabled(slackContext.user) : true);
+        (slackContext?.user ? userSettingsStore.getUserThinkingEnabled(slackContext.user) : DEFAULT_THINKING_ENABLED);
       if (!thinkingEnabled) {
-        options.thinking = { type: 'disabled' };
+        options.thinking = buildThinkingOption(false, false);
         this.logger.debug('Thinking disabled for session');
+      } else {
+        const showSummary = slackContext?.user
+          ? userSettingsStore.getUserShowThinking(slackContext.user)
+          : DEFAULT_SHOW_THINKING;
+        options.thinking = buildThinkingOption(true, showSummary);
+        this.logger.debug('Thinking adaptive', { display: showSummary ? 'summarized' : 'omitted' });
       }
-      // When enabled, don't set thinking \u2014 SDK defaults to adaptive for Opus 4.6+
     }
 
     // Sandbox: enabled by default for all users. Only admin-toggled
@@ -889,10 +930,13 @@ export class ClaudeHandler {
       this.logger.debug('Starting new Claude conversation');
     }
 
-    // Enable 1M context window beta (applies to supported models).
-    // Only set for API key users \u2014 subscription users get a noisy warning from the SDK.
-    if (process.env.ANTHROPIC_API_KEY) {
-      options.betas = ['context-1m-2025-08-07'];
+    // 1M context window: GA on Opus 4.7, Opus 4.6, Sonnet 4.6 — no beta header needed there.
+    // Still required for older Sonnet 4.5 / Haiku 4.5 when using API-key auth.
+    {
+      const betas = buildBetaHeaders(options.model, !!process.env.ANTHROPIC_API_KEY);
+      if (betas) {
+        options.betas = betas;
+      }
     }
 
     // Set abort controller

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -71,7 +71,10 @@ export { getAvailablePersonas, SessionExpiryCallbacks };
  * `'summarized'` to preserve Slack thinking-summary UX (stream-processor.ts:414
  * filters out empty thinking blocks).
  */
-export function buildThinkingOption(thinkingEnabled: boolean, showSummary: boolean): NonNullable<Options['thinking']> {
+export function buildThinkingOption(
+  thinkingEnabled: boolean,
+  showSummary: boolean = false,
+): NonNullable<Options['thinking']> {
   if (!thinkingEnabled) {
     return { type: 'disabled' };
   }
@@ -817,15 +820,13 @@ export class ClaudeHandler {
     }
 
     // Set thinking config (adaptive reasoning toggle).
-    // Opus 4.7 API default is `display: 'omitted'` — we must explicitly opt in to
-    // `'summarized'` to preserve Slack thinking-summary UX (stream-processor.ts:414
-    // filters out empty thinking blocks).
+    // See `buildThinkingOption` JSDoc for why we explicitly opt into 'summarized'.
     {
       const thinkingEnabled =
         session?.thinkingEnabled ??
         (slackContext?.user ? userSettingsStore.getUserThinkingEnabled(slackContext.user) : DEFAULT_THINKING_ENABLED);
       if (!thinkingEnabled) {
-        options.thinking = buildThinkingOption(false, false);
+        options.thinking = buildThinkingOption(false);
         this.logger.debug('Thinking disabled for session');
       } else {
         const userShowThinking = slackContext?.user

--- a/src/deploy/main-env-bootstrap.test.ts
+++ b/src/deploy/main-env-bootstrap.test.ts
@@ -225,4 +225,28 @@ describe('main-env-bootstrap', () => {
     const settings = JSON.parse(fs.readFileSync(path.join(targetDir, 'data', 'user-settings.json'), 'utf8'));
     expect(settings.U1.defaultModel).toBe('claude-opus-4-6');
   });
+
+  it('preserves stored claude-sonnet-4-6 setting through normalize', async () => {
+    // Regression guard: VALID_MODELS must include sonnet-4-6 so Sonnet users
+    // are NOT silently force-migrated to the default Opus 4.7 model on boot.
+    const targetDir = makeTempDir('bootstrap-target-');
+
+    fs.mkdirSync(path.join(targetDir, 'data'), { recursive: true });
+    writeJson(path.join(targetDir, 'data', 'user-settings.json'), {
+      U1: {
+        userId: 'U1',
+        defaultDirectory: '',
+        bypassPermission: false,
+        persona: 'default',
+        defaultModel: 'claude-sonnet-4-6',
+        lastUpdated: '2026-03-12T00:00:00.000Z',
+        accepted: true,
+      },
+    });
+
+    await normalizeMainTargetData(targetDir);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(targetDir, 'data', 'user-settings.json'), 'utf8'));
+    expect(settings.U1.defaultModel).toBe('claude-sonnet-4-6');
+  });
 });

--- a/src/deploy/main-env-bootstrap.test.ts
+++ b/src/deploy/main-env-bootstrap.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { AVAILABLE_MODELS, DEFAULT_MODEL as STORE_DEFAULT_MODEL } from '../user-settings-store';
 import { bootstrapMainEnvironment, normalizeMainTargetData } from './main-env-bootstrap';
 
 function writeJson(filePath: string, value: unknown): void {
@@ -224,6 +225,42 @@ describe('main-env-bootstrap', () => {
 
     const settings = JSON.parse(fs.readFileSync(path.join(targetDir, 'data', 'user-settings.json'), 'utf8'));
     expect(settings.U1.defaultModel).toBe('claude-opus-4-6');
+  });
+
+  it('VALID_MODELS + DEFAULT_MODEL stay in sync with user-settings-store canonical list', async () => {
+    // Bootstrap duplicates these constants (to keep bootstrap import-lean). This
+    // drift guard catches the failure mode that originally shipped sonnet-4-6 as
+    // silently force-migrated to the default: any model added to the canonical
+    // AVAILABLE_MODELS must also be accepted here, otherwise users on that model
+    // will be rewritten to DEFAULT_MODEL on boot normalize.
+    const targetDir = makeTempDir('bootstrap-target-');
+    fs.mkdirSync(path.join(targetDir, 'data'), { recursive: true });
+    const settings: Record<string, Record<string, unknown>> = {};
+    for (const model of AVAILABLE_MODELS) {
+      // claude-opus-4-5-20251101 is intentionally still migrated (retired model).
+      if (model === 'claude-opus-4-5-20251101') continue;
+      const userId = `U-${model}`;
+      settings[userId] = {
+        userId,
+        defaultDirectory: '',
+        bypassPermission: false,
+        persona: 'default',
+        defaultModel: model,
+        lastUpdated: '2026-03-12T00:00:00.000Z',
+        accepted: true,
+      };
+    }
+    writeJson(path.join(targetDir, 'data', 'user-settings.json'), settings);
+
+    await normalizeMainTargetData(targetDir);
+
+    const after = JSON.parse(fs.readFileSync(path.join(targetDir, 'data', 'user-settings.json'), 'utf8'));
+    for (const model of AVAILABLE_MODELS) {
+      if (model === 'claude-opus-4-5-20251101') continue;
+      expect(after[`U-${model}`].defaultModel).toBe(model);
+    }
+    // And the store's canonical default is one of the accepted models.
+    expect(AVAILABLE_MODELS).toContain(STORE_DEFAULT_MODEL);
   });
 
   it('preserves stored claude-sonnet-4-6 setting through normalize', async () => {

--- a/src/deploy/main-env-bootstrap.test.ts
+++ b/src/deploy/main-env-bootstrap.test.ts
@@ -176,9 +176,53 @@ describe('main-env-bootstrap', () => {
     const sessions = JSON.parse(fs.readFileSync(path.join(targetDir, 'data', 'sessions.json'), 'utf8'));
 
     expect(settings.U1.accepted).toBe(true);
-    expect(settings.U1.defaultModel).toBe('claude-opus-4-6');
+    expect(settings.U1.defaultModel).toBe('claude-opus-4-7');
     expect(sessions[0].ownerId).toBe('U1');
     expect(sessions[0].state).toBe('MAIN');
     expect(sessions[0].workflow).toBe('default');
+  });
+
+  it('preserves stored claude-opus-4-7 setting through normalize', async () => {
+    const targetDir = makeTempDir('bootstrap-target-');
+
+    fs.mkdirSync(path.join(targetDir, 'data'), { recursive: true });
+    writeJson(path.join(targetDir, 'data', 'user-settings.json'), {
+      U1: {
+        userId: 'U1',
+        defaultDirectory: '',
+        bypassPermission: false,
+        persona: 'default',
+        defaultModel: 'claude-opus-4-7',
+        lastUpdated: '2026-03-12T00:00:00.000Z',
+        accepted: true,
+      },
+    });
+
+    await normalizeMainTargetData(targetDir);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(targetDir, 'data', 'user-settings.json'), 'utf8'));
+    expect(settings.U1.defaultModel).toBe('claude-opus-4-7');
+  });
+
+  it('preserves stored claude-opus-4-6 setting through normalize', async () => {
+    const targetDir = makeTempDir('bootstrap-target-');
+
+    fs.mkdirSync(path.join(targetDir, 'data'), { recursive: true });
+    writeJson(path.join(targetDir, 'data', 'user-settings.json'), {
+      U1: {
+        userId: 'U1',
+        defaultDirectory: '',
+        bypassPermission: false,
+        persona: 'default',
+        defaultModel: 'claude-opus-4-6',
+        lastUpdated: '2026-03-12T00:00:00.000Z',
+        accepted: true,
+      },
+    });
+
+    await normalizeMainTargetData(targetDir);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(targetDir, 'data', 'user-settings.json'), 'utf8'));
+    expect(settings.U1.defaultModel).toBe('claude-opus-4-6');
   });
 });

--- a/src/deploy/main-env-bootstrap.ts
+++ b/src/deploy/main-env-bootstrap.ts
@@ -4,8 +4,9 @@ import path from 'path';
 const DEFAULT_DEV_SOURCE_DIR = '/opt/soma-work/dev';
 const DEFAULT_LEGACY_ROOT_DIR = '/Users/dd/app.claude-code-slack-bot';
 const MARKER_FILE_NAME = '.main-bootstrap.json';
-const DEFAULT_MODEL = 'claude-opus-4-6';
+const DEFAULT_MODEL = 'claude-opus-4-7';
 const VALID_MODELS = new Set([
+  'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-sonnet-4-5-20250929',
   'claude-opus-4-5-20251101',

--- a/src/deploy/main-env-bootstrap.ts
+++ b/src/deploy/main-env-bootstrap.ts
@@ -8,6 +8,7 @@ const DEFAULT_MODEL = 'claude-opus-4-7';
 const VALID_MODELS = new Set([
   'claude-opus-4-7',
   'claude-opus-4-6',
+  'claude-sonnet-4-6',
   'claude-sonnet-4-5-20250929',
   'claude-opus-4-5-20251101',
   'claude-haiku-4-5-20251001',

--- a/src/metrics/__tests__/model-registry.test.ts
+++ b/src/metrics/__tests__/model-registry.test.ts
@@ -10,12 +10,23 @@ import {
 
 describe('model-registry', () => {
   describe('PRICING_VERSION', () => {
-    it('should be 2026-04-16', () => {
-      expect(PRICING_VERSION).toBe('2026-04-16');
+    it('should be 2026-04-17', () => {
+      expect(PRICING_VERSION).toBe('2026-04-17');
     });
   });
 
   describe('getModelSpec', () => {
+    it('returns Opus 4.7 spec', () => {
+      const spec = getModelSpec('claude-opus-4-7');
+      expect(spec.pricing.inputPerMTok).toBe(5);
+      expect(spec.pricing.outputPerMTok).toBe(25);
+      expect(spec.pricing.cacheReadPerMTok).toBe(0.5);
+      expect(spec.pricing.cache5minWritePerMTok).toBe(6.25);
+      expect(spec.pricing.cache1hrWritePerMTok).toBe(10);
+      expect(spec.contextWindow).toBe(1_000_000);
+      expect(spec.maxOutput).toBe(128_000);
+    });
+
     it('returns Opus 4.6 spec', () => {
       const spec = getModelSpec('claude-opus-4-6-20250414');
       expect(spec.pricing.inputPerMTok).toBe(5);
@@ -71,6 +82,11 @@ describe('model-registry', () => {
   });
 
   describe('calculateTokenCost', () => {
+    it('calculates Opus 4.7 cost correctly', () => {
+      const cost = calculateTokenCost('claude-opus-4-7', 1_000_000, 1_000_000, 1_000_000, 1_000_000);
+      expect(cost).toBeCloseTo(36.75, 2);
+    });
+
     it('calculates Opus 4.6 cost correctly', () => {
       // 1M input + 1M output + 1M cache read + 1M cache create
       const cost = calculateTokenCost('claude-opus-4-6-20250414', 1_000_000, 1_000_000, 1_000_000, 1_000_000);

--- a/src/metrics/model-registry.ts
+++ b/src/metrics/model-registry.ts
@@ -1,10 +1,10 @@
 /**
  * Unified model registry — single source of truth for pricing, context windows, and max output.
  * Source: https://docs.anthropic.com/en/docs/about-claude/models
- * Last updated: 2026-04-16
+ * Last updated: 2026-04-17
  */
 
-export const PRICING_VERSION = '2026-04-16';
+export const PRICING_VERSION = '2026-04-17';
 
 export interface ModelPricingSpec {
   inputPerMTok: number;
@@ -27,6 +27,21 @@ export interface ModelSpec {
  * Order matters — first match wins.
  */
 const MODEL_REGISTRY: [pattern: string, spec: ModelSpec][] = [
+  // Claude 4.7
+  [
+    'opus-4-7',
+    {
+      pricing: {
+        inputPerMTok: 5,
+        outputPerMTok: 25,
+        cacheReadPerMTok: 0.5,
+        cache5minWritePerMTok: 6.25,
+        cache1hrWritePerMTok: 10,
+      },
+      contextWindow: 1_000_000,
+      maxOutput: 128_000,
+    },
+  ],
   // Claude 4.6
   [
     'opus-4-6',

--- a/src/prompt/workflows/onboarding.prompt
+++ b/src/prompt/workflows/onboarding.prompt
@@ -42,7 +42,7 @@ Check `<context>` for `jira-name`:
 
 ### 3. Settings Confirmation
 Explain current settings from `<context>` first, then explain defaults:
-- Model default: Opus 4.6
+- Model default: Opus 4.7
 - Persona default: `default`
 - Permission bypass default: off
 

--- a/src/session-registry.test.ts
+++ b/src/session-registry.test.ts
@@ -73,6 +73,47 @@ describe('SessionRegistry persistence', () => {
     expect(restored?.threadRootTs).toBe('777.888');
   });
 
+  it('backfills effort from user default on legacy sessions without effort field', () => {
+    // Simulate a sessions.json written before the effort field existed. Without
+    // backfill, the restored session would have effort=undefined and the handler
+    // would fall through to the SDK internal default instead of the app's
+    // DEFAULT_EFFORT ('xhigh'). See review finding on PR #527 (risk vector P3).
+    const sessionsFile = `${TEST_DATA_DIR}/sessions.json`;
+    fs.writeFileSync(
+      sessionsFile,
+      JSON.stringify(
+        [
+          {
+            key: 'C-legacy-170.000',
+            ownerId: 'U-legacy',
+            userId: 'U-legacy',
+            channelId: 'C-legacy',
+            threadTs: '170.000',
+            sessionId: 'legacy-session-1',
+            isActive: true,
+            lastActivity: new Date().toISOString(),
+            state: 'MAIN',
+            workflow: 'default',
+            // effort deliberately omitted to mimic legacy payload
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+
+    const reader = new SessionRegistry();
+    const loaded = reader.loadSessions();
+    const restored = reader.getSession('C-legacy', '170.000');
+
+    // Sanity: the session must actually be loaded (not filtered out by age).
+    expect(loaded).toBe(1);
+    expect(restored).toBeDefined();
+    // DEFAULT_EFFORT is 'xhigh' per user-settings-store; user has no stored
+    // effort override so legacy restore should backfill to that default.
+    expect(restored?.effort).toBe('xhigh');
+  });
+
   it('persists linkHistory and sequence for session resources', () => {
     const writer = new SessionRegistry();
     const session = writer.createSession('U123', 'Tester', 'C123', '171.003');

--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -1434,8 +1434,9 @@ export class SessionRegistry {
           }
         }
 
+        const resolvedOwnerId = serialized.ownerId || serialized.userId;
         const session: ConversationSession = {
-          ownerId: serialized.ownerId || serialized.userId, // Fallback for legacy sessions
+          ownerId: resolvedOwnerId, // Fallback for legacy sessions
           ownerName: serialized.ownerName,
           userId: serialized.userId, // Legacy field
           channelId: serialized.channelId,
@@ -1454,7 +1455,10 @@ export class SessionRegistry {
           sleepStartedAt,
           activityState: serialized.activityState || 'idle', // Preserve saved state for correct dashboard display; crash recovery handles auto-resume
           logVerbosity: serialized.logVerbosity,
-          effort: serialized.effort,
+          // Backfill effort from user default when missing on legacy sessions. Without this,
+          // a session saved before the effort field existed would resume on SDK internal
+          // default instead of our configured DEFAULT_EFFORT ('xhigh').
+          effort: serialized.effort ?? userSettingsStore.getUserDefaultEffort(resolvedOwnerId),
           thinkingEnabled: serialized.thinkingEnabled,
           showThinking: serialized.showThinking,
           // Clear stale messageTs/renderKey on restore — the Slack message may have been

--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -1455,9 +1455,8 @@ export class SessionRegistry {
           sleepStartedAt,
           activityState: serialized.activityState || 'idle', // Preserve saved state for correct dashboard display; crash recovery handles auto-resume
           logVerbosity: serialized.logVerbosity,
-          // Backfill effort from user default when missing on legacy sessions. Without this,
-          // a session saved before the effort field existed would resume on SDK internal
-          // default instead of our configured DEFAULT_EFFORT ('xhigh').
+          // Backfill effort on legacy sessions so resume uses DEFAULT_EFFORT
+          // rather than the SDK default.
           effort: serialized.effort ?? userSettingsStore.getUserDefaultEffort(resolvedOwnerId),
           thinkingEnabled: serialized.thinkingEnabled,
           showThinking: serialized.showThinking,

--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -28,7 +28,7 @@ import type {
   SessionState,
   WorkflowType,
 } from './types';
-import { userSettingsStore } from './user-settings-store';
+import { type EffortLevel, userSettingsStore } from './user-settings-store';
 
 const SESSIONS_FILE = path.join(DATA_DIR, 'sessions.json');
 
@@ -87,7 +87,7 @@ interface SerializedSession {
   // Log verbosity bitmask
   logVerbosity?: number;
   // Effort level for Claude thinking
-  effort?: 'low' | 'medium' | 'high' | 'max';
+  effort?: EffortLevel;
   // Extended thinking (adaptive reasoning) toggle
   thinkingEnabled?: boolean;
   // Thinking summary display toggle

--- a/src/slack/command-parser.test.ts
+++ b/src/slack/command-parser.test.ts
@@ -898,6 +898,7 @@ describe('CommandParser', () => {
       'effort low',
       'effort medium',
       'effort high',
+      'effort xhigh',
       'effort max',
       '/effort',
       '/effort high',
@@ -930,7 +931,7 @@ describe('CommandParser', () => {
       expect(CommandParser.parseEffortCommand('effort status')).toEqual({ action: 'status' });
     });
 
-    it.each(['low', 'medium', 'high', 'max'])('parses "effort %s" as set', (level) => {
+    it.each(['low', 'medium', 'high', 'xhigh', 'max'])('parses "effort %s" as set', (level) => {
       expect(CommandParser.parseEffortCommand(`effort ${level}`)).toEqual({ action: 'set', level });
     });
 
@@ -1020,6 +1021,14 @@ describe('CommandParser', () => {
         type: 'effort',
         action: 'set',
         level: 'high',
+      });
+    });
+
+    it('parses "%effort xhigh" as effort set', () => {
+      expect(CommandParser.parseSessionCommand('%effort xhigh')).toEqual({
+        type: 'effort',
+        action: 'set',
+        level: 'xhigh',
       });
     });
 

--- a/src/slack/command-parser.ts
+++ b/src/slack/command-parser.ts
@@ -2,6 +2,8 @@
  * Command parsing utilities for Slack bot commands
  */
 
+import { EFFORT_LEVELS } from '../user-settings-store';
+
 export type CctAction = { action: 'status' } | { action: 'set'; target: string } | { action: 'next' };
 
 export type BypassAction = 'on' | 'off' | 'status';
@@ -1051,7 +1053,7 @@ export class CommandParser {
       '• `verbosity` - Show current log verbosity',
       '• `verbosity <level>` - Set log verbosity (minimal/compact/detail/verbose)',
       '• `effort` - Show current default effort level',
-      '• `effort <level>` - Set default effort (low/medium/high/max). Persists for all future sessions.',
+      `• \`effort <level>\` - Set default effort (${EFFORT_LEVELS.join('/')}). Persists for all future sessions.`,
       '',
       '*LLM Chat Config:*',
       '• `show llm_chat` - Show current llm_chat model configuration',
@@ -1066,7 +1068,7 @@ export class CommandParser {
       '• `%model` - Show session model',
       '• `%model <name>` - Change model for this session only',
       '• `%effort` - Show session effort level',
-      '• `%effort <level>` - Change effort for this session only (low/medium/high/max)',
+      `• \`%effort <level>\` - Change effort for this session only (${EFFORT_LEVELS.join('/')})`,
       '• `%verbosity` - Show session verbosity',
       '• `%verbosity <level>` - Change verbosity for this session only',
       '• `%thinking` - Show extended thinking (adaptive reasoning) status',

--- a/src/slack/commands/effort-handler.test.ts
+++ b/src/slack/commands/effort-handler.test.ts
@@ -5,13 +5,13 @@ const { mockSetUserDefaultEffort, mockGetUserDefaultEffort, mockResolveEffortInp
   mockSetUserDefaultEffort: vi.fn(),
   mockGetUserDefaultEffort: vi.fn().mockReturnValue('high'),
   mockResolveEffortInput: vi.fn((v: string) =>
-    ['low', 'medium', 'high', 'max'].includes(v) ? (v as 'low' | 'medium' | 'high' | 'max') : null,
+    ['low', 'medium', 'high', 'xhigh', 'max'].includes(v) ? (v as 'low' | 'medium' | 'high' | 'xhigh' | 'max') : null,
   ),
 }));
 
 vi.mock('../../user-settings-store', () => ({
   DEFAULT_EFFORT: 'high',
-  EFFORT_LEVELS: ['low', 'medium', 'high', 'max'] as const,
+  EFFORT_LEVELS: ['low', 'medium', 'high', 'xhigh', 'max'] as const,
   userSettingsStore: {
     getUserDefaultEffort: mockGetUserDefaultEffort,
     setUserDefaultEffort: mockSetUserDefaultEffort,
@@ -80,7 +80,7 @@ describe('EffortHandler', () => {
   });
 
   describe('execute — set', () => {
-    it.each(['low', 'medium', 'high', 'max'])('persists valid level "%s"', async (level) => {
+    it.each(['low', 'medium', 'high', 'xhigh', 'max'])('persists valid level "%s"', async (level) => {
       const ctx = makeCtx(`effort ${level}`);
       const result = await handler.execute(ctx);
       expect(result.handled).toBe(true);

--- a/src/slack/commands/session-command-handler.ts
+++ b/src/slack/commands/session-command-handler.ts
@@ -1,6 +1,8 @@
 import {
+  DEFAULT_EFFORT,
   DEFAULT_SHOW_THINKING,
   DEFAULT_THINKING_ENABLED,
+  EFFORT_LEVELS,
   MODEL_ALIASES,
   type ModelId,
   userSettingsStore,
@@ -284,7 +286,7 @@ export class SessionCommandHandler implements CommandHandler {
 
   private async setSessionEffort(ctx: CommandContext, session: any, input: string): Promise<CommandResult> {
     const { say, threadTs } = ctx;
-    const valid = ['low', 'medium', 'high', 'max'] as const;
+    const valid = EFFORT_LEVELS;
     const normalized = input.toLowerCase();
 
     if (!valid.includes(normalized as any)) {
@@ -299,7 +301,7 @@ export class SessionCommandHandler implements CommandHandler {
     session.effort = normalized as (typeof valid)[number];
     const warning = normalized === 'max' ? '\n_⚠️ `max` requires API key — will fail on Claude.ai subscription_' : '';
     await say({
-      text: `⚡ *Session Effort Changed*\n\nThis session now uses: *${normalized}*${warning}\n_Use \`%effort high\` to restore default._`,
+      text: `⚡ *Session Effort Changed*\n\nThis session now uses: *${normalized}*${warning}\n_Use \`%effort ${DEFAULT_EFFORT}\` to restore default._`,
       thread_ts: threadTs,
     });
     return { handled: true };

--- a/src/slack/pipeline/session-initializer-midthread.test.ts
+++ b/src/slack/pipeline/session-initializer-midthread.test.ts
@@ -29,16 +29,17 @@ vi.mock('../../user-settings-store', () => ({
     loadSlackJiraMapping: vi.fn(),
     getSlackJiraMapping: vi.fn().mockReturnValue({}),
     findJiraAccountBySlackId: vi.fn().mockReturnValue(undefined),
-    getModelDisplayName: vi.fn().mockReturnValue('Opus 4.6'),
+    getModelDisplayName: vi.fn().mockReturnValue('Opus 4.7'),
     getUserSessionTheme: vi.fn().mockReturnValue('D'),
   },
   AVAILABLE_MODELS: [
+    'claude-opus-4-7',
     'claude-opus-4-6',
     'claude-sonnet-4-5-20250929',
     'claude-opus-4-5-20251101',
     'claude-haiku-4-5-20251001',
   ],
-  DEFAULT_MODEL: 'claude-opus-4-6',
+  DEFAULT_MODEL: 'claude-opus-4-7',
 }));
 
 vi.mock('../../admin-utils', () => ({

--- a/src/slack/pipeline/session-initializer-onboarding.test.ts
+++ b/src/slack/pipeline/session-initializer-onboarding.test.ts
@@ -29,16 +29,17 @@ vi.mock('../../user-settings-store', () => ({
     loadSlackJiraMapping: vi.fn(),
     getSlackJiraMapping: vi.fn().mockReturnValue({}),
     findJiraAccountBySlackId: vi.fn().mockReturnValue(undefined),
-    getModelDisplayName: vi.fn().mockReturnValue('Opus 4.6'),
+    getModelDisplayName: vi.fn().mockReturnValue('Opus 4.7'),
     getUserSessionTheme: vi.fn().mockReturnValue('D'),
   },
   AVAILABLE_MODELS: [
+    'claude-opus-4-7',
     'claude-opus-4-6',
     'claude-sonnet-4-5-20250929',
     'claude-opus-4-5-20251101',
     'claude-haiku-4-5-20251001',
   ],
-  DEFAULT_MODEL: 'claude-opus-4-6',
+  DEFAULT_MODEL: 'claude-opus-4-7',
 }));
 
 vi.mock('../../admin-utils', () => ({

--- a/src/slack/pipeline/session-initializer-routing.test.ts
+++ b/src/slack/pipeline/session-initializer-routing.test.ts
@@ -8,14 +8,14 @@ vi.mock('../../user-settings-store', () => ({
       defaultDirectory: '',
       bypassPermission: false,
       persona: 'default',
-      defaultModel: 'claude-opus-4-6',
+      defaultModel: 'claude-opus-4-7',
       lastUpdated: new Date().toISOString(),
     }),
     createPendingUser: vi.fn(),
-    getModelDisplayName: vi.fn().mockReturnValue('Opus 4.6'),
+    getModelDisplayName: vi.fn().mockReturnValue('Opus 4.7'),
     getUserSessionTheme: vi.fn().mockReturnValue('D'),
   },
-  DEFAULT_MODEL: 'claude-opus-4-6',
+  DEFAULT_MODEL: 'claude-opus-4-7',
 }));
 
 vi.mock('../../admin-utils', () => ({

--- a/src/slack/pipeline/session-initializer-workspace.test.ts
+++ b/src/slack/pipeline/session-initializer-workspace.test.ts
@@ -8,14 +8,14 @@ vi.mock('../../user-settings-store', () => ({
       defaultDirectory: '',
       bypassPermission: false,
       persona: 'default',
-      defaultModel: 'claude-opus-4-6',
+      defaultModel: 'claude-opus-4-7',
       lastUpdated: new Date().toISOString(),
     }),
     createPendingUser: vi.fn(),
-    getModelDisplayName: vi.fn().mockReturnValue('Opus 4.6'),
+    getModelDisplayName: vi.fn().mockReturnValue('Opus 4.7'),
     getUserSessionTheme: vi.fn().mockReturnValue('D'),
   },
-  DEFAULT_MODEL: 'claude-opus-4-6',
+  DEFAULT_MODEL: 'claude-opus-4-7',
 }));
 
 vi.mock('../../admin-utils', () => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ import type {
   UserChoices,
   WorkflowType,
 } from 'somalib/model-commands/session-types';
+import type { EffortLevel } from './user-settings-store';
 
 /**
  * Session state machine states
@@ -167,8 +168,8 @@ export interface ConversationSession {
   actionPanel?: ActionPanelState;
   // Log verbosity bitmask (controls which output types are shown in Slack)
   logVerbosity?: number;
-  // Effort level for Claude thinking (low/medium/high/max)
-  effort?: 'low' | 'medium' | 'high' | 'max';
+  // Effort level for Claude thinking
+  effort?: EffortLevel;
   // Whether extended thinking (adaptive reasoning) is enabled for this session
   thinkingEnabled?: boolean;
   // Whether thinking output is shown in Slack for this session

--- a/src/user-settings-store-acceptance.test.ts
+++ b/src/user-settings-store-acceptance.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { UserSettingsStore } from './user-settings-store';
+import { DEFAULT_EFFORT, UserSettingsStore } from './user-settings-store';
 
 // Trace: Scenario 1 — Existing User Migration
 // Trace: Scenario 2/3 — Acceptance gate data model
@@ -147,6 +147,65 @@ describe('UserSettingsStore — acceptance', () => {
       const store = new UserSettingsStore(tmpDir);
 
       expect(store.isUserAccepted('U_UNKNOWN')).toBe(false);
+    });
+  });
+
+  describe('defaultEffort coercion on load', () => {
+    it('keeps valid stored defaultEffort unchanged', () => {
+      const data = {
+        U1: {
+          userId: 'U1',
+          defaultDirectory: '',
+          bypassPermission: false,
+          persona: 'default',
+          defaultModel: 'claude-opus-4-7',
+          defaultEffort: 'max',
+          lastUpdated: '2026-01-01',
+          accepted: true,
+        },
+      };
+      fs.writeFileSync(`${tmpDir}/user-settings.json`, JSON.stringify(data));
+
+      const store = new UserSettingsStore(tmpDir);
+      expect(store.getUserDefaultEffort('U1')).toBe('max');
+    });
+
+    it('coerces unknown defaultEffort to DEFAULT_EFFORT', () => {
+      const data = {
+        U1: {
+          userId: 'U1',
+          defaultDirectory: '',
+          bypassPermission: false,
+          persona: 'default',
+          defaultModel: 'claude-opus-4-7',
+          defaultEffort: 'bogus',
+          lastUpdated: '2026-01-01',
+          accepted: true,
+        },
+      };
+      fs.writeFileSync(`${tmpDir}/user-settings.json`, JSON.stringify(data));
+
+      const store = new UserSettingsStore(tmpDir);
+      expect(store.getUserDefaultEffort('U1')).toBe(DEFAULT_EFFORT);
+    });
+
+    it('accepts xhigh as a valid stored value', () => {
+      const data = {
+        U1: {
+          userId: 'U1',
+          defaultDirectory: '',
+          bypassPermission: false,
+          persona: 'default',
+          defaultModel: 'claude-opus-4-7',
+          defaultEffort: 'xhigh',
+          lastUpdated: '2026-01-01',
+          accepted: true,
+        },
+      };
+      fs.writeFileSync(`${tmpDir}/user-settings.json`, JSON.stringify(data));
+
+      const store = new UserSettingsStore(tmpDir);
+      expect(store.getUserDefaultEffort('U1')).toBe('xhigh');
     });
   });
 });

--- a/src/user-settings-store.ts
+++ b/src/user-settings-store.ts
@@ -35,12 +35,13 @@ export const MODEL_ALIASES: Record<string, ModelId> = {
 export const DEFAULT_MODEL: ModelId = 'claude-opus-4-7';
 
 // Effort levels
-export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 export const DEFAULT_EFFORT: EffortLevel = 'xhigh';
-export const EFFORT_LEVELS: readonly EffortLevel[] = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
 
+/** Coerce arbitrary stored input to a known EffortLevel, falling back to DEFAULT_EFFORT. */
 export function coerceEffort(value: unknown): EffortLevel {
-  return (EFFORT_LEVELS as readonly string[]).includes(value as string) ? (value as EffortLevel) : DEFAULT_EFFORT;
+  return (EFFORT_LEVELS as readonly unknown[]).includes(value) ? (value as EffortLevel) : DEFAULT_EFFORT;
 }
 
 // Thinking (adaptive reasoning) toggle

--- a/src/user-settings-store.ts
+++ b/src/user-settings-store.ts
@@ -9,6 +9,7 @@ const logger = new Logger('UserSettingsStore');
 
 // Available models
 export const AVAILABLE_MODELS = [
+  'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-sonnet-4-6',
   'claude-sonnet-4-5-20250929',
@@ -23,19 +24,24 @@ export const MODEL_ALIASES: Record<string, ModelId> = {
   sonnet: 'claude-sonnet-4-6',
   'sonnet-4.6': 'claude-sonnet-4-6',
   'sonnet-4.5': 'claude-sonnet-4-5-20250929',
-  opus: 'claude-opus-4-6',
+  opus: 'claude-opus-4-7',
+  'opus-4.7': 'claude-opus-4-7',
   'opus-4.6': 'claude-opus-4-6',
   'opus-4.5': 'claude-opus-4-5-20251101',
   haiku: 'claude-haiku-4-5-20251001',
   'haiku-4.5': 'claude-haiku-4-5-20251001',
 };
 
-export const DEFAULT_MODEL: ModelId = 'claude-opus-4-6';
+export const DEFAULT_MODEL: ModelId = 'claude-opus-4-7';
 
 // Effort levels
-export type EffortLevel = 'low' | 'medium' | 'high' | 'max';
-export const DEFAULT_EFFORT: EffortLevel = 'high';
-export const EFFORT_LEVELS: readonly EffortLevel[] = ['low', 'medium', 'high', 'max'] as const;
+export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export const DEFAULT_EFFORT: EffortLevel = 'xhigh';
+export const EFFORT_LEVELS: readonly EffortLevel[] = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+
+export function coerceEffort(value: unknown): EffortLevel {
+  return (EFFORT_LEVELS as readonly string[]).includes(value as string) ? (value as EffortLevel) : DEFAULT_EFFORT;
+}
 
 // Thinking (adaptive reasoning) toggle
 export const DEFAULT_THINKING_ENABLED = true;
@@ -195,6 +201,14 @@ export class UserSettingsStore {
           if ((userSettings as any).accepted === undefined) {
             userSettings.accepted = true;
             didUpdate = true;
+          }
+          // Coerce unknown defaultEffort values to DEFAULT_EFFORT
+          if (userSettings.defaultEffort !== undefined) {
+            const coerced = coerceEffort(userSettings.defaultEffort);
+            if (coerced !== userSettings.defaultEffort) {
+              userSettings.defaultEffort = coerced;
+              didUpdate = true;
+            }
           }
         }
         if (didUpdate) {
@@ -653,6 +667,8 @@ export class UserSettingsStore {
    */
   getModelDisplayName(model: ModelId): string {
     switch (model) {
+      case 'claude-opus-4-7':
+        return 'Opus 4.7';
       case 'claude-sonnet-4-6':
         return 'Sonnet 4.6';
       case 'claude-sonnet-4-5-20250929':


### PR DESCRIPTION
Closes #526

## Summary
- Upgrade `@anthropic-ai/claude-agent-sdk` `^0.2.97` → `^0.2.111` (xhigh / thinking.display / taskBudget GA); model default, aliases, pricing, effort types all flipped to Opus 4.7 per [migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide.md).
- Explicit `thinking: { type: 'adaptive', display: 'summarized' }` to preserve Slack thinking-summary UX against Opus 4.7's new `omitted` API default (would be silently dropped at `stream-processor.ts:414`).
- Drop `context-1m-2025-08-07` beta header for 1M-GA models (opus-4-7, opus-4-6, sonnet-4-6); keep for older Sonnet 4.5 / Haiku 4.5 on API-key auth.
- Effort SSOT: `EffortLevel` / `EFFORT_LEVELS` now single-sourced in `user-settings-store.ts`; removed 4 sites that duplicated the literal union.

## Scope
- **Opus-only.** Sonnet/Haiku model IDs untouched. SDK bump is a shared dependency — unavoidable, baseline tests verified green.
- **Full-plus.** Model ID + all breaking changes + recommended tweaks (xhigh default, beta-header cleanup, thinking-display guardrail).
- **Rollback path preserved.** `opus-4.6` alias still resolves to `claude-opus-4-6`; 4.6 remains in `AVAILABLE_MODELS`.

## Release notes
- Default model: **Opus 4.6 → Opus 4.7** (same pricing, adaptive thinking off-default unless we opt in — we do).
- Default effort: **high → xhigh** (migration guide recommendation for coding/agentic). Stored effort preserved.
- Unknown stored `defaultEffort` coerced to DEFAULT_EFFORT on load.
- New tokenizer can use 1.0–1.35× more tokens — monitor dashboard.

## Test plan
- [x] `npm run lint` → exit 0.
- [x] `npm test` → 3810 passed, 5 skipped, 0 failed (baseline 3788 → +22 new assertions).
- [x] New: `claude-handler.test.ts` (thinking matrix + beta gating), Opus 4.7 spec in model-registry, xhigh in command-parser/effort-handler, defaultEffort coercion in user-settings-store-acceptance.
- [ ] Dev smoke: default session resolves to Opus 4.7 + xhigh + visible thinking + no 1M beta; `opus-4.6` rollback works; `%effort xhigh` persists.
- [ ] `package-lock.json` diff reviewed.

## Out-of-scope (follow-up)
- Sonnet 4.7 / Haiku 4.7, `VALID_MODELS` sonnet-4-6 drift, `taskBudget` alpha adoption, legacy 4.6/4.5 removal, prompt audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <z@2lab.ai>