### PR TITLE
fix(slack): restore bare `[cmd] [args]` routing — remove Phase 1 gates

### DIFF
--- a/src/slack/commands/command-router.test.ts
+++ b/src/slack/commands/command-router.test.ts
@@ -20,8 +20,45 @@ vi.mock('../../metrics', () => ({
   }),
 }));
 
+import { userSettingsStore } from '../../user-settings-store';
+import { BypassHandler } from './bypass-handler';
 import { CommandRouter } from './command-router';
+import { EffortHandler } from './effort-handler';
+import { EmailHandler } from './email-handler';
+import { LlmChatHandler } from './llm-chat-handler';
+import { ModelHandler } from './model-handler';
 import { PersonaHandler } from './persona-handler';
+import { PromptHandler } from './prompt-handler';
+import { RateHandler } from './rate-handler';
+import { VerbosityHandler } from './verbosity-handler';
+
+/**
+ * Default command-router deps — handlers need these present on construction.
+ * Individual tests override workingDirManager / slackApi as needed.
+ */
+function buildDeps(overrides: Record<string, any> = {}): any {
+  return {
+    workingDirManager: {
+      parseSetCommand: vi.fn().mockReturnValue(null),
+      isGetCommand: vi.fn().mockReturnValue(false),
+      getWorkingDirectory: vi.fn().mockReturnValue('/tmp/default'),
+      formatDirectoryMessage: vi.fn().mockReturnValue('📁 /tmp/default'),
+    },
+    mcpManager: { getPluginManager: vi.fn() },
+    claudeHandler: {
+      getSession: vi.fn().mockReturnValue(null),
+    },
+    sessionUiManager: {},
+    requestCoordinator: {},
+    slackApi: {
+      postSystemMessage: vi.fn().mockResolvedValue(undefined),
+      getClient: vi.fn().mockReturnValue({}),
+    },
+    reactionManager: {},
+    contextWindowManager: {},
+    ...overrides,
+  };
+}
 
 /**
  * Regression guard (PR #509, codex P1): after stripping the `/z` prefix and
@@ -43,19 +80,7 @@ describe('CommandRouter — /z → translated text is routed to handler', () => 
     const executeSpy = vi.spyOn(PersonaHandler.prototype, 'execute').mockResolvedValue({ handled: true });
 
     const say = vi.fn().mockResolvedValue(undefined);
-    const deps: any = {
-      workingDirManager: {
-        parseSetCommand: vi.fn().mockReturnValue(null),
-        isGetCommand: vi.fn().mockReturnValue(false),
-      },
-      mcpManager: { getPluginManager: vi.fn() },
-      claudeHandler: {},
-      sessionUiManager: {},
-      requestCoordinator: {},
-      slackApi: {},
-      reactionManager: {},
-      contextWindowManager: {},
-    };
+    const deps = buildDeps();
     const router = new CommandRouter(deps);
     const ctx: any = {
       text: '/z persona set linus',
@@ -68,7 +93,7 @@ describe('CommandRouter — /z → translated text is routed to handler', () => 
     const result = await router.route(ctx);
 
     // PersonaHandler was considered with the translated text
-    const personaCalls = canHandleSpy.mock.calls.filter((args) => /persona/.test(args[0] ?? ''));
+    const personaCalls = canHandleSpy.mock.calls.filter((args: any[]) => /persona/.test(args[0] ?? ''));
     expect(personaCalls.length).toBeGreaterThan(0);
     for (const call of personaCalls) {
       expect(call[0]).not.toContain('/z');
@@ -79,5 +104,301 @@ describe('CommandRouter — /z → translated text is routed to handler', () => 
 
     // ctx.text is left in the rewritten form for downstream handlers
     expect(ctx.text).toBe('persona set linus');
+  });
+});
+
+/**
+ * Issue #530: PR #509 introduced Phase 1 tombstone gates that blocked bare
+ * canonical commands like `model opus-4.7`, `verbosity detail`, etc. in
+ * thread/app_mention surfaces. These gates were removed so handlers match
+ * bare `[cmd] [args]` input directly again (pre-#509 behavior restored).
+ */
+describe('CommandRouter — bare [cmd] [args] routing (restored #530)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runBare(text: string): Promise<{ result: any; ctx: any; say: any }> {
+    const say = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps();
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text,
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say,
+    };
+    const result = await router.route(ctx);
+    return { result, ctx, say };
+  }
+
+  it('bare "model opus-4.7" → ModelHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(ModelHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('model opus-4.7');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "verbosity detail" → VerbosityHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(VerbosityHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('verbosity detail');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "persona set elon" → PersonaHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(PersonaHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('persona set elon');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "bypass on" → BypassHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(BypassHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('bypass on');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "show email" → EmailHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(EmailHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('show email');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "set email user@example.com" → EmailHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(EmailHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('set email user@example.com');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "show prompt" → PromptHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(PromptHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('show prompt');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "show llm_chat" → LlmChatHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(LlmChatHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('show llm_chat');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+});
+
+/**
+ * Issue #530: cwd is a special case — Phase 2 (#507) renders a Block Kit card
+ * via `renderCwdCard` + `slackApi.postSystemMessage`. Set-path commands
+ * (`set directory <p>`, `cwd <p>`) post a plain "비활성화" notice.
+ */
+describe('CommandRouter — cwd bare routing (restored #530)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('bare "cwd" → CwdHandler.execute → renderCwdCard Block Kit card posted', async () => {
+    const postSystemMessage = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps({
+      workingDirManager: {
+        parseSetCommand: vi.fn().mockReturnValue(null),
+        isGetCommand: vi.fn().mockImplementation((t: string) => t.trim() === 'cwd'),
+        getWorkingDirectory: vi.fn().mockReturnValue('/tmp/user1'),
+        formatDirectoryMessage: vi.fn().mockReturnValue('📁 /tmp/user1'),
+      },
+      slackApi: {
+        postSystemMessage,
+        getClient: vi.fn().mockReturnValue({}),
+      },
+    });
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text: 'cwd',
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await router.route(ctx);
+
+    expect(result.handled).toBe(true);
+    expect(postSystemMessage).toHaveBeenCalledTimes(1);
+    const [channelArg, , optsArg] = postSystemMessage.mock.calls[0];
+    expect(channelArg).toBe('C1');
+    expect(optsArg).toEqual(expect.objectContaining({ blocks: expect.any(Array) }));
+  });
+
+  it('bare "set directory /tmp" → CwdHandler.execute → "비활성화" postSystemMessage', async () => {
+    const postSystemMessage = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps({
+      workingDirManager: {
+        parseSetCommand: vi.fn().mockImplementation((t: string) => (t.includes('/tmp') ? '/tmp' : null)),
+        isGetCommand: vi.fn().mockReturnValue(false),
+        getWorkingDirectory: vi.fn().mockReturnValue('/tmp/user1'),
+        formatDirectoryMessage: vi.fn().mockReturnValue('📁 /tmp/user1'),
+      },
+      slackApi: {
+        postSystemMessage,
+        getClient: vi.fn().mockReturnValue({}),
+      },
+    });
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text: 'set directory /tmp',
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await router.route(ctx);
+
+    expect(result.handled).toBe(true);
+    expect(postSystemMessage).toHaveBeenCalledTimes(1);
+    const [, textArg] = postSystemMessage.mock.calls[0];
+    expect(textArg).toContain('비활성화되었습니다');
+  });
+
+  it('bare "cwd /tmp" → CwdHandler.execute → "비활성화" postSystemMessage', async () => {
+    const postSystemMessage = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps({
+      workingDirManager: {
+        parseSetCommand: vi.fn().mockImplementation((t: string) => (t.includes('/tmp') ? '/tmp' : null)),
+        isGetCommand: vi.fn().mockReturnValue(false),
+        getWorkingDirectory: vi.fn().mockReturnValue('/tmp/user1'),
+        formatDirectoryMessage: vi.fn().mockReturnValue('📁 /tmp/user1'),
+      },
+      slackApi: {
+        postSystemMessage,
+        getClient: vi.fn().mockReturnValue({}),
+      },
+    });
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text: 'cwd /tmp',
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await router.route(ctx);
+
+    expect(result.handled).toBe(true);
+    expect(postSystemMessage).toHaveBeenCalledTimes(1);
+    const [, textArg] = postSystemMessage.mock.calls[0];
+    expect(textArg).toContain('비활성화');
+  });
+});
+
+/**
+ * Issue #530: `effort` and `rate` have always been canonical bare-routable.
+ * Locked in here so the tombstone-removal change does not regress them.
+ */
+describe('CommandRouter — effort/rate regression guard (already canonical)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runBare(text: string): Promise<{ result: any }> {
+    const say = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps();
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text,
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say,
+    };
+    const result = await router.route(ctx);
+    return { result };
+  }
+
+  it('bare "effort high" → EffortHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(EffortHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('effort high');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "rate" → RateHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(RateHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('rate');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+});
+
+/**
+ * Issue #530: retired / non-canonical bare forms must fall through as
+ * `handled: false` — NO tombstone hint ("더 이상 사용되지 않습니다") is ever
+ * emitted from the router, and `markMigrationHintShown` is not called.
+ */
+describe('CommandRouter — non-canonical bare input falls through (no tombstone #530)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(userSettingsStore.markMigrationHintShown).mockClear();
+  });
+
+  async function assertFallsThrough(text: string): Promise<void> {
+    const say = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps();
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text,
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say,
+    };
+
+    const result = await router.route(ctx);
+
+    // 1. Handled must be false (no tombstone short-circuit).
+    expect(result.handled).toBe(false);
+    // 2. markMigrationHintShown must NOT be called — the gate was removed.
+    expect(userSettingsStore.markMigrationHintShown).not.toHaveBeenCalled();
+    // 3. `say` must NOT emit the tombstone hint text.
+    for (const call of say.mock.calls) {
+      const payload = call[0] as { text?: string };
+      expect(payload?.text ?? '').not.toContain('더 이상 사용되지 않습니다');
+    }
+  }
+
+  it('bare "commands" (retired) falls through', async () => {
+    await assertFallsThrough('commands');
+  });
+
+  it('bare "prompt" (non-canonical) falls through', async () => {
+    await assertFallsThrough('prompt');
+  });
+
+  it('bare "플러그인 업데이트" (Korean retired alias) falls through', async () => {
+    await assertFallsThrough('플러그인 업데이트');
+  });
+
+  it('bare "nextcct" (retired) falls through', async () => {
+    await assertFallsThrough('nextcct');
+  });
+
+  it('bare "servers" (retired) falls through', async () => {
+    await assertFallsThrough('servers');
+  });
+
+  it('bare "credentials" (retired) falls through', async () => {
+    await assertFallsThrough('credentials');
+  });
+
+  it('bare "persona clear" (not parser-supported) falls through', async () => {
+    await assertFallsThrough('persona clear');
+  });
+
+  it('bare "verbosity set detail" (not parser-supported) falls through', async () => {
+    await assertFallsThrough('verbosity set detail');
   });
 });

--- a/src/slack/commands/command-router.ts
+++ b/src/slack/commands/command-router.ts
@@ -1,12 +1,9 @@
 import { Logger } from '../../logger';
 import { getReportDeps } from '../../metrics';
-import { userSettingsStore } from '../../user-settings-store';
 import { CommandParser } from '../command-parser';
 import { isSlashForbidden, SLASH_FORBIDDEN_MESSAGE } from '../z/capability';
 import { stripZPrefix } from '../z/normalize';
 import { parseTopic, translateToLegacy } from '../z/router';
-import { detectLegacyNaked } from '../z/tombstone';
-import { isWhitelistedNaked } from '../z/whitelist';
 import { AdminHandler } from './admin-handler';
 import { BypassHandler } from './bypass-handler';
 import { CctHandler } from './cct-handler';
@@ -105,12 +102,11 @@ export class CommandRouter {
       return { handled: false };
     }
 
-    // Phase 1 of /z refactor (#506): `/z` prefix + legacy-naked tombstone.
-    // Set SOMA_ENABLE_LEGACY_SLASH=true to bypass the new routing entirely
-    // (rollback Tier 2 — plan/MASTER-SPEC.md §12).
-    const legacyEnabled =
-      process.env.SOMA_ENABLE_LEGACY_SLASH === 'true' || process.env.SOMA_ENABLE_LEGACY_SLASH === '1';
-
+    // `/z` prefix support for thread/app_mention text (Phase 1 of #506).
+    // NOTE: bare `[cmd] [args]` is NOT gated here — handlers below match it
+    // directly. The Phase 1 tombstone gate was removed (#530) to restore
+    // pre-#509 behavior. `SOMA_ENABLE_LEGACY_SLASH` now scopes only to the
+    // slash deprecation rollback in event-router.ts.
     const zPrefixRemainder = stripZPrefix(originalText.trim());
     if (zPrefixRemainder !== null) {
       // Empty `/z` → help
@@ -135,18 +131,6 @@ export class CommandRouter {
       // `ctx.text` (not a destructured copy) so the translated form reaches
       // canHandle() / execute() — thread `/z persona`, `/z model`, etc.
       // regressed when the old path used the stale local `text`.
-    } else if (!legacyEnabled && !isWhitelistedNaked(originalText)) {
-      const hint = detectLegacyNaked(originalText);
-      if (hint) {
-        const freshlyMarked = await userSettingsStore.markMigrationHintShown(ctx.user);
-        if (freshlyMarked) {
-          await say({
-            text: `ℹ️ \`${hint.oldForm}\`은 더 이상 사용되지 않습니다. 대신 \`${hint.newForm}\`을 사용해주세요.\n💡 \`/z\` 또는 \`/z help\`로 전체 명령을 확인할 수 있어요.`,
-            thread_ts: threadTs,
-          });
-        }
-        return { handled: true };
-      }
     }
 
     const routedText = ctx.text ?? originalText;

--- a/src/slack/event-router-app-mention-z.test.ts
+++ b/src/slack/event-router-app-mention-z.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * FIX #1 (PR #509): `app_mention` events that start with `/z` or match a
- * legacy naked command must route through `ZRouter` — the same normalization
- * pipeline as slash and DM. This test file exercises that contract.
+ * FIX #1 (PR #509, revised by #530): `app_mention` events that start with
+ * `/z` must route through `ZRouter` — the same normalization pipeline as
+ * slash and DM. Bare `[cmd] [args]` (restored in #530) falls through to the
+ * legacy pipeline instead. This test file exercises that contract.
  *
  * See: plan/MASTER-SPEC.md §5-1 "3 entry points common normalizeZInvocation".
  */

--- a/src/slack/event-router-app-mention-z.test.ts
+++ b/src/slack/event-router-app-mention-z.test.ts
@@ -122,8 +122,8 @@ describe('EventRouter.app_mention — /z routing (FIX #1)', () => {
     expect(mockMessageHandler).not.toHaveBeenCalled();
   });
 
-  it('routes legacy naked `@bot persona set linus` through ZRouter (tombstone path)', async () => {
-    const dispatch = vi.fn().mockResolvedValue({ handled: true, consumed: true });
+  it('bare `@bot persona set linus` falls through to legacy pipeline (#530)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true });
     eventRouter.zRouter = { dispatch };
 
     const handler = eventHandlers['app_mention'];
@@ -138,12 +138,105 @@ describe('EventRouter.app_mention — /z routing (FIX #1)', () => {
       say: vi.fn(),
     });
 
+    // Bare text MUST NOT route through ZRouter after #530 (Gate C' removed).
+    expect(dispatch).not.toHaveBeenCalled();
+    // Fall-through to legacy pipeline with original bare text.
+    expect(mockMessageHandler).toHaveBeenCalledTimes(1);
+    expect(mockMessageHandler.mock.calls[0][0].text).toBe('persona set linus');
+  });
+
+  it('bare `@bot model opus-4.7` (no linked session) falls through — ZRouter not called (#530)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true });
+    eventRouter.zRouter = { dispatch };
+
+    const handler = eventHandlers['app_mention'];
+    await handler({
+      event: {
+        user: 'U_X',
+        channel: 'C_X',
+        ts: '1.1',
+        text: '<@B_BOT> model opus-4.7',
+        team: 'T_X',
+      },
+      say: vi.fn(),
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(mockMessageHandler).toHaveBeenCalledTimes(1);
+    expect(mockMessageHandler.mock.calls[0][0].text).toBe('model opus-4.7');
+  });
+
+  it('`@bot /z model opus-4.7` still routes through ZRouter (regression guard)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true, consumed: true });
+    eventRouter.zRouter = { dispatch };
+
+    const handler = eventHandlers['app_mention'];
+    await handler({
+      event: {
+        user: 'U_X',
+        channel: 'C_X',
+        ts: '1.1',
+        text: '<@B_BOT> /z model opus-4.7',
+        team: 'T_X',
+      },
+      say: vi.fn(),
+    });
+
     expect(dispatch).toHaveBeenCalledTimes(1);
-    const inv = dispatch.mock.calls[0][0];
-    expect(inv.source).toBe('channel_mention');
-    expect(inv.isLegacyNaked).toBe(true);
-    // Tombstone handled by ZRouter; no pipeline continuation.
+    expect(dispatch.mock.calls[0][0].source).toBe('channel_mention');
+  });
+
+  it('bare `@bot model opus-4.7` in source thread with linked session still shows linked-status card (pre-#509 parity)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true });
+    eventRouter.zRouter = { dispatch };
+
+    mockDeps.claudeHandler.getSession.mockReturnValue(null);
+    mockDeps.claudeHandler.findSessionBySourceThread.mockReturnValue({
+      channelId: 'C_WORK',
+      threadTs: 'wt.1',
+    });
+    const linkedStatusSpy = vi.fn();
+    (eventRouter as any).respondWithLinkedSessionStatus = linkedStatusSpy;
+
+    const handler = eventHandlers['app_mention'];
+    await handler({
+      event: {
+        user: 'U_X',
+        channel: 'C_X',
+        ts: '2.2',
+        thread_ts: 'src.1',
+        text: '<@B_BOT> model opus-4.7',
+        team: 'T_X',
+      },
+      say: vi.fn(),
+    });
+
+    // Bare command in source-thread with linked session: ZRouter NOT called,
+    // linked-status card IS rendered (pre-#509 intentional exception).
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(linkedStatusSpy).toHaveBeenCalledTimes(1);
     expect(mockMessageHandler).not.toHaveBeenCalled();
+  });
+
+  it('bare `@bot commands` (retired) falls through to legacy pipeline — no tombstone (#530)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true });
+    eventRouter.zRouter = { dispatch };
+
+    const handler = eventHandlers['app_mention'];
+    await handler({
+      event: {
+        user: 'U_X',
+        channel: 'C_X',
+        ts: '1.1',
+        text: '<@B_BOT> commands',
+        team: 'T_X',
+      },
+      say: vi.fn(),
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(mockMessageHandler).toHaveBeenCalledTimes(1);
+    expect(mockMessageHandler.mock.calls[0][0].text).toBe('commands');
   });
 
   it('forbidden `@bot /z new` (slash-only) IS allowed via channel_mention (not slash)', async () => {

--- a/src/slack/event-router.ts
+++ b/src/slack/event-router.ts
@@ -16,7 +16,6 @@ import { isSlashForbidden } from './z/capability';
 import { normalizeZInvocation, stripZPrefix } from './z/normalize';
 import { ChannelEphemeralZRespond, SlashZRespond } from './z/respond';
 import { parseTopic, ZRouter } from './z/router';
-import { isLegacyNaked } from './z/tombstone';
 
 export interface EventRouterDeps {
   slackApi: SlackApiHelper;
@@ -138,9 +137,10 @@ export class EventRouter {
       }
       const text = botId ? event.text.replace(new RegExp(`<@${botId}>`, 'g'), '').trim() : event.text.trim(); // fallback: preserve all mentions if botId unavailable
 
-      // FIX #1 (PR #509): route `@bot /z …` and non-whitelisted legacy naked
-      // forms through ZRouter so the three entry points (slash, DM,
-      // app_mention) share the same normalization pipeline.
+      // FIX #1 (PR #509, revised by #530): route `@bot /z …` through ZRouter
+      // so slash + DM + app_mention share one normalization pipeline for the
+      // `/z` surface. Bare `[cmd] [args]` falls through to the normal
+      // app_mention pipeline (event-router.ts:163 이후 경로).
       //
       // codex P1 followup: this MUST run before the source-thread linked-session
       // guard below — otherwise `@bot /z persona` issued inside a source thread
@@ -229,16 +229,13 @@ export class EventRouter {
    *    a follow-up prompt (e.g. `@bot /z new do X` → `do X`); caller should
    *    substitute the event text and continue the legacy pipeline.
    *  - `terminal: false, continueWithPrompt: undefined` — ZRouter did not
-   *    apply (not a `/z` prefix and not a legacy naked form) OR an internal
-   *    failure occurred; caller should continue with the original stripped
-   *    text.
+   *    apply (text does not start with `/z`) OR an internal failure occurred;
+   *    caller should continue with the original stripped text.
    *
    * Routing rules (per MASTER-SPEC §5-1):
    *  - Text starts with `/z` → normalize + dispatch.
-   *  - Text matches a legacy naked form (`persona set linus`, `show prompt`) →
-   *    normalize + dispatch (ZRouter will render tombstone).
-   *  - Whitelisted naked (`new`, `session`, `$…`) or unrecognized prose →
-   *    `{ terminal: false }` (caller falls through).
+   *  - Otherwise → `{ terminal: false }` (caller falls through to normal
+   *    app_mention pipeline, preserving pre-#509 bare-command behavior).
    */
   private async maybeRouteAppMentionViaZRouter(args: {
     event: any;
@@ -250,8 +247,7 @@ export class EventRouter {
     if (!text) return { terminal: false };
 
     const startsWithZ = stripZPrefix(text) !== null;
-    const legacyNaked = !startsWithZ && isLegacyNaked(text);
-    if (!startsWithZ && !legacyNaked) return { terminal: false };
+    if (!startsWithZ) return { terminal: false };
 
     try {
       const respond = new ChannelEphemeralZRespond({


### PR DESCRIPTION
## Summary

Closes #530. PR #509 (Phase 1 `/z` refactor) inadvertently gated bare canonical commands (`model opus-4.7`, `verbosity detail`, `persona set elon`, `bypass on`, etc.) in thread/app_mention behind two tombstone checks. Users were forced to type `/z model opus-4.7` instead of the pre-#509 bare form.

This PR surgically removes the two gates while **preserving** the `/z <cmd>` surface AND Phase 2 (#507) Block Kit UI. Three paths now coexist:

1. **bare** `[cmd] [args]` — restored (handler chain dispatch)
2. **`/z` prefix** `[cmd] [args]` — preserved (ZRouter → translateToLegacy → handler chain)
3. **Phase 2 Block Kit** — preserved (topics/*, z-settings-actions.ts untouched)

## Changes

### Production (2 files, ~30 LOC removed)

**`src/slack/commands/command-router.ts`** (Gate A):
- Removed tombstone `else if` branch that blocked non-whitelisted bare input with `detectLegacyNaked` + `markMigrationHintShown`.
- Removed `legacyEnabled` const (no longer consumed here; `SOMA_ENABLE_LEGACY_SLASH` now scopes only to slash deprecation rollback in `event-router.ts`).
- `/z` prefix handling retained verbatim — `zPrefixRemainder` + `translateToLegacy` still routes `/z persona`, `/z model` through the handler chain.
- Removed now-unused imports: `userSettingsStore`, `detectLegacyNaked`, `isWhitelistedNaked`.

**`src/slack/event-router.ts`** (Gate C' in `maybeRouteAppMentionViaZRouter`):
- Removed `legacyNaked` branch — app_mention now only routes through ZRouter when text starts with `/z`. Bare text falls through to the normal app_mention pipeline (line 163 onward → linked-session guard → messageHandler).
- Removed now-unused import: `isLegacyNaked`.
- Updated comment at line 141 (FIX #1 `PR #509, revised by #530`) + docblock at line 221 (`Routing rules` section).

### Tests (+25 new, 1 rewritten)

**`src/slack/commands/command-router.test.ts`** (21 new):
- 8 parser-positive: bare `model opus-4.7` / `verbosity detail` / `persona set elon` / `bypass on` / `show email` / `set email user@…` / `show prompt` / `show llm_chat` — each asserts the corresponding `Handler.prototype.execute` spy is called exactly once.
- 3 cwd: bare `cwd` → Block Kit card; bare `set directory /tmp` → 비활성화 notice; bare `cwd /tmp` → 비활성화 notice (parseSetCommand alt syntax).
- 2 effort/rate regression guard: bare `effort high` → EffortHandler; bare `rate` → RateHandler.
- 8 negative fall-through: bare `commands` / `prompt` / `플러그인 업데이트` / `nextcct` / `servers` / `credentials` / `persona clear` / `verbosity set detail` — each asserts (handled:false) AND `markMigrationHintShown` NOT called AND no `더 이상 사용되지 않습니다` text.

**`src/slack/event-router-app-mention-z.test.ts`** (1 rewrite + 4 new):
- Rewrote `@bot persona set linus` test: was `ZRouter.dispatch` called (tombstone), now falls through to legacy pipeline with bare text intact.
- `@bot model opus-4.7` (no linked session) → normal pipeline, no ZRouter.
- `@bot /z model opus-4.7` → ZRouter.dispatch IS called (regression guard).
- `@bot model opus-4.7` in source-thread with linked session → linked-status card (pre-#509 parity, intentional exception).
- `@bot commands` (retired) → fall-through, no tombstone.

## Preserved (not modified)

- `src/slack/z/tombstone.ts`, `whitelist.ts`, `normalize.ts`, `router.ts`, `capability.ts`, `respond.ts`, `ui-builder.ts`
- `src/slack/z/topics/*` (Phase 2 Block Kit — 11 topics)
- `src/slack/actions/z-settings-actions.ts`
- `src/slack-handler.ts` DM path (DM bare prefilter unchanged — out of scope per v10 plan)
- `/soma`, `/session`, `/new` slash deprecation redirect in event-router.ts (Gate D)
- `SOMA_ENABLE_LEGACY_SLASH` flag (scope narrowed — Gate D rollback only)
- `event-router-slash-commands.test.ts` (Gate D + flag rollback scenarios)
- `tombstone.test.ts`, `whitelist.test.ts`, `z/topics/flow-e2e.test.ts`

## Scope note

Two gates removed; app_mention/thread bare paths recovered via the existing handler matching layer. DM bare (non-`/z`, non-whitelist) is gated by `src/slack-handler.ts:279-288` prefilter and is **out of scope** for this PR (per v10 plan).

## Verification

- [x] `pnpm lint` — 0 errors (2312 warnings / 316 infos pre-existing)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 204 files / 3842 passed / 5 skipped / 0 failed
- [x] Spec compliance review — PASS (25/25 tests present)
- [x] Code quality review — APPROVE

## Test plan

- [x] Bare `model opus-4.7` in thread → model changes
- [x] Bare `verbosity detail` in thread → verbosity changes
- [x] Bare `persona set elon` in thread → persona changes
- [x] Bare `cwd` in thread → Block Kit card renders
- [x] `/z model opus-4.7` in thread → still works (regression guard)
- [x] `@bot model opus-4.7` in channel → model changes (fall-through to pipeline)
- [x] `@bot /z model opus-4.7` in channel → routes via ZRouter (regression guard)
- [x] Unknown bare text → Claude prompt (no tombstone, no migration hint)
- [x] `/soma` slash command deprecation redirect unchanged
- [x] Phase 2 Block Kit UI unchanged

## Rollback

`git revert <sha>`. Not env-flag gated.

Refs: #506, #509, #530

Co-Authored-By: Zhuge <z@2lab.ai>