### PR TITLE
fix(cct-store): reinterpret malformed "v2 with v1 body" on load

### DIFF
--- a/src/cct-store/store.test.ts
+++ b/src/cct-store/store.test.ts
@@ -396,3 +396,113 @@ describe('CctStore.load — v1 → v2 migration on first read', () => {
     warnSpy.mockRestore();
   });
 });
+
+describe('CctStore.load — malformed v2 recovery', () => {
+  let tmp: string;
+  beforeEach(async () => {
+    tmp = await makeTmpDir();
+  });
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('reinterprets "version:2 with v1 body" as v1 and re-runs migration', async () => {
+    const filePath = path.join(tmp, 'cct-store.json');
+    // Shape observed on a production dev host: version was flipped to 2 but
+    // slots/registry are still v1-shaped and `state` is absent entirely.
+    const malformed = {
+      version: 2,
+      revision: 5135,
+      registry: {
+        slots: [
+          {
+            slotId: '01KPG2HKB3DXZY74QWVMBNC2X9',
+            name: 'ai2',
+            kind: 'setup_token',
+            value: 'sk-ant-oat01-aaa',
+            createdAt: '2026-04-18T10:35:21.827Z',
+          },
+          {
+            slotId: '01KPG2HKBZJDTF9QPN0H19WHS5',
+            name: 'ai3',
+            kind: 'setup_token',
+            value: 'sk-ant-oat01-bbb',
+            createdAt: '2026-04-18T10:35:21.855Z',
+          },
+        ],
+        activeSlotId: '01KPG2HKB3DXZY74QWVMBNC2X9',
+      },
+    };
+    await fs.writeFile(filePath, JSON.stringify(malformed, null, 2), 'utf8');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = new CctStore(filePath);
+    const loaded = await store.load();
+
+    // The in-memory snapshot is valid v2.
+    expect(loaded.version).toBe(2);
+    expect(loaded.revision).toBe(5135);
+    expect(loaded.registry.activeKeyId).toBe('01KPG2HKB3DXZY74QWVMBNC2X9');
+    expect(loaded.registry.slots).toHaveLength(2);
+    for (const slot of loaded.registry.slots) {
+      expect(slot.kind).toBe('cct');
+      if (slot.kind !== 'cct') throw new Error('unreachable');
+      expect(slot.source).toBe('setup');
+      if (slot.source !== 'setup') throw new Error('unreachable');
+      expect(typeof slot.keyId).toBe('string');
+      expect(slot.keyId.length).toBeGreaterThan(0);
+      expect(typeof slot.setupToken).toBe('string');
+    }
+    expect(loaded.state).toEqual({});
+
+    // Disk is rewritten as proper v2.
+    const disk = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    expect(disk.version).toBe(2);
+    expect(disk.registry.activeKeyId).toBe('01KPG2HKB3DXZY74QWVMBNC2X9');
+    expect('activeSlotId' in disk.registry).toBe(false);
+    expect(disk.registry.slots[0]).toMatchObject({ kind: 'cct', source: 'setup' });
+    expect(disk.registry.slots[0].setupToken).toBe('sk-ant-oat01-aaa');
+    expect('slotId' in disk.registry.slots[0]).toBe(false);
+    expect('value' in disk.registry.slots[0]).toBe(false);
+    expect(disk.state).toEqual({});
+
+    // We surface a single warning so operators notice the repair.
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('defaults missing `state` to {} on an otherwise valid v2 file', async () => {
+    const filePath = path.join(tmp, 'cct-store.json');
+    const missingStateV2 = {
+      version: 2,
+      revision: 1,
+      registry: {
+        activeKeyId: 'k-only',
+        slots: [
+          {
+            kind: 'cct',
+            source: 'setup',
+            keyId: 'k-only',
+            name: 'only',
+            setupToken: 'sk-ant-oat01-solo',
+            createdAt: '2026-04-18T00:00:00.000Z',
+          },
+        ],
+      },
+    };
+    await fs.writeFile(filePath, JSON.stringify(missingStateV2, null, 2), 'utf8');
+
+    const store = new CctStore(filePath);
+    const loaded = await store.load();
+    expect(loaded.version).toBe(2);
+    // In-memory repair: subsequent `snap.state[keyId]` reads are safe.
+    expect(loaded.state).toEqual({});
+
+    // The first write after a repaired read persists the normalised shape.
+    await store.mutate((snap) => {
+      snap.state[snap.registry.slots[0].keyId] = { authState: 'healthy', activeLeases: [] };
+    });
+    const disk = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    expect(disk.state['k-only']).toEqual({ authState: 'healthy', activeLeases: [] });
+  });
+});

--- a/src/cct-store/store.ts
+++ b/src/cct-store/store.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import lockfile from 'proper-lockfile';
 import { migrateLegacyCooldowns } from './migrate';
 import { migrateV1ToV2 } from './migrate-v2';
-import type { CctStoreSnapshot, PersistedSnapshot } from './types';
+import type { CctStoreSnapshot, LegacyV1Snapshot, LegacyV1TokenSlot, PersistedSnapshot, SlotState } from './types';
 
 const MAX_CAS_RETRIES = 5;
 const CAS_BACKOFF_MS = 20;
@@ -51,6 +51,67 @@ async function pathExists(target: string): Promise<boolean> {
 async function readSnapshotRaw(filePath: string): Promise<PersistedSnapshot> {
   const raw = await fs.readFile(filePath, 'utf8');
   return JSON.parse(raw) as PersistedSnapshot;
+}
+
+/**
+ * Guard against a pathological on-disk shape where `version: 2` coexists with
+ * a v1-styled body (slots keyed by `slotId`/`value`, registry with
+ * `activeSlotId`, absent `state`). This is not a shape any code path in the
+ * current tree emits, but it has been observed in the wild — typically when
+ * an operator hand-edits `cct-store.json` (or a short-lived PR that wrote v2
+ * prematurely gets reverted, leaving the next boot staring at a mislabelled
+ * v1 body). Without this guard, `load()` would trust the declared version,
+ * skip migration, and downstream `snap.state[slot.keyId]` blows up with the
+ * diagnostic-hostile `Cannot read properties of undefined (reading 'undefined')`.
+ *
+ * The repair strategy is deliberately narrow:
+ *   - v1-shaped slots present → relabel the snapshot as v1 so the normal
+ *     `migrateV1ToV2` path handles it (and persists the canonical v2 shape).
+ *   - v2-shaped body with `state` missing → fill in `{}` and return; callers
+ *     treat this as a non-migration load, so the repair is only persisted on
+ *     the next write.
+ */
+function reinterpretIfMalformed(raw: PersistedSnapshot): PersistedSnapshot {
+  if (raw.version !== 2) return raw;
+
+  const slots = (raw.registry as { slots?: unknown[] } | undefined)?.slots;
+  const hasV1Slots =
+    Array.isArray(slots) &&
+    slots.length > 0 &&
+    slots.every(
+      (s) =>
+        typeof (s as { slotId?: unknown })?.slotId === 'string' &&
+        typeof (s as { keyId?: unknown })?.keyId !== 'string',
+    );
+
+  if (hasV1Slots) {
+    console.warn(
+      'cct-store: on-disk file claims version:2 but body is v1-shaped — ' +
+        're-running v1→v2 migration. Check for a stray manual edit or an aborted schema rollout.',
+    );
+    const registry = raw.registry as { activeSlotId?: string; activeKeyId?: string; slots?: unknown[] };
+    const activeSlotId = registry.activeSlotId ?? registry.activeKeyId;
+    const state = ((raw as { state?: Record<string, SlotState> }).state ?? {}) as Record<string, SlotState>;
+    const v1: LegacyV1Snapshot = {
+      version: 1,
+      revision: raw.revision,
+      registry: {
+        slots: slots as LegacyV1TokenSlot[],
+        ...(activeSlotId !== undefined ? { activeSlotId } : {}),
+      },
+      state,
+    };
+    return v1;
+  }
+
+  // Well-formed v2 with an absent state map: normalise so every downstream
+  // `snap.state[keyId]` read is well-defined. We return a new object; the
+  // caller decides whether to persist (load() currently does not, which keeps
+  // the happy path zero-write).
+  if ((raw as { state?: unknown }).state === undefined) {
+    return { ...(raw as CctStoreSnapshot), state: {} };
+  }
+  return raw;
 }
 
 function randomHex(bytes: number): string {
@@ -109,6 +170,10 @@ export class CctStore {
     } else {
       raw = emptySnapshot();
     }
+
+    // Repair a mislabelled v2 body (observed in the wild after manual edits)
+    // BEFORE any downstream consumer trusts `raw.version`.
+    raw = reinterpretIfMalformed(raw);
 
     const dir = path.dirname(this.filePath);
     const cooldownResult = await migrateLegacyCooldowns(raw, dir);
@@ -247,8 +312,12 @@ export class CctStore {
       retries: { retries: 50, minTimeout: 10, maxTimeout: 100 },
     });
     try {
-      // Re-read under the lock.
-      const diskRaw = (await pathExists(this.filePath)) ? await readSnapshotRaw(this.filePath) : emptySnapshot();
+      // Re-read under the lock, and repair any mislabelled v2 body so we
+      // don't short-circuit into a malformed snapshot on the "race-won" path
+      // below.
+      const diskRaw = (await pathExists(this.filePath))
+        ? reinterpretIfMalformed(await readSnapshotRaw(this.filePath))
+        : emptySnapshot();
 
       // Race-won path: another writer already upgraded the file to v2.
       // Prefer their snapshot over our in-memory copy so we don't clobber


### PR DESCRIPTION
## Summary

- Observed on a prod dev host after PR #612 landed: `cct-store.json` had `version: 2` but a v1-shaped body — slots keyed by `slotId`/`value`, registry with `activeSlotId`, and `state` absent. The loader trusted the declared version, skipped migration, and every downstream `snap.state[slot.keyId]` blew up with `Cannot read properties of undefined (reading 'undefined')` — crash-looping the bot inside `PidLock` before any request could land.
- Add `reinterpretIfMalformed()` to `load()` and `persistMigrated()`: v1-shaped slots + `version: 2` → relabel to v1 so `migrateV1ToV2` runs and the canonical v2 shape is persisted under the lock. Well-formed v2 with missing `state` → fill `{}` in-memory so downstream reads are defined; the normalised shape persists on the next write.
- TDD: RED→GREEN with two new tests covering the production shape and the missing-state edge case. Existing migration + CAS suites unaffected.

## Background

The exact file that triggered the crash:

```jsonc
{
  "version": 2,          // ← claimed v2
  "revision": 5135,
  "registry": {
    "slots": [
      { "slotId": "…", "name": "ai2", "kind": "setup_token", "value": "sk-ant-oat01-…", … }
      // … 5 more setup_token slots, all with slotId/value (v1 shape)
    ],
    "activeSlotId": "…"   // ← v1 field, not activeKeyId
  }
  // no `state` field at all
}
```

`CctStore.load()` cast `raw as CctStoreSnapshot`, so `snap.state` was `undefined`, `snap.registry.activeKeyId` was `undefined`, and every slot's `keyId` was `undefined`. `TokenManager.ensureActiveSlot()` reached `snap.registry.slots.find((s) => isEligible(snap.state[s.keyId], now))` → `undefined[undefined]` → TypeError.

This file shape is not something the current tree emits. Likely origins are an aborted schema-rollout (PR #596 landed then was reverted by #604 before #612) or an operator hand-edit. Either way, the loader should heal itself instead of crash-looping.

## Test plan

- [x] `npx vitest run src/cct-store/` — 21/21 pass (includes 2 new tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — exit 0
- [x] Full suite: baseline 117 failed / 4502 passed (pre-existing, unrelated to cct-store); after this PR: 117 failed / **4504 passed**. No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)