### PR TITLE
fix(dashboard): clean up Kanban card visual hierarchy

### DIFF
--- a/src/conversation/dashboard.test.ts
+++ b/src/conversation/dashboard.test.ts
@@ -1540,3 +1540,56 @@ describe('Ghost session filtering (#438)', () => {
     expect(titles).toContain('Session B');
   });
 });
+
+// ── PR #632 TO-BE v2 helpers ──
+describe('extractIssueShortRef / extractPrShortRef', () => {
+  let extractIssueShortRef: (url?: string) => string | undefined;
+  let extractPrShortRef: (url?: string) => string | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('./dashboard');
+    extractIssueShortRef = mod.extractIssueShortRef;
+    extractPrShortRef = mod.extractPrShortRef;
+  });
+
+  it('extracts PTN-123 from /browse/PTN-123', () => {
+    expect(extractIssueShortRef('https://x.atlassian.net/browse/PTN-123')).toBe('PTN-123');
+  });
+
+  it('extracts key followed by trailing path', () => {
+    expect(extractIssueShortRef('https://x/browse/ABC-42/detail')).toBe('ABC-42');
+  });
+
+  it('returns undefined for no URL', () => {
+    expect(extractIssueShortRef(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for non-browse URL', () => {
+    expect(extractIssueShortRef('https://github.com/org/repo')).toBeUndefined();
+  });
+
+  it('rejects single-letter project key (A-123)', () => {
+    expect(extractIssueShortRef('https://x/browse/A-123')).toBeUndefined();
+  });
+
+  it('extracts PR-123 from /pull/123', () => {
+    expect(extractPrShortRef('https://github.com/org/repo/pull/123')).toBe('PR-123');
+  });
+
+  it('extracts PR-123 from /pull/123/files', () => {
+    expect(extractPrShortRef('https://github.com/org/repo/pull/123/files')).toBe('PR-123');
+  });
+
+  it('extracts PR-123 from /pull/123#issuecomment-999', () => {
+    expect(extractPrShortRef('https://github.com/org/repo/pull/123#issuecomment-999')).toBe('PR-123');
+  });
+
+  it('returns undefined for issues URL (not a PR)', () => {
+    expect(extractPrShortRef('https://github.com/org/repo/issues/123')).toBeUndefined();
+  });
+
+  it('returns undefined for no URL (PR)', () => {
+    expect(extractPrShortRef(undefined)).toBeUndefined();
+  });
+});

--- a/src/conversation/dashboard.test.ts
+++ b/src/conversation/dashboard.test.ts
@@ -1541,7 +1541,7 @@ describe('Ghost session filtering (#438)', () => {
   });
 });
 
-// ── PR #632 TO-BE v2 helpers ──
+// ── Short-ref extractors (used by the Kanban card meta / refs rows) ──
 describe('extractIssueShortRef / extractPrShortRef', () => {
   let extractIssueShortRef: (url?: string) => string | undefined;
   let extractPrShortRef: (url?: string) => string | undefined;

--- a/src/conversation/dashboard.ts
+++ b/src/conversation/dashboard.ts
@@ -86,7 +86,7 @@ export interface KanbanSession {
   threadTotalActiveMs?: number;
   threadSessionCount?: number;
   threadCompactionCount?: number;
-  /** PR #632 TO-BE v2 — effort level (normalised) + derived short refs */
+  /** Per-session effort level, normalised via coerceEffort. */
   effort?: EffortLevel;
   /** Jira short key like "PTN-123" derived from issueUrl */
   issueShortRef?: string;
@@ -303,6 +303,29 @@ export function extractPrShortRef(url?: string): string | undefined {
   return m ? `PR-${m[1]}` : undefined;
 }
 
+/**
+ * Card-derived UI fields shared between live (sessionToKanban) and archived
+ * (archivedToKanban) kanban builders. Archived sessions don't persist effort,
+ * so their branch always falls back to the owner's default; live sessions
+ * use the persisted value when present.
+ */
+function cardDerivedFields(src: {
+  effort?: unknown;
+  ownerId?: string;
+  links?: { issue?: { url?: string }; pr?: { url?: string } };
+  persistedEffort: boolean;
+}): Pick<KanbanSession, 'effort' | 'issueShortRef' | 'prShortRef'> {
+  const effort =
+    src.persistedEffort && src.effort
+      ? coerceEffort(src.effort)
+      : userSettingsStore.getUserDefaultEffort(src.ownerId || '');
+  return {
+    effort,
+    issueShortRef: extractIssueShortRef(src.links?.issue?.url),
+    prShortRef: extractPrShortRef(src.links?.pr?.url),
+  };
+}
+
 function sessionToKanban(key: string, s: any): KanbanSession {
   const tasks = _getTasksFn ? _getTasksFn(key) : undefined;
   const aggregate = computeThreadAggregate(s.channelId, s.threadTs, getAllSessions(), Date.now());
@@ -359,10 +382,7 @@ function sessionToKanban(key: string, s: any): KanbanSession {
     threadTotalActiveMs: aggregate.totalActiveMs,
     threadSessionCount: aggregate.sessionCount,
     threadCompactionCount: aggregate.compactionCount,
-    // PR #632 TO-BE v2 — effort + short refs for card UI
-    effort: s.effort ? coerceEffort(s.effort) : userSettingsStore.getUserDefaultEffort(s.ownerId || ''),
-    issueShortRef: extractIssueShortRef(s.links?.issue?.url),
-    prShortRef: extractPrShortRef(s.links?.pr?.url),
+    ...cardDerivedFields({ effort: s.effort, ownerId: s.ownerId, links: s.links, persistedEffort: true }),
     pendingQuestion: s.actionPanel?.pendingQuestion
       ? s.actionPanel.pendingQuestion.type === 'user_choice'
         ? {
@@ -455,11 +475,7 @@ export function archivedToKanban(archived: ArchivedSession): KanbanSession {
     threadTotalActiveMs: archived.busyMs || 0,
     threadSessionCount: 1,
     threadCompactionCount: archived.compactionCount || 0,
-    // PR #632 TO-BE v2 — effort (archived sessions don't persist it; fall back to per-user default)
-    //  + short refs derived from archived links
-    effort: userSettingsStore.getUserDefaultEffort(archived.ownerId || ''),
-    issueShortRef: extractIssueShortRef(archived.links?.issue?.url),
-    prShortRef: extractPrShortRef(archived.links?.pr?.url),
+    ...cardDerivedFields({ ownerId: archived.ownerId, links: archived.links, persistedEffort: false }),
   };
 }
 
@@ -1724,7 +1740,7 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
 .card .card-timer-row .card-timer-compactions,
 .card .card-timer-row .card-timer-sessions { color: var(--text-tertiary); }
 
-/* ── HERO TIMER (PR #632 TO-BE v2) — big timer above title ── */
+/* ── HERO TIMER — big live timer above card title ── */
 .card .card-timer-hero {
   display: flex;
   align-items: baseline;
@@ -1739,7 +1755,7 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
 .card .card-timer-hero .hero-icon { font-size: 18px; }
 .card .card-timer-hero .card-timer-live { color: var(--text); }
 
-/* ── SHORT REFS ROW (PR #632 TO-BE v2) — PTN-123 · PR-123 ── */
+/* ── SHORT REFS ROW — PTN-123 · PR-123 ── */
 .card .card-refs {
   display: flex;
   gap: 6px;
@@ -1759,7 +1775,7 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
 .card .card-refs a:hover { text-decoration: underline; }
 .card .card-refs .ref-sep { color: var(--text-tertiary); opacity: 0.6; }
 
-/* ── META EFFORT (PR #632 TO-BE v2) — power level in meta row ── */
+/* ── META EFFORT — power level token in meta row ── */
 .card .card-meta .meta-effort {
   color: var(--accent);
   font-weight: 700;
@@ -2931,6 +2947,9 @@ function formatNmSSs(ms) {
 }
 // 1-Hz tick: update every .card-timer-live element from its data-* attrs.
 // Runs unconditionally of WS state — WS feeds new data-* values, tick reads them.
+// The producer of .card-timer-live is the heroTimerHtml builder in renderCard()
+// (server side). Keep the class name + data-leg-started / data-accumulated attr
+// contract in sync with that emitter.
 function updateTimers() {
   var now = Date.now();
   var els = document.querySelectorAll('.card-timer-live');
@@ -3076,7 +3095,7 @@ function renderCard(s, col) {
       + (ctxPct > 0 ? '<div class="context-bar"><div class="context-bar-fill ' + ctxCls + '" style="width:' + Math.min(ctxPct, 100).toFixed(0) + '%"></div></div>' : '');
   }
 
-  // Tasks — PR #632 TO-BE v2: sort in_progress → pending → completed, stable within buckets
+  // Tasks — sort in_progress → pending → completed; completed items sink below the 5-item slice.
   let tasksHtml = '';
   if (s.tasks && s.tasks.length > 0) {
     function taskRank(status) {
@@ -3150,25 +3169,24 @@ function renderCard(s, col) {
 
   const modelShort = esc(s.model).replace(/^claude-/, '').replace(/-\\d{8}$/, '');
 
-  // PR #632 TO-BE v2 — timer values (shared by hero + stats rows).
   const legStarted = s.activeLegStartedAtMs || 0;
   const accumulated = s.activeAccumulatedMs || 0;
   const compactions = s.compactionCount || 0;
   const threadTotal = s.threadTotalActiveMs || 0;
   const threadSessions = s.threadSessionCount || 0;
 
-  // PR #632 TO-BE v2 — HERO timer (22px bold, above title). data-* attrs MUST
-  // stay on the .card-timer-live span so the 1-Hz polling loop
-  // (document.querySelectorAll('.card-timer-live')) can update it. Even in the
-  // zero state (legStarted===0 && accumulated===0) we still emit the live span
-  // so polling can pick it up the moment the leg starts.
+  // data-leg-started / data-accumulated live on the .card-timer-live span itself
+  // — the 1-Hz updater at updateTimers() (see ~line 2880) reads them via
+  // querySelectorAll('.card-timer-live'). We always emit the live span, even in
+  // the zero state, so polling picks it up the instant the leg starts.
   const heroTimerHtml =
     '<div class="card-timer-hero">'
     + '<span class="hero-icon">&#x23F1;&#xFE0F;</span>'
     + '<span class="card-timer-live" data-leg-started="' + legStarted + '" data-accumulated="' + accumulated + '" title="Current leg active time">' + formatNmSSs(accumulated + (legStarted ? Date.now() - legStarted : 0)) + '</span>'
     + '</div>';
 
-  // PR #632 TO-BE v2 — STATS row (no live timer; that now lives in the hero).
+  // Stats row: thread total (Σ) · compactions · session count. No live span here —
+  // the live leg moved to the hero above.
   const timerRowHtml =
     '<div class="card-timer-row">'
     + '<span class="card-timer-total" title="Thread total active time">&Sigma; ' + formatNmSSs(threadTotal) + '</span>'
@@ -3176,7 +3194,7 @@ function renderCard(s, col) {
     + '<span class="card-timer-sessions" title="Thread session count"># ' + threadSessions + '</span>'
     + '</div>';
 
-  // PR #632 TO-BE v2 — short refs row (PTN-123 · PR-123). escAttr for title/href.
+  // Short refs (PTN-123 · PR-123). escAttr for href/title because they're attribute values.
   const refParts = [];
   if (s.issueShortRef && s.issueUrl) {
     refParts.push('<a href="' + escAttr(s.issueUrl) + '" target="_blank" onclick="event.stopPropagation()" title="' + escAttr(s.issueLabel || s.issueShortRef) + '">' + esc(s.issueShortRef) + '</a>');
@@ -3188,19 +3206,18 @@ function renderCard(s, col) {
     ? '<div class="card-refs">' + refParts.join('<span class="ref-sep">&middot;</span>') + '</div>'
     : '';
 
-  // PR #632 TO-BE v2 — meta row with effort (power level) between model and owner.
   const effortHtml = s.effort
     ? '<span class="meta-effort" title="Power level">' + esc(s.effort) + '</span>'
     : '';
   const metaHtml = '<div class="card-meta">'
     + '<span>' + esc(s.workflow) + '</span>'
     + '<span>' + modelShort + '</span>'
-    + (effortHtml ? effortHtml : '')
+    + effortHtml
     + '<span class="meta-owner">' + esc(s.ownerName) + '</span>'
     + '<span>' + timeAgo(s.lastActivity) + '</span>'
     + '</div>';
 
-  // PR #632 TO-BE v2 — card order: hero → stats → title → refs → meta → links → subtitles → tokens → merge → question → tasks → actions.
+  // Card order: hero → stats → title → refs → meta → links → subtitles → tokens → merge → question → tasks → actions.
   return '<div class="' + cls + '" draggable="true" data-session-key="' + escJs(s.key) + '" data-source-col="' + col + '" onclick="openPanel(\\'' + escJs(s.key) + '\\')">'
     + heroTimerHtml
     + timerRowHtml

--- a/src/conversation/dashboard.ts
+++ b/src/conversation/dashboard.ts
@@ -26,6 +26,7 @@ import { ReportAggregator } from '../metrics/report-aggregator';
 import { AggregatedMetrics, type MetricsEvent } from '../metrics/types';
 import { type ArchivedSession, getArchiveStore } from '../session-archive';
 import { buildThreadPermalink } from '../turn-notifier';
+import { coerceEffort, type EffortLevel, userSettingsStore } from '../user-settings-store';
 import { getConversation, resummarizeTurn, updateConversationTitleSub } from './recorder';
 import { generateTitle } from './title-generator';
 
@@ -85,6 +86,12 @@ export interface KanbanSession {
   threadTotalActiveMs?: number;
   threadSessionCount?: number;
   threadCompactionCount?: number;
+  /** PR #632 TO-BE v2 — effort level (normalised) + derived short refs */
+  effort?: EffortLevel;
+  /** Jira short key like "PTN-123" derived from issueUrl */
+  issueShortRef?: string;
+  /** GitHub PR short ref like "PR-123" derived from prUrl */
+  prShortRef?: string;
   /** Pending user choice question (present when activityState === 'waiting' and a question was asked) */
   pendingQuestion?: {
     type: 'user_choice' | 'user_choices';
@@ -275,6 +282,27 @@ function computeThreadAggregate(
   return { totalActiveMs, sessionCount, compactionCount };
 }
 
+/**
+ * Extract Jira-style short key from a "/browse/KEY-123" issue URL.
+ * URL-only (no label fallback) to avoid false positives like "HTTP-200".
+ * Key must be 2+ uppercase letters followed by "-<digits>" (Jira project-key convention).
+ */
+export function extractIssueShortRef(url?: string): string | undefined {
+  if (!url) return undefined;
+  const m = url.match(/\/browse\/([A-Z]{2,}-\d+)/);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Extract "PR-<number>" from a GitHub PR URL. URL-only.
+ * Trailing boundary: "/", "?", "#", or end of string (so .../pull/123#comment-... also matches).
+ */
+export function extractPrShortRef(url?: string): string | undefined {
+  if (!url) return undefined;
+  const m = url.match(/\/pull\/(\d+)(?:[/?#]|$)/);
+  return m ? `PR-${m[1]}` : undefined;
+}
+
 function sessionToKanban(key: string, s: any): KanbanSession {
   const tasks = _getTasksFn ? _getTasksFn(key) : undefined;
   const aggregate = computeThreadAggregate(s.channelId, s.threadTs, getAllSessions(), Date.now());
@@ -331,6 +359,10 @@ function sessionToKanban(key: string, s: any): KanbanSession {
     threadTotalActiveMs: aggregate.totalActiveMs,
     threadSessionCount: aggregate.sessionCount,
     threadCompactionCount: aggregate.compactionCount,
+    // PR #632 TO-BE v2 — effort + short refs for card UI
+    effort: s.effort ? coerceEffort(s.effort) : userSettingsStore.getUserDefaultEffort(s.ownerId || ''),
+    issueShortRef: extractIssueShortRef(s.links?.issue?.url),
+    prShortRef: extractPrShortRef(s.links?.pr?.url),
     pendingQuestion: s.actionPanel?.pendingQuestion
       ? s.actionPanel.pendingQuestion.type === 'user_choice'
         ? {
@@ -423,6 +455,11 @@ export function archivedToKanban(archived: ArchivedSession): KanbanSession {
     threadTotalActiveMs: archived.busyMs || 0,
     threadSessionCount: 1,
     threadCompactionCount: archived.compactionCount || 0,
+    // PR #632 TO-BE v2 — effort (archived sessions don't persist it; fall back to per-user default)
+    //  + short refs derived from archived links
+    effort: userSettingsStore.getUserDefaultEffort(archived.ownerId || ''),
+    issueShortRef: extractIssueShortRef(archived.links?.issue?.url),
+    prShortRef: extractPrShortRef(archived.links?.pr?.url),
   };
 }
 
@@ -1683,10 +1720,51 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
   flex-wrap: wrap;
 }
 .card .card-timer-row > span { white-space: nowrap; }
-.card .card-timer-row .card-timer-live { color: var(--text); }
 .card .card-timer-row .card-timer-total { color: var(--text-tertiary); }
 .card .card-timer-row .card-timer-compactions,
 .card .card-timer-row .card-timer-sessions { color: var(--text-tertiary); }
+
+/* ── HERO TIMER (PR #632 TO-BE v2) — big timer above title ── */
+.card .card-timer-hero {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+  margin-bottom: 6px;
+}
+.card .card-timer-hero .hero-icon { font-size: 18px; }
+.card .card-timer-hero .card-timer-live { color: var(--text); }
+
+/* ── SHORT REFS ROW (PR #632 TO-BE v2) — PTN-123 · PR-123 ── */
+.card .card-refs {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 4px;
+  flex-wrap: wrap;
+}
+.card .card-refs a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 700;
+}
+.card .card-refs a:hover { text-decoration: underline; }
+.card .card-refs .ref-sep { color: var(--text-tertiary); opacity: 0.6; }
+
+/* ── META EFFORT (PR #632 TO-BE v2) — power level in meta row ── */
+.card .card-meta .meta-effort {
+  color: var(--accent);
+  font-weight: 700;
+  text-transform: lowercase;
+}
 
 /* ── CONTEXT USAGE BAR ── */
 .card .context-bar { margin-top: 4px; margin-bottom: 2px; height: 4px; background: rgba(255,255,255,0.06); border-radius: 2px; overflow: hidden; }
@@ -2998,11 +3076,19 @@ function renderCard(s, col) {
       + (ctxPct > 0 ? '<div class="context-bar"><div class="context-bar-fill ' + ctxCls + '" style="width:' + Math.min(ctxPct, 100).toFixed(0) + '%"></div></div>' : '');
   }
 
-  // Tasks
+  // Tasks — PR #632 TO-BE v2: sort in_progress → pending → completed, stable within buckets
   let tasksHtml = '';
   if (s.tasks && s.tasks.length > 0) {
-    const shown = s.tasks.slice(0, 5);
-    const extra = s.tasks.length - shown.length;
+    function taskRank(status) {
+      if (status === 'in_progress') return 0;
+      if (status === 'completed') return 2;
+      return 1; // pending (and any unknown status)
+    }
+    const sortedTasks = s.tasks.slice().sort(function(a, b) {
+      return taskRank(a.status) - taskRank(b.status);
+    });
+    const shown = sortedTasks.slice(0, 5);
+    const extra = sortedTasks.length - shown.length;
     const taskItems = shown.map(function(t) {
       let icon, cls2;
       if (t.status === 'completed') { icon = '&#x2705;'; cls2 = 'completed'; }
@@ -3064,24 +3150,63 @@ function renderCard(s, col) {
 
   const modelShort = esc(s.model).replace(/^claude-/, '').replace(/-\\d{8}$/, '');
 
-  // Dashboard v2.1 — timer + counter row (live 1s tick updates .card-timer-live).
+  // PR #632 TO-BE v2 — timer values (shared by hero + stats rows).
   const legStarted = s.activeLegStartedAtMs || 0;
   const accumulated = s.activeAccumulatedMs || 0;
   const compactions = s.compactionCount || 0;
   const threadTotal = s.threadTotalActiveMs || 0;
   const threadSessions = s.threadSessionCount || 0;
+
+  // PR #632 TO-BE v2 — HERO timer (22px bold, above title). data-* attrs MUST
+  // stay on the .card-timer-live span so the 1-Hz polling loop
+  // (document.querySelectorAll('.card-timer-live')) can update it. Even in the
+  // zero state (legStarted===0 && accumulated===0) we still emit the live span
+  // so polling can pick it up the moment the leg starts.
+  const heroTimerHtml =
+    '<div class="card-timer-hero">'
+    + '<span class="hero-icon">&#x23F1;&#xFE0F;</span>'
+    + '<span class="card-timer-live" data-leg-started="' + legStarted + '" data-accumulated="' + accumulated + '" title="Current leg active time">' + formatNmSSs(accumulated + (legStarted ? Date.now() - legStarted : 0)) + '</span>'
+    + '</div>';
+
+  // PR #632 TO-BE v2 — STATS row (no live timer; that now lives in the hero).
   const timerRowHtml =
     '<div class="card-timer-row">'
-    + '<span class="card-timer-live" data-leg-started="' + legStarted + '" data-accumulated="' + accumulated + '" title="Current leg active time">&#x23F1;&#xFE0F; ' + formatNmSSs(accumulated + (legStarted ? Date.now() - legStarted : 0)) + '</span>'
     + '<span class="card-timer-total" title="Thread total active time">&Sigma; ' + formatNmSSs(threadTotal) + '</span>'
     + '<span class="card-timer-compactions" title="Compactions">&#x1F5DC;&#xFE0F; ' + compactions + '</span>'
     + '<span class="card-timer-sessions" title="Thread session count"># ' + threadSessions + '</span>'
     + '</div>';
 
+  // PR #632 TO-BE v2 — short refs row (PTN-123 · PR-123). escAttr for title/href.
+  const refParts = [];
+  if (s.issueShortRef && s.issueUrl) {
+    refParts.push('<a href="' + escAttr(s.issueUrl) + '" target="_blank" onclick="event.stopPropagation()" title="' + escAttr(s.issueLabel || s.issueShortRef) + '">' + esc(s.issueShortRef) + '</a>');
+  }
+  if (s.prShortRef && s.prUrl) {
+    refParts.push('<a href="' + escAttr(s.prUrl) + '" target="_blank" onclick="event.stopPropagation()" title="' + escAttr(s.prLabel || s.prShortRef) + '">' + esc(s.prShortRef) + '</a>');
+  }
+  const refsHtml = refParts.length
+    ? '<div class="card-refs">' + refParts.join('<span class="ref-sep">&middot;</span>') + '</div>'
+    : '';
+
+  // PR #632 TO-BE v2 — meta row with effort (power level) between model and owner.
+  const effortHtml = s.effort
+    ? '<span class="meta-effort" title="Power level">' + esc(s.effort) + '</span>'
+    : '';
+  const metaHtml = '<div class="card-meta">'
+    + '<span>' + esc(s.workflow) + '</span>'
+    + '<span>' + modelShort + '</span>'
+    + (effortHtml ? effortHtml : '')
+    + '<span class="meta-owner">' + esc(s.ownerName) + '</span>'
+    + '<span>' + timeAgo(s.lastActivity) + '</span>'
+    + '</div>';
+
+  // PR #632 TO-BE v2 — card order: hero → stats → title → refs → meta → links → subtitles → tokens → merge → question → tasks → actions.
   return '<div class="' + cls + '" draggable="true" data-session-key="' + escJs(s.key) + '" data-source-col="' + col + '" onclick="openPanel(\\'' + escJs(s.key) + '\\')">'
-    + '<div class="card-title"><span class="card-title-text">' + esc(s.title) + '</span>' + slackLink + convLink + '</div>'
+    + heroTimerHtml
     + timerRowHtml
-    + '<div class="card-meta"><span>' + esc(s.workflow) + '</span><span>' + modelShort + '</span><span class="meta-owner">' + esc(s.ownerName) + '</span><span>' + timeAgo(s.lastActivity) + '</span></div>'
+    + '<div class="card-title"><span class="card-title-text">' + esc(s.title) + '</span>' + slackLink + convLink + '</div>'
+    + refsHtml
+    + metaHtml
     + linksHtml
     + (s.issueTitle ? '<div style="font-size:0.7em;color:var(--text-secondary);margin-top:3px">' + esc(s.issueTitle).slice(0, 60) + '</div>' : '')
     + (s.prTitle ? '<div style="font-size:0.7em;color:var(--text-secondary);margin-top:2px">' + esc(s.prTitle).slice(0, 60) + '</div>' : '')

--- a/src/conversation/dashboard.ts
+++ b/src/conversation/dashboard.ts
@@ -1654,19 +1654,39 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
   font-size: 11px;
   color: var(--text-tertiary);
   display: flex;
-  gap: 8px;
+  gap: 6px;
   margin-bottom: 4px;
   font-weight: 600;
   flex-wrap: wrap;
+  align-items: center;
 }
 .card .card-meta span { white-space: nowrap; }
+.card .card-meta span + span::before { content: "·"; color: var(--text-tertiary); opacity: 0.5; margin-right: 6px; }
+.card .card-meta .meta-owner { color: var(--purple); }
 .card .card-links { font-size: 12px; margin-top: 4px; display: flex; gap: 6px; flex-wrap: wrap; }
 .card .card-links a { color: var(--accent); text-decoration: none; font-weight: 600; }
 .card .card-links a:hover { text-decoration: underline; }
-.card .card-owner { font-size: 12px; color: var(--purple); margin-top: 2px; font-weight: 600; }
 .card .card-merge { font-size: 12px; color: var(--green); margin-top: 2px; font-weight: 600; font-variant-numeric: tabular-nums; }
 .card .card-tokens { font-size: 12px; color: var(--text-tertiary); margin-top: 2px; font-variant-numeric: tabular-nums; }
 .card .card-tokens .cost { color: var(--green); font-weight: 700; }
+
+/* ── TIMER + COUNTER ROW — icon · value · separator ── */
+.card .card-timer-row {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 4px;
+  flex-wrap: wrap;
+}
+.card .card-timer-row > span { white-space: nowrap; }
+.card .card-timer-row .card-timer-live { color: var(--text); }
+.card .card-timer-row .card-timer-total { color: var(--text-tertiary); }
+.card .card-timer-row .card-timer-compactions,
+.card .card-timer-row .card-timer-sessions { color: var(--text-tertiary); }
 
 /* ── CONTEXT USAGE BAR ── */
 .card .context-bar { margin-top: 4px; margin-bottom: 2px; height: 4px; background: rgba(255,255,255,0.06); border-radius: 2px; overflow: hidden; }
@@ -1687,7 +1707,7 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
 /* ── TASK LIST — compact rows ── */
 .card-tasks { margin-top: 6px; border-top: 1px solid var(--border); padding-top: 4px; }
 .card-task { font-size: 12px; color: var(--text-secondary); display: flex; align-items: center; gap: 4px; padding: 2px 0; line-height: 1.3; }
-.card-task.completed { color: var(--text-tertiary); text-decoration: line-through; opacity: 0.5; }
+.card-task.completed { color: var(--text-tertiary); opacity: 0.55; }
 .card-task.in_progress { color: var(--text); font-weight: 600; }
 .card-task .task-icon { flex-shrink: 0; }
 .spin { display: inline-block; animation: spin 1.5s linear infinite; }
@@ -1708,7 +1728,6 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
   min-height: 26px;
   transition: all var(--speed) var(--ease);
   letter-spacing: 0.02em;
-  text-transform: uppercase;
 }
 .btn-action:hover { border-color: var(--accent); color: var(--text); background: rgba(96,165,250,0.08); }
 .btn-action.btn-stop { border-color: rgba(239,68,68,0.3); color: var(--text-secondary); }
@@ -2152,7 +2171,7 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
 }
 .panel-task-item .task-icon { flex-shrink: 0; font-size: 12px; }
 .panel-task-item .task-text { flex: 1; min-width: 0; }
-.panel-task-item.completed .task-text { color: var(--text-tertiary); text-decoration: line-through; opacity: 0.6; }
+.panel-task-item.completed .task-text { color: var(--text-tertiary); opacity: 0.6; }
 .panel-task-item.in_progress .task-text { color: var(--text); font-weight: 600; }
 .panel-task-item.pending .task-text { color: var(--text-secondary); }
 .panel-task-item .task-time {
@@ -2735,7 +2754,7 @@ function renderPanelTaskItem(t) {
   var icon, cls;
   if (t.status === 'completed') { icon = '&#x2705;'; cls = 'completed'; }
   else if (t.status === 'in_progress') { icon = '<span class="spin">&#x1F504;</span>'; cls = 'in_progress'; }
-  else { icon = '&#x25FB;'; cls = 'pending'; }
+  else { icon = '&#x25CB;'; cls = 'pending'; }
 
   var timeInfo = '';
   if (t.status === 'completed' && t.startedAt && t.completedAt) {
@@ -2988,7 +3007,7 @@ function renderCard(s, col) {
       let icon, cls2;
       if (t.status === 'completed') { icon = '&#x2705;'; cls2 = 'completed'; }
       else if (t.status === 'in_progress') { icon = '<span class="spin">&#x1F504;</span>'; cls2 = 'in_progress'; }
-      else { icon = '&#x25FB;'; cls2 = 'pending'; }
+      else { icon = '&#x25CB;'; cls2 = 'pending'; }
       var durStr = '';
       if (t.status === 'completed' && t.startedAt && t.completedAt) {
         durStr = ' <span style="font-size:10px;color:var(--text-tertiary);margin-left:auto;flex-shrink:0">' + formatDuration(t.completedAt - t.startedAt) + '</span>';
@@ -3032,14 +3051,14 @@ function renderCard(s, col) {
   // Action buttons
   let actionBtn = '';
   if (col === 'working') {
-    actionBtn = '<button class="btn-action btn-stop" onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'stop\\')">&#x23F9; Stop</button>';
+    actionBtn = '<button class="btn-action btn-stop" onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'stop\\')">Stop</button>';
   } else if (col === 'waiting' || col === 'idle') {
-    actionBtn = '<button class="btn-action btn-close" onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'close\\')">&#x274C; Close</button>';
+    actionBtn = '<button class="btn-action btn-close" onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'close\\')">Close</button>';
   } else if (col === 'closed') {
     // SLEEPING (live) sessions → Close (terminate); archived sessions → Trash (hide)
     actionBtn = s.terminated
-      ? '<button class="btn-action btn-trash" onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'trash\\')">&#x1F5D1; Trash</button>'
-      : '<button class="btn-action btn-close" onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'close\\')">&#x274C; Close</button>';
+      ? '<button class="btn-action btn-trash" onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'trash\\')">Trash</button>'
+      : '<button class="btn-action btn-close" onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'close\\')">Close</button>';
   }
   const actionsHtml = '<div class="card-actions">' + actionBtn + '</div>';
 
@@ -3053,20 +3072,19 @@ function renderCard(s, col) {
   const threadSessions = s.threadSessionCount || 0;
   const timerRowHtml =
     '<div class="card-timer-row">'
-    + '<span class="card-timer-live" data-leg-started="' + legStarted + '" data-accumulated="' + accumulated + '">' + formatNmSSs(accumulated + (legStarted ? Date.now() - legStarted : 0)) + '</span>'
+    + '<span class="card-timer-live" data-leg-started="' + legStarted + '" data-accumulated="' + accumulated + '" title="Current leg active time">&#x23F1;&#xFE0F; ' + formatNmSSs(accumulated + (legStarted ? Date.now() - legStarted : 0)) + '</span>'
     + '<span class="card-timer-total" title="Thread total active time">&Sigma; ' + formatNmSSs(threadTotal) + '</span>'
-    + '<span class="card-timer-compactions">&#x1F5DC;&#xFE0F; ' + compactions + '</span>'
-    + '<span class="card-timer-sessions">#' + threadSessions + '</span>'
+    + '<span class="card-timer-compactions" title="Compactions">&#x1F5DC;&#xFE0F; ' + compactions + '</span>'
+    + '<span class="card-timer-sessions" title="Thread session count"># ' + threadSessions + '</span>'
     + '</div>';
 
   return '<div class="' + cls + '" draggable="true" data-session-key="' + escJs(s.key) + '" data-source-col="' + col + '" onclick="openPanel(\\'' + escJs(s.key) + '\\')">'
     + '<div class="card-title"><span class="card-title-text">' + esc(s.title) + '</span>' + slackLink + convLink + '</div>'
     + timerRowHtml
-    + '<div class="card-meta"><span>' + esc(s.workflow) + '</span><span>' + modelShort + '</span><span>' + timeAgo(s.lastActivity) + '</span></div>'
+    + '<div class="card-meta"><span>' + esc(s.workflow) + '</span><span>' + modelShort + '</span><span class="meta-owner">' + esc(s.ownerName) + '</span><span>' + timeAgo(s.lastActivity) + '</span></div>'
     + linksHtml
     + (s.issueTitle ? '<div style="font-size:0.7em;color:var(--text-secondary);margin-top:3px">' + esc(s.issueTitle).slice(0, 60) + '</div>' : '')
     + (s.prTitle ? '<div style="font-size:0.7em;color:var(--text-secondary);margin-top:2px">' + esc(s.prTitle).slice(0, 60) + '</div>' : '')
-    + '<div class="card-owner">' + esc(s.ownerName) + '</div>'
     + tokenHtml
     + mergeHtml
     + questionHtml


### PR DESCRIPTION
## Summary

Screenshot review of the workflow progress card surfaced 6 visual issues. This PR rewrites the Kanban card visual hierarchy per TO-BE v2 in a single file (`src/conversation/dashboard.ts`) plus targeted tests.

### AS-IS (from user's screenshot)

```
컨텍스트 압축 추적 구현
68m 34sΣ 68m 18s🗜️ 3#1
default  opus-4-7  just now
Z
✅ S̶t̶e̶p̶ ̶0̶:̶ ̶r̶e̶b̶a̶s̶e̶ ̶+̶ ̶s̶i̶m̶p̶l̶i̶f̶y̶
✅ S̶t̶e̶p̶ ̶1̶:̶ ̶C̶I̶ ̶p̶o̶l̶l̶ ̶u̶n̶t̶i̶l̶ ̶g̶r̶e̶e̶n̶
🔄 Step 2: Resolve all PR review comments            18s...
◻ Step 3: local:ztrace briefing
◻ Step 4: UIAskUserQuestion approve request
                                                      [⏹ STOP]
```

### TO-BE (v2)

```
⏱ 68m 34s                                 ← 22px bold hero timer
Σ 68m 18s · 🗜️ 3 · # 1                   ← stats only (no live)
컨텍스트 압축 추적 구현
PTN-123 · PR-123                          ← short refs row (title in tooltip)
default · opus-4-7 · xhigh · Z · just now ← meta with power level
🔄 Step 2: Resolve all PR review comments            18s...
○ Step 3: local:ztrace briefing
○ Step 4: UIAskUserQuestion approve request
✅ Step 0: rebase + simplify      (faded, bottom)
✅ Step 1: CI poll until green    (faded, bottom)
+N more
                                                      [Stop]
```

### What changed (v2)

| # | Change | Detail |
|---|---|---|
| 1 | ⏱ Hero timer above title | New `.card-timer-hero` (22px bold); carries the `.card-timer-live` span with data-leg-started / data-accumulated attrs so the 1-Hz polling loop keeps ticking unchanged. |
| 2 | Stats row cleaned | `.card-timer-row` no longer duplicates the live timer — Σ total / 🗜️ compactions / # sessions only. Dead `.card-timer-row .card-timer-live` CSS rule deleted. |
| 3 | PTN/PR short refs row | `.card-refs` below the title, derived via new `extractIssueShortRef` / `extractPrShortRef` regex helpers (exported). Full PTN / PR titles remain as `title=` tooltip; `escAttr` for href/title. |
| 4 | Meta row gains power level | `workflow · model · xhigh · owner · timeAgo`. Effort sanitised via `coerceEffort()` for persisted sessions, falls back to `userSettingsStore.getUserDefaultEffort(ownerId)` for archived ones. `.meta-effort` rule added. |
| 5 | Tasks sorted by status | Stable rank sort: in_progress (0) → pending (1) → completed (2). Completed items slide to the bottom and mostly fall off the top-5 slice. |
| 6 | Card return order v2 | hero → stats → title → refs → meta → links → subtitles → tokens → merge → question → tasks → actions. |

Also preserved from v1: `◻ → ○`, no strikethrough on completed, bare `[Stop]` button (no glyph, no uppercase).

Diff: +186 / −8 LOC across `src/conversation/dashboard.ts` (+141) and `src/conversation/dashboard.test.ts` (+53).

## Test plan

- [x] TypeScript: `tsc --noEmit` clean
- [x] Biome: baseline count preserved (65 warnings / 0 errors, same as pre-change)
- [x] Unit tests: `vitest run src/conversation/dashboard.test.ts` — **59/59 pass** (49 original + 10 new helper unit tests for `extractIssueShortRef` / `extractPrShortRef` via dynamic `await import('./dashboard')` pattern)
- [x] onclick-escape invariant: `actionClosings.length === 18` still holds — no new onclick handlers added by this revision
- [x] Polling compatibility: `.card-timer-live` selector + `data-leg-started` / `data-accumulated` attrs preserved exactly on the live span (just moved inside `.card-timer-hero`)
- [ ] Visual verification: deploy to dev, open `/conversation/dashboard`, compare screenshot against the v2 TO-BE spec in this PR body

## Notes

- Outer render-client is one giant backtick template string; all new server-emitted markup uses single-quote concat only (no nested ES6 backticks / `${}`) to avoid breaking the enclosing literal.
- All attribute values are escaped with `escAttr` (not `esc`) — `esc` does not escape `"`.
- `KanbanSession` interface grew three optional fields: `effort?`, `issueShortRef?`, `prShortRef?`. Both `sessionToKanban` (live sessions) and `archivedToKanban` (archived) populate them.
- Archived sessions don't persist effort on-disk, so `archivedToKanban` falls back to the owner's default effort — acceptable because the archived column is historical and rarely scrutinised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <z@2lab.ai>
