### PR TITLE
deploy(dev): 2026-04-17 release

### DIFF
--- a/src/local/skills/architecture-diagram/SKILL.md
+++ b/src/local/skills/architecture-diagram/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: architecture-diagram
+description: Generate professional dark-themed system architecture diagrams as standalone HTML/SVG files. Self-contained output with no external dependencies. Based on Cocoon AI's architecture-diagram-generator (MIT).
+version: 1.0.0
+author: Cocoon AI (hello@cocoon-ai.com), ported by Hermes Agent
+license: MIT
+dependencies: []
+metadata:
+  hermes:
+    tags: [architecture, diagrams, SVG, HTML, visualization, infrastructure, cloud]
+    related_skills: [excalidraw]
+---
+
+# Architecture Diagram Skill
+
+Generate professional, dark-themed technical architecture diagrams as standalone HTML files with inline SVG graphics. No external tools, no API keys, no rendering libraries — just write the HTML file and open it in a browser.
+
+Based on [Cocoon AI's architecture-diagram-generator](https://github.com/Cocoon-AI/architecture-diagram-generator) (MIT).
+
+## Workflow
+
+1. User describes their system architecture (components, connections, technologies)
+2. Generate the HTML file following the design system below
+3. Save with `write_file` to a `.html` file (e.g. `~/architecture-diagram.html`)
+4. User opens in any browser — works offline, no dependencies
+
+### Output Location
+
+Save diagrams to a user-specified path, or default to the current working directory:
+```
+./[project-name]-architecture.html
+```
+
+### Preview
+
+After saving, suggest the user open it:
+```bash
+# macOS
+open ./my-architecture.html
+# Linux
+xdg-open ./my-architecture.html
+```
+
+## Design System & Visual Language
+
+### Color Palette (Semantic Mapping)
+
+Use specific `rgba` fills and hex strokes to categorize components:
+
+| Component Type | Fill (rgba) | Stroke (Hex) |
+| :--- | :--- | :--- |
+| **Frontend** | `rgba(8, 51, 68, 0.4)` | `#22d3ee` (cyan-400) |
+| **Backend** | `rgba(6, 78, 59, 0.4)` | `#34d399` (emerald-400) |
+| **Database** | `rgba(76, 29, 149, 0.4)` | `#a78bfa` (violet-400) |
+| **AWS/Cloud** | `rgba(120, 53, 15, 0.3)` | `#fbbf24` (amber-400) |
+| **Security** | `rgba(136, 19, 55, 0.4)` | `#fb7185` (rose-400) |
+| **Message Bus** | `rgba(251, 146, 60, 0.3)` | `#fb923c` (orange-400) |
+| **External** | `rgba(30, 41, 59, 0.5)` | `#94a3b8` (slate-400) |
+
+### Typography & Background
+- **Font:** JetBrains Mono (Monospace), loaded from Google Fonts
+- **Sizes:** 12px (Names), 9px (Sublabels), 8px (Annotations), 7px (Tiny labels)
+- **Background:** Slate-950 (`#020617`) with a subtle 40px grid pattern
+
+```svg
+<!-- Background Grid Pattern -->
+<pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+  <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+</pattern>
+```
+
+## Technical Implementation Details
+
+### Component Rendering
+Components are rounded rectangles (`rx="6"`) with 1.5px strokes. To prevent arrows from showing through semi-transparent fills, use a **double-rect masking technique**:
+1. Draw an opaque background rect (`#0f172a`)
+2. Draw the semi-transparent styled rect on top
+
+### Connection Rules
+- **Z-Order:** Draw arrows *early* in the SVG (after the grid) so they render behind component boxes
+- **Arrowheads:** Defined via SVG markers
+- **Security Flows:** Use dashed lines in rose color (`#fb7185`)
+- **Boundaries:**
+  - *Security Groups:* Dashed (`4,4`), rose color
+  - *Regions:* Large dashed (`8,4`), amber color, `rx="12"`
+
+### Spacing & Layout Logic
+- **Standard Height:** 60px (Services); 80-120px (Large components)
+- **Vertical Gap:** Minimum 40px between components
+- **Message Buses:** Must be placed *in the gap* between services, not overlapping them
+- **Legend Placement:** **CRITICAL.** Must be placed outside all boundary boxes. Calculate the lowest Y-coordinate of all boundaries and place the legend at least 20px below it.
+
+## Document Structure
+
+The generated HTML file follows a four-part layout:
+1. **Header:** Title with a pulsing dot indicator and subtitle
+2. **Main SVG:** The diagram contained within a rounded border card
+3. **Summary Cards:** A grid of three cards below the diagram for high-level details
+4. **Footer:** Minimal metadata
+
+### Info Card Pattern
+```html
+<div class="card">
+  <div class="card-header">
+    <div class="card-dot cyan"></div>
+    <h3>Title</h3>
+  </div>
+  <ul>
+    <li>• Item one</li>
+    <li>• Item two</li>
+  </ul>
+</div>
+```
+
+## Output Requirements
+- **Single File:** One self-contained `.html` file
+- **No External Dependencies:** All CSS and SVG must be inline (except Google Fonts)
+- **No JavaScript:** Use pure CSS for any animations (like pulsing dots)
+- **Compatibility:** Must render correctly in any modern web browser
+
+## Template Reference
+
+Load the full HTML template for the exact structure, CSS, and SVG component examples:
+
+```
+skill_view(name="architecture-diagram", file_path="templates/template.html")
+```
+
+The template contains working examples of every component type (frontend, backend, database, cloud, security), arrow styles (standard, dashed, curved), security groups, region boundaries, and the legend — use it as your structural reference when generating diagrams.

--- a/src/local/skills/architecture-diagram/templates/template.html
+++ b/src/local/skills/architecture-diagram/templates/template.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>[PROJECT NAME] Architecture Diagram</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    
+    body {
+      font-family: 'JetBrains Mono', monospace;
+      background: #020617;
+      min-height: 100vh;
+      padding: 2rem;
+      color: white;
+    }
+    
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    
+    .header {
+      margin-bottom: 2rem;
+    }
+    
+    .header-row {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 0.5rem;
+    }
+    
+    .pulse-dot {
+      width: 12px;
+      height: 12px;
+      background: #22d3ee;
+      border-radius: 50%;
+      animation: pulse 2s infinite;
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+    
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.025em;
+    }
+    
+    .subtitle {
+      color: #94a3b8;
+      font-size: 0.875rem;
+      margin-left: 1.75rem;
+    }
+    
+    .diagram-container {
+      background: rgba(15, 23, 42, 0.5);
+      border-radius: 1rem;
+      border: 1px solid #1e293b;
+      padding: 1.5rem;
+      overflow-x: auto;
+    }
+    
+    svg {
+      width: 100%;
+      min-width: 900px;
+      display: block;
+    }
+    
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+      margin-top: 2rem;
+    }
+    
+    .card {
+      background: rgba(15, 23, 42, 0.5);
+      border-radius: 0.75rem;
+      border: 1px solid #1e293b;
+      padding: 1.25rem;
+    }
+    
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+    
+    .card-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+    
+    .card-dot.cyan { background: #22d3ee; }
+    .card-dot.emerald { background: #34d399; }
+    .card-dot.violet { background: #a78bfa; }
+    .card-dot.amber { background: #fbbf24; }
+    .card-dot.rose { background: #fb7185; }
+    
+    .card h3 {
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
+    
+    .card ul {
+      list-style: none;
+      color: #94a3b8;
+      font-size: 0.75rem;
+    }
+    
+    .card li {
+      margin-bottom: 0.375rem;
+    }
+    
+    .footer {
+      text-align: center;
+      margin-top: 1.5rem;
+      color: #475569;
+      font-size: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <!-- Header -->
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>[PROJECT NAME] Architecture</h1>
+      </div>
+      <p class="subtitle">[Subtitle description]</p>
+    </div>
+
+    <!-- Main Diagram -->
+    <div class="diagram-container">
+      <svg viewBox="0 0 1000 680">
+        <!-- Definitions -->
+        <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <!-- Background Grid -->
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- =================================================================
+             COMPONENT EXAMPLES - Copy and customize these patterns
+             ================================================================= -->
+
+        <!-- External/Generic Component -->
+        <rect x="30" y="280" width="100" height="50" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="80" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">Users</text>
+        <text x="80" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">Browser/Mobile</text>
+
+        <!-- Security Component -->
+        <rect x="30" y="80" width="100" height="60" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="80" y="105" fill="white" font-size="11" font-weight="600" text-anchor="middle">Auth Provider</text>
+        <text x="80" y="121" fill="#94a3b8" font-size="9" text-anchor="middle">OAuth 2.0</text>
+
+        <!-- Region/Cloud Boundary -->
+        <rect x="160" y="40" width="820" height="620" rx="12" fill="rgba(251, 191, 36, 0.05)" stroke="#fbbf24" stroke-width="1" stroke-dasharray="8,4"/>
+        <text x="172" y="58" fill="#fbbf24" font-size="10" font-weight="600">AWS Region: us-west-2</text>
+
+        <!-- AWS/Cloud Service -->
+        <rect x="200" y="280" width="110" height="50" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="255" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">CloudFront</text>
+        <text x="255" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">CDN</text>
+
+        <!-- Multi-line AWS Component (S3 Buckets example) -->
+        <rect x="200" y="380" width="110" height="100" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="255" y="400" fill="white" font-size="11" font-weight="600" text-anchor="middle">S3 Buckets</text>
+        <text x="255" y="420" fill="#94a3b8" font-size="8" text-anchor="middle">• bucket-one</text>
+        <text x="255" y="434" fill="#94a3b8" font-size="8" text-anchor="middle">• bucket-two</text>
+        <text x="255" y="448" fill="#94a3b8" font-size="8" text-anchor="middle">• bucket-three</text>
+        <text x="255" y="466" fill="#fbbf24" font-size="7" text-anchor="middle">OAI Protected</text>
+
+        <!-- Security Group (dashed boundary) -->
+        <rect x="350" y="265" width="120" height="80" rx="8" fill="transparent" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <text x="358" y="279" fill="#fb7185" font-size="8">sg-name :port</text>
+        
+        <!-- Component inside security group -->
+        <rect x="360" y="280" width="100" height="50" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="410" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">Load Balancer</text>
+        <text x="410" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">HTTPS :443</text>
+
+        <!-- Backend Component -->
+        <rect x="510" y="280" width="110" height="50" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="565" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">API Server</text>
+        <text x="565" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">FastAPI :8000</text>
+
+        <!-- Database Component -->
+        <rect x="700" y="280" width="120" height="50" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="760" y="300" fill="white" font-size="11" font-weight="600" text-anchor="middle">Database</text>
+        <text x="760" y="316" fill="#94a3b8" font-size="9" text-anchor="middle">PostgreSQL</text>
+
+        <!-- Frontend Component -->
+        <rect x="200" y="520" width="200" height="110" rx="8" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="300" y="545" fill="white" font-size="12" font-weight="600" text-anchor="middle">Frontend</text>
+        <text x="300" y="565" fill="#94a3b8" font-size="9" text-anchor="middle">React + TypeScript</text>
+        <text x="300" y="580" fill="#94a3b8" font-size="9" text-anchor="middle">Additional detail</text>
+        <text x="300" y="595" fill="#94a3b8" font-size="9" text-anchor="middle">More info</text>
+        <text x="300" y="615" fill="#22d3ee" font-size="8" text-anchor="middle">domain.example.com</text>
+
+        <!-- =================================================================
+             ARROW EXAMPLES
+             ================================================================= -->
+
+        <!-- Standard arrow with label -->
+        <line x1="130" y1="305" x2="198" y2="305" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="164" y="299" fill="#94a3b8" font-size="9" text-anchor="middle">HTTPS</text>
+        
+        <!-- Simple arrow (no label) -->
+        <line x1="310" y1="305" x2="358" y2="305" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        
+        <!-- Vertical arrow -->
+        <line x1="255" y1="330" x2="255" y2="378" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="270" y="358" fill="#94a3b8" font-size="9">OAI</text>
+        
+        <!-- Dashed arrow (for auth/security flows) -->
+        <line x1="460" y1="305" x2="508" y2="305" stroke="#34d399" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="620" y1="305" x2="698" y2="305" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="655" y="299" fill="#94a3b8" font-size="9">TLS</text>
+
+        <!-- Curved path for auth flow -->
+        <path d="M 80 140 L 80 200 Q 80 220 100 220 L 200 220 Q 220 220 220 240 L 220 278" fill="none" stroke="#fb7185" stroke-width="1.5" stroke-dasharray="5,5"/>
+        <text x="150" y="210" fill="#fb7185" font-size="8">JWT + PKCE</text>
+
+        <!-- =================================================================
+             LEGEND
+             ================================================================= -->
+        <text x="720" y="70" fill="white" font-size="10" font-weight="600">Legend</text>
+        
+        <rect x="720" y="82" width="16" height="10" rx="2" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1"/>
+        <text x="742" y="90" fill="#94a3b8" font-size="8">Frontend</text>
+        
+        <rect x="720" y="98" width="16" height="10" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1"/>
+        <text x="742" y="106" fill="#94a3b8" font-size="8">Backend</text>
+        
+        <rect x="720" y="114" width="16" height="10" rx="2" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1"/>
+        <text x="742" y="122" fill="#94a3b8" font-size="8">Cloud Service</text>
+        
+        <rect x="720" y="130" width="16" height="10" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="742" y="138" fill="#94a3b8" font-size="8">Database</text>
+        
+        <rect x="720" y="146" width="16" height="10" rx="2" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1"/>
+        <text x="742" y="154" fill="#94a3b8" font-size="8">Security</text>
+        
+        <line x1="720" y1="168" x2="736" y2="168" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3"/>
+        <text x="742" y="171" fill="#94a3b8" font-size="8">Auth Flow</text>
+        
+        <rect x="720" y="178" width="16" height="10" rx="2" fill="transparent" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3"/>
+        <text x="742" y="186" fill="#94a3b8" font-size="8">Security Group</text>
+      </svg>
+    </div>
+
+    <!-- Info Cards -->
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot rose"></div>
+          <h3>Card Title 1</h3>
+        </div>
+        <ul>
+          <li>• Item one</li>
+          <li>• Item two</li>
+          <li>• Item three</li>
+          <li>• Item four</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot amber"></div>
+          <h3>Card Title 2</h3>
+        </div>
+        <ul>
+          <li>• Item one</li>
+          <li>• Item two</li>
+          <li>• Item three</li>
+          <li>• Item four</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot violet"></div>
+          <h3>Card Title 3</h3>
+        </div>
+        <ul>
+          <li>• Item one</li>
+          <li>• Item two</li>
+          <li>• Item three</li>
+          <li>• Item four</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <p class="footer">
+      [Project Name] • [Additional metadata]
+    </p>
+  </div>
+</body>
+</html>

--- a/src/slack/commands/command-router.test.ts
+++ b/src/slack/commands/command-router.test.ts
@@ -20,8 +20,45 @@ vi.mock('../../metrics', () => ({
   }),
 }));
 
+import { userSettingsStore } from '../../user-settings-store';
+import { BypassHandler } from './bypass-handler';
 import { CommandRouter } from './command-router';
+import { EffortHandler } from './effort-handler';
+import { EmailHandler } from './email-handler';
+import { LlmChatHandler } from './llm-chat-handler';
+import { ModelHandler } from './model-handler';
 import { PersonaHandler } from './persona-handler';
+import { PromptHandler } from './prompt-handler';
+import { RateHandler } from './rate-handler';
+import { VerbosityHandler } from './verbosity-handler';
+
+/**
+ * Default command-router deps — handlers need these present on construction.
+ * Individual tests override workingDirManager / slackApi as needed.
+ */
+function buildDeps(overrides: Record<string, any> = {}): any {
+  return {
+    workingDirManager: {
+      parseSetCommand: vi.fn().mockReturnValue(null),
+      isGetCommand: vi.fn().mockReturnValue(false),
+      getWorkingDirectory: vi.fn().mockReturnValue('/tmp/default'),
+      formatDirectoryMessage: vi.fn().mockReturnValue('📁 /tmp/default'),
+    },
+    mcpManager: { getPluginManager: vi.fn() },
+    claudeHandler: {
+      getSession: vi.fn().mockReturnValue(null),
+    },
+    sessionUiManager: {},
+    requestCoordinator: {},
+    slackApi: {
+      postSystemMessage: vi.fn().mockResolvedValue(undefined),
+      getClient: vi.fn().mockReturnValue({}),
+    },
+    reactionManager: {},
+    contextWindowManager: {},
+    ...overrides,
+  };
+}
 
 /**
  * Regression guard (PR #509, codex P1): after stripping the `/z` prefix and
@@ -43,19 +80,7 @@ describe('CommandRouter — /z → translated text is routed to handler', () => 
     const executeSpy = vi.spyOn(PersonaHandler.prototype, 'execute').mockResolvedValue({ handled: true });
 
     const say = vi.fn().mockResolvedValue(undefined);
-    const deps: any = {
-      workingDirManager: {
-        parseSetCommand: vi.fn().mockReturnValue(null),
-        isGetCommand: vi.fn().mockReturnValue(false),
-      },
-      mcpManager: { getPluginManager: vi.fn() },
-      claudeHandler: {},
-      sessionUiManager: {},
-      requestCoordinator: {},
-      slackApi: {},
-      reactionManager: {},
-      contextWindowManager: {},
-    };
+    const deps = buildDeps();
     const router = new CommandRouter(deps);
     const ctx: any = {
       text: '/z persona set linus',
@@ -68,7 +93,7 @@ describe('CommandRouter — /z → translated text is routed to handler', () => 
     const result = await router.route(ctx);
 
     // PersonaHandler was considered with the translated text
-    const personaCalls = canHandleSpy.mock.calls.filter((args) => /persona/.test(args[0] ?? ''));
+    const personaCalls = canHandleSpy.mock.calls.filter((args: any[]) => /persona/.test(args[0] ?? ''));
     expect(personaCalls.length).toBeGreaterThan(0);
     for (const call of personaCalls) {
       expect(call[0]).not.toContain('/z');
@@ -79,5 +104,301 @@ describe('CommandRouter — /z → translated text is routed to handler', () => 
 
     // ctx.text is left in the rewritten form for downstream handlers
     expect(ctx.text).toBe('persona set linus');
+  });
+});
+
+/**
+ * Issue #530: PR #509 introduced Phase 1 tombstone gates that blocked bare
+ * canonical commands like `model opus-4.7`, `verbosity detail`, etc. in
+ * thread/app_mention surfaces. These gates were removed so handlers match
+ * bare `[cmd] [args]` input directly again (pre-#509 behavior restored).
+ */
+describe('CommandRouter — bare [cmd] [args] routing (restored #530)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runBare(text: string): Promise<{ result: any; ctx: any; say: any }> {
+    const say = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps();
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text,
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say,
+    };
+    const result = await router.route(ctx);
+    return { result, ctx, say };
+  }
+
+  it('bare "model opus-4.7" → ModelHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(ModelHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('model opus-4.7');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "verbosity detail" → VerbosityHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(VerbosityHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('verbosity detail');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "persona set elon" → PersonaHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(PersonaHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('persona set elon');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "bypass on" → BypassHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(BypassHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('bypass on');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "show email" → EmailHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(EmailHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('show email');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "set email user@example.com" → EmailHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(EmailHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('set email user@example.com');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "show prompt" → PromptHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(PromptHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('show prompt');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "show llm_chat" → LlmChatHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(LlmChatHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('show llm_chat');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+});
+
+/**
+ * Issue #530: cwd is a special case — Phase 2 (#507) renders a Block Kit card
+ * via `renderCwdCard` + `slackApi.postSystemMessage`. Set-path commands
+ * (`set directory <p>`, `cwd <p>`) post a plain "비활성화" notice.
+ */
+describe('CommandRouter — cwd bare routing (restored #530)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('bare "cwd" → CwdHandler.execute → renderCwdCard Block Kit card posted', async () => {
+    const postSystemMessage = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps({
+      workingDirManager: {
+        parseSetCommand: vi.fn().mockReturnValue(null),
+        isGetCommand: vi.fn().mockImplementation((t: string) => t.trim() === 'cwd'),
+        getWorkingDirectory: vi.fn().mockReturnValue('/tmp/user1'),
+        formatDirectoryMessage: vi.fn().mockReturnValue('📁 /tmp/user1'),
+      },
+      slackApi: {
+        postSystemMessage,
+        getClient: vi.fn().mockReturnValue({}),
+      },
+    });
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text: 'cwd',
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await router.route(ctx);
+
+    expect(result.handled).toBe(true);
+    expect(postSystemMessage).toHaveBeenCalledTimes(1);
+    const [channelArg, , optsArg] = postSystemMessage.mock.calls[0];
+    expect(channelArg).toBe('C1');
+    expect(optsArg).toEqual(expect.objectContaining({ blocks: expect.any(Array) }));
+  });
+
+  it('bare "set directory /tmp" → CwdHandler.execute → "비활성화" postSystemMessage', async () => {
+    const postSystemMessage = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps({
+      workingDirManager: {
+        parseSetCommand: vi.fn().mockImplementation((t: string) => (t.includes('/tmp') ? '/tmp' : null)),
+        isGetCommand: vi.fn().mockReturnValue(false),
+        getWorkingDirectory: vi.fn().mockReturnValue('/tmp/user1'),
+        formatDirectoryMessage: vi.fn().mockReturnValue('📁 /tmp/user1'),
+      },
+      slackApi: {
+        postSystemMessage,
+        getClient: vi.fn().mockReturnValue({}),
+      },
+    });
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text: 'set directory /tmp',
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await router.route(ctx);
+
+    expect(result.handled).toBe(true);
+    expect(postSystemMessage).toHaveBeenCalledTimes(1);
+    const [, textArg] = postSystemMessage.mock.calls[0];
+    expect(textArg).toContain('비활성화되었습니다');
+  });
+
+  it('bare "cwd /tmp" → CwdHandler.execute → "비활성화" postSystemMessage', async () => {
+    const postSystemMessage = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps({
+      workingDirManager: {
+        parseSetCommand: vi.fn().mockImplementation((t: string) => (t.includes('/tmp') ? '/tmp' : null)),
+        isGetCommand: vi.fn().mockReturnValue(false),
+        getWorkingDirectory: vi.fn().mockReturnValue('/tmp/user1'),
+        formatDirectoryMessage: vi.fn().mockReturnValue('📁 /tmp/user1'),
+      },
+      slackApi: {
+        postSystemMessage,
+        getClient: vi.fn().mockReturnValue({}),
+      },
+    });
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text: 'cwd /tmp',
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await router.route(ctx);
+
+    expect(result.handled).toBe(true);
+    expect(postSystemMessage).toHaveBeenCalledTimes(1);
+    const [, textArg] = postSystemMessage.mock.calls[0];
+    expect(textArg).toContain('비활성화');
+  });
+});
+
+/**
+ * Issue #530: `effort` and `rate` have always been canonical bare-routable.
+ * Locked in here so the tombstone-removal change does not regress them.
+ */
+describe('CommandRouter — effort/rate regression guard (already canonical)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runBare(text: string): Promise<{ result: any }> {
+    const say = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps();
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text,
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say,
+    };
+    const result = await router.route(ctx);
+    return { result };
+  }
+
+  it('bare "effort high" → EffortHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(EffortHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('effort high');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+
+  it('bare "rate" → RateHandler.execute called', async () => {
+    const executeSpy = vi.spyOn(RateHandler.prototype, 'execute').mockResolvedValue({ handled: true });
+    const { result } = await runBare('rate');
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.handled).toBe(true);
+  });
+});
+
+/**
+ * Issue #530: retired / non-canonical bare forms must fall through as
+ * `handled: false` — NO tombstone hint ("더 이상 사용되지 않습니다") is ever
+ * emitted from the router, and `markMigrationHintShown` is not called.
+ */
+describe('CommandRouter — non-canonical bare input falls through (no tombstone #530)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(userSettingsStore.markMigrationHintShown).mockClear();
+  });
+
+  async function assertFallsThrough(text: string): Promise<void> {
+    const say = vi.fn().mockResolvedValue(undefined);
+    const deps = buildDeps();
+    const router = new CommandRouter(deps);
+    const ctx: any = {
+      text,
+      user: 'U1',
+      channel: 'C1',
+      threadTs: 'T1',
+      say,
+    };
+
+    const result = await router.route(ctx);
+
+    // 1. Handled must be false (no tombstone short-circuit).
+    expect(result.handled).toBe(false);
+    // 2. markMigrationHintShown must NOT be called — the gate was removed.
+    expect(userSettingsStore.markMigrationHintShown).not.toHaveBeenCalled();
+    // 3. `say` must NOT emit the tombstone hint text.
+    for (const call of say.mock.calls) {
+      const payload = call[0] as { text?: string };
+      expect(payload?.text ?? '').not.toContain('더 이상 사용되지 않습니다');
+    }
+  }
+
+  it('bare "commands" (retired) falls through', async () => {
+    await assertFallsThrough('commands');
+  });
+
+  it('bare "prompt" (non-canonical) falls through', async () => {
+    await assertFallsThrough('prompt');
+  });
+
+  it('bare "플러그인 업데이트" (Korean retired alias) falls through', async () => {
+    await assertFallsThrough('플러그인 업데이트');
+  });
+
+  it('bare "nextcct" (retired) falls through', async () => {
+    await assertFallsThrough('nextcct');
+  });
+
+  it('bare "servers" (retired) falls through', async () => {
+    await assertFallsThrough('servers');
+  });
+
+  it('bare "credentials" (retired) falls through', async () => {
+    await assertFallsThrough('credentials');
+  });
+
+  it('bare "persona clear" (not parser-supported) falls through', async () => {
+    await assertFallsThrough('persona clear');
+  });
+
+  it('bare "verbosity set detail" (not parser-supported) falls through', async () => {
+    await assertFallsThrough('verbosity set detail');
   });
 });

--- a/src/slack/commands/command-router.ts
+++ b/src/slack/commands/command-router.ts
@@ -1,12 +1,9 @@
 import { Logger } from '../../logger';
 import { getReportDeps } from '../../metrics';
-import { userSettingsStore } from '../../user-settings-store';
 import { CommandParser } from '../command-parser';
 import { isSlashForbidden, SLASH_FORBIDDEN_MESSAGE } from '../z/capability';
 import { stripZPrefix } from '../z/normalize';
 import { parseTopic, translateToLegacy } from '../z/router';
-import { detectLegacyNaked } from '../z/tombstone';
-import { isWhitelistedNaked } from '../z/whitelist';
 import { AdminHandler } from './admin-handler';
 import { BypassHandler } from './bypass-handler';
 import { CctHandler } from './cct-handler';
@@ -105,12 +102,11 @@ export class CommandRouter {
       return { handled: false };
     }
 
-    // Phase 1 of /z refactor (#506): `/z` prefix + legacy-naked tombstone.
-    // Set SOMA_ENABLE_LEGACY_SLASH=true to bypass the new routing entirely
-    // (rollback Tier 2 — plan/MASTER-SPEC.md §12).
-    const legacyEnabled =
-      process.env.SOMA_ENABLE_LEGACY_SLASH === 'true' || process.env.SOMA_ENABLE_LEGACY_SLASH === '1';
-
+    // `/z` prefix support for thread/app_mention text (Phase 1 of #506).
+    // NOTE: bare `[cmd] [args]` is NOT gated here — handlers below match it
+    // directly. The Phase 1 tombstone gate was removed (#530) to restore
+    // pre-#509 behavior. `SOMA_ENABLE_LEGACY_SLASH` now scopes only to the
+    // slash deprecation rollback in event-router.ts.
     const zPrefixRemainder = stripZPrefix(originalText.trim());
     if (zPrefixRemainder !== null) {
       // Empty `/z` → help
@@ -135,18 +131,6 @@ export class CommandRouter {
       // `ctx.text` (not a destructured copy) so the translated form reaches
       // canHandle() / execute() — thread `/z persona`, `/z model`, etc.
       // regressed when the old path used the stale local `text`.
-    } else if (!legacyEnabled && !isWhitelistedNaked(originalText)) {
-      const hint = detectLegacyNaked(originalText);
-      if (hint) {
-        const freshlyMarked = await userSettingsStore.markMigrationHintShown(ctx.user);
-        if (freshlyMarked) {
-          await say({
-            text: `ℹ️ \`${hint.oldForm}\`은 더 이상 사용되지 않습니다. 대신 \`${hint.newForm}\`을 사용해주세요.\n💡 \`/z\` 또는 \`/z help\`로 전체 명령을 확인할 수 있어요.`,
-            thread_ts: threadTs,
-          });
-        }
-        return { handled: true };
-      }
     }
 
     const routedText = ctx.text ?? originalText;

--- a/src/slack/event-router-app-mention-z.test.ts
+++ b/src/slack/event-router-app-mention-z.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * FIX #1 (PR #509): `app_mention` events that start with `/z` or match a
- * legacy naked command must route through `ZRouter` — the same normalization
- * pipeline as slash and DM. This test file exercises that contract.
+ * FIX #1 (PR #509, revised by #530): `app_mention` events that start with
+ * `/z` must route through `ZRouter` — the same normalization pipeline as
+ * slash and DM. Bare `[cmd] [args]` (restored in #530) falls through to the
+ * legacy pipeline instead. This test file exercises that contract.
  *
  * See: plan/MASTER-SPEC.md §5-1 "3 entry points common normalizeZInvocation".
  */
@@ -122,8 +123,8 @@ describe('EventRouter.app_mention — /z routing (FIX #1)', () => {
     expect(mockMessageHandler).not.toHaveBeenCalled();
   });
 
-  it('routes legacy naked `@bot persona set linus` through ZRouter (tombstone path)', async () => {
-    const dispatch = vi.fn().mockResolvedValue({ handled: true, consumed: true });
+  it('bare `@bot persona set linus` falls through to legacy pipeline (#530)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true });
     eventRouter.zRouter = { dispatch };
 
     const handler = eventHandlers['app_mention'];
@@ -138,12 +139,105 @@ describe('EventRouter.app_mention — /z routing (FIX #1)', () => {
       say: vi.fn(),
     });
 
+    // Bare text MUST NOT route through ZRouter after #530 (Gate C' removed).
+    expect(dispatch).not.toHaveBeenCalled();
+    // Fall-through to legacy pipeline with original bare text.
+    expect(mockMessageHandler).toHaveBeenCalledTimes(1);
+    expect(mockMessageHandler.mock.calls[0][0].text).toBe('persona set linus');
+  });
+
+  it('bare `@bot model opus-4.7` (no linked session) falls through — ZRouter not called (#530)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true });
+    eventRouter.zRouter = { dispatch };
+
+    const handler = eventHandlers['app_mention'];
+    await handler({
+      event: {
+        user: 'U_X',
+        channel: 'C_X',
+        ts: '1.1',
+        text: '<@B_BOT> model opus-4.7',
+        team: 'T_X',
+      },
+      say: vi.fn(),
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(mockMessageHandler).toHaveBeenCalledTimes(1);
+    expect(mockMessageHandler.mock.calls[0][0].text).toBe('model opus-4.7');
+  });
+
+  it('`@bot /z model opus-4.7` still routes through ZRouter (regression guard)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true, consumed: true });
+    eventRouter.zRouter = { dispatch };
+
+    const handler = eventHandlers['app_mention'];
+    await handler({
+      event: {
+        user: 'U_X',
+        channel: 'C_X',
+        ts: '1.1',
+        text: '<@B_BOT> /z model opus-4.7',
+        team: 'T_X',
+      },
+      say: vi.fn(),
+    });
+
     expect(dispatch).toHaveBeenCalledTimes(1);
-    const inv = dispatch.mock.calls[0][0];
-    expect(inv.source).toBe('channel_mention');
-    expect(inv.isLegacyNaked).toBe(true);
-    // Tombstone handled by ZRouter; no pipeline continuation.
+    expect(dispatch.mock.calls[0][0].source).toBe('channel_mention');
+  });
+
+  it('bare `@bot model opus-4.7` in source thread with linked session still shows linked-status card (pre-#509 parity)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true });
+    eventRouter.zRouter = { dispatch };
+
+    mockDeps.claudeHandler.getSession.mockReturnValue(null);
+    mockDeps.claudeHandler.findSessionBySourceThread.mockReturnValue({
+      channelId: 'C_WORK',
+      threadTs: 'wt.1',
+    });
+    const linkedStatusSpy = vi.fn();
+    (eventRouter as any).respondWithLinkedSessionStatus = linkedStatusSpy;
+
+    const handler = eventHandlers['app_mention'];
+    await handler({
+      event: {
+        user: 'U_X',
+        channel: 'C_X',
+        ts: '2.2',
+        thread_ts: 'src.1',
+        text: '<@B_BOT> model opus-4.7',
+        team: 'T_X',
+      },
+      say: vi.fn(),
+    });
+
+    // Bare command in source-thread with linked session: ZRouter NOT called,
+    // linked-status card IS rendered (pre-#509 intentional exception).
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(linkedStatusSpy).toHaveBeenCalledTimes(1);
     expect(mockMessageHandler).not.toHaveBeenCalled();
+  });
+
+  it('bare `@bot commands` (retired) falls through to legacy pipeline — no tombstone (#530)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ handled: true });
+    eventRouter.zRouter = { dispatch };
+
+    const handler = eventHandlers['app_mention'];
+    await handler({
+      event: {
+        user: 'U_X',
+        channel: 'C_X',
+        ts: '1.1',
+        text: '<@B_BOT> commands',
+        team: 'T_X',
+      },
+      say: vi.fn(),
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(mockMessageHandler).toHaveBeenCalledTimes(1);
+    expect(mockMessageHandler.mock.calls[0][0].text).toBe('commands');
   });
 
   it('forbidden `@bot /z new` (slash-only) IS allowed via channel_mention (not slash)', async () => {

--- a/src/slack/event-router.ts
+++ b/src/slack/event-router.ts
@@ -16,7 +16,6 @@ import { isSlashForbidden } from './z/capability';
 import { normalizeZInvocation, stripZPrefix } from './z/normalize';
 import { ChannelEphemeralZRespond, SlashZRespond } from './z/respond';
 import { parseTopic, ZRouter } from './z/router';
-import { isLegacyNaked } from './z/tombstone';
 
 export interface EventRouterDeps {
   slackApi: SlackApiHelper;
@@ -138,9 +137,10 @@ export class EventRouter {
       }
       const text = botId ? event.text.replace(new RegExp(`<@${botId}>`, 'g'), '').trim() : event.text.trim(); // fallback: preserve all mentions if botId unavailable
 
-      // FIX #1 (PR #509): route `@bot /z …` and non-whitelisted legacy naked
-      // forms through ZRouter so the three entry points (slash, DM,
-      // app_mention) share the same normalization pipeline.
+      // FIX #1 (PR #509, revised by #530): route `@bot /z …` through ZRouter
+      // so slash + DM + app_mention share one normalization pipeline for the
+      // `/z` surface. Bare `[cmd] [args]` falls through to the normal
+      // app_mention pipeline (event-router.ts:163 이후 경로).
       //
       // codex P1 followup: this MUST run before the source-thread linked-session
       // guard below — otherwise `@bot /z persona` issued inside a source thread
@@ -229,16 +229,13 @@ export class EventRouter {
    *    a follow-up prompt (e.g. `@bot /z new do X` → `do X`); caller should
    *    substitute the event text and continue the legacy pipeline.
    *  - `terminal: false, continueWithPrompt: undefined` — ZRouter did not
-   *    apply (not a `/z` prefix and not a legacy naked form) OR an internal
-   *    failure occurred; caller should continue with the original stripped
-   *    text.
+   *    apply (text does not start with `/z`) OR an internal failure occurred;
+   *    caller should continue with the original stripped text.
    *
    * Routing rules (per MASTER-SPEC §5-1):
    *  - Text starts with `/z` → normalize + dispatch.
-   *  - Text matches a legacy naked form (`persona set linus`, `show prompt`) →
-   *    normalize + dispatch (ZRouter will render tombstone).
-   *  - Whitelisted naked (`new`, `session`, `$…`) or unrecognized prose →
-   *    `{ terminal: false }` (caller falls through).
+   *  - Otherwise → `{ terminal: false }` (caller falls through to normal
+   *    app_mention pipeline, preserving pre-#509 bare-command behavior).
    */
   private async maybeRouteAppMentionViaZRouter(args: {
     event: any;
@@ -250,8 +247,7 @@ export class EventRouter {
     if (!text) return { terminal: false };
 
     const startsWithZ = stripZPrefix(text) !== null;
-    const legacyNaked = !startsWithZ && isLegacyNaked(text);
-    if (!startsWithZ && !legacyNaked) return { terminal: false };
+    if (!startsWithZ) return { terminal: false };
 
     try {
       const respond = new ChannelEphemeralZRespond({


### PR DESCRIPTION
## Deploy Delta

**Commits (2):**
- `e4d0586` fix(slack): restore bare `[cmd] [args]` routing — remove Phase 1 gates (#531)
- `351f9cd` feat(skills): add architecture-diagram skill from Hermes Agent (#528)

**Stats:** 6 files, +900 / -57

## Highlights

**#531 — Slack command routing restoration**
- Bare `[cmd] [args]` (thread + `@bot`) 실행 복원 — pre-#509 동작 회복
- `/z [cmd] [args]` 경로 보존 (ZRouter + Block Kit UI 그대로)
- 3-path coexistence: bare / `/z` thread / `@bot /z`
- 25 new RED tests, red/green proof (23/34 fail → 34/34 pass)
- codex 96/100 + 97/100 APPROVE

**#528 — architecture-diagram skill 추가**
- 새 local skill (SKILL.md + template.html), 기존 기능 영향 없음

## Deploy Targets
- mac-mini-dev
- oudwood-dev

Co-Authored-By: Zhuge <z@2lab.ai>