### PR TITLE
deploy(dev): #617 v2 compact live ticker + rich complete message

### DIFF
--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -350,6 +350,8 @@ export class SessionRegistry {
       compactPostTokens: null,
       compactTrigger: null,
       compactDurationMs: null,
+      compactStartingMessageTs: null,
+      compactStartedAtMs: null,
       autoCompactPending: false,
       pendingUserText: null,
       pendingEventContext: null,
@@ -1030,6 +1032,14 @@ export class SessionRegistry {
         clearTimeout(session.pendingRetryTimer);
         session.pendingRetryTimer = undefined;
       }
+      // #617 followup v2: cancel any orphan compact-starting ticker — safe
+      // hygiene even though the ticker has its own 10-min safety ceiling.
+      if (session.compactTickInterval) {
+        clearInterval(session.compactTickInterval);
+        session.compactTickInterval = undefined;
+      }
+      session.compactStartingMessageTs = null;
+      session.compactStartedAtMs = null;
       // Persist to disk so restart doesn't resurrect stale state (Issue #214)
       this.saveSessions();
     }
@@ -1094,6 +1104,14 @@ export class SessionRegistry {
       clearTimeout(session.pendingRetryTimer);
       session.pendingRetryTimer = undefined;
     }
+    // #617 followup v2: cancel any orphan compact-starting ticker so /new
+    // /renew doesn't leak an interval into the fresh logical session.
+    if (session.compactTickInterval) {
+      clearInterval(session.compactTickInterval);
+      session.compactTickInterval = undefined;
+    }
+    session.compactStartingMessageTs = null;
+    session.compactStartedAtMs = null;
 
     // Dashboard v2.1 — /new (and /renew) starts a fresh logical session.
     // Orphan-sweep any open leg into the accumulator, then reset the

--- a/src/slack/hooks/compact-complete-message.test.ts
+++ b/src/slack/hooks/compact-complete-message.test.ts
@@ -1,21 +1,20 @@
 /**
- * #617 followup — "Compaction complete" rich message.
+ * #617 followup v2 — "Compaction completed" rich message + live "starting"
+ * message with elapsed-time ticker.
  *
- * Regression guard for the user-reported bug where the completion message
- * always showed `was ~?% → now ~?%`. Root cause: the SDK compact_metadata
- * (`pre_tokens`, `post_tokens`, `trigger`, `duration_ms`) was never captured
- * on the session, so the message had no data to display.
+ * Replaces the v1 regression guard (which asserted the flat `· was ~X% → now
+ * ~Y%` shape). The new format is a 2-line block with every SDK-reported
+ * field plus a context-window snapshot, and the starting message shows
+ * elapsed seconds MCP-style.
  *
- * These tests cover `buildCompactCompleteMessage` directly to prove the
- * message emits every field available on the session and falls back cleanly
- * when fields are missing. Callsite (compact-hooks.ts::postCompactCompleteIfNeeded)
- * goes through `slackApi.postSystemMessage` — the AC5 coverage in
- * compact-hooks.test.ts already asserts the call path.
+ * These tests cover `buildCompactCompleteMessage` and
+ * `buildCompactStartingMessage` directly. Hook integration (post → update →
+ * complete) is covered separately in compact-hooks.test.ts.
  */
 
 import { describe, expect, it } from 'vitest';
 import type { ConversationSession } from '../../types';
-import { buildCompactCompleteMessage } from './compact-hooks';
+import { buildCompactCompleteMessage, buildCompactStartingMessage } from './compact-hooks';
 
 function baseSession(overrides: Partial<ConversationSession> = {}): ConversationSession {
   return {
@@ -34,67 +33,123 @@ function baseSession(overrides: Partial<ConversationSession> = {}): Conversation
     autoCompactPending: false,
     pendingUserText: null,
     pendingEventContext: null,
-    ...overrides,
-  } as ConversationSession;
+    // No `model` → resolveContextWindow falls back to 200k, exercised in tests below.
+  } as ConversationSession as ConversationSession & typeof overrides;
 }
 
-describe('buildCompactCompleteMessage — SDK-authoritative fields (#617 followup)', () => {
-  it('AC5 followup: all fields present → full message with tokens + trigger + duration', () => {
-    const session = baseSession({
-      preCompactUsagePct: 83,
-      lastKnownUsagePct: 12,
-      compactPreTokens: 166_000,
-      compactPostTokens: 24_000,
-      compactTrigger: 'auto',
-      compactDurationMs: 1234,
-    });
-    expect(buildCompactCompleteMessage(session)).toBe(
-      '✅ Compaction complete · was ~83% (166,000 tok) → now ~12% (24,000 tok) · trigger=auto · 1.2s',
+function withOverrides(overrides: Partial<ConversationSession>): ConversationSession {
+  return { ...baseSession(), ...overrides } as ConversationSession;
+}
+
+describe('buildCompactStartingMessage — live "Compaction starting" indicator', () => {
+  it('initial post (no elapsed) with auto trigger', () => {
+    expect(buildCompactStartingMessage({ trigger: 'auto' })).toBe('⏳ 🗜️ Compaction starting · trigger=auto');
+  });
+
+  it('initial post with manual trigger', () => {
+    expect(buildCompactStartingMessage({ trigger: 'manual' })).toBe('⏳ 🗜️ Compaction starting · trigger=manual');
+  });
+
+  it('initial post with UNKNOWN trigger (fallback path) — omits trigger segment entirely', () => {
+    // Regression: AS-IS used to show `trigger=unknown (fallback)` which the
+    // user called noise. We now drop the segment rather than print a lie.
+    expect(buildCompactStartingMessage({ trigger: null })).toBe('⏳ 🗜️ Compaction starting');
+  });
+
+  it('ticker update appends elapsed seconds (sub-minute)', () => {
+    expect(buildCompactStartingMessage({ trigger: 'auto', elapsedMs: 5_000 })).toBe(
+      '⏳ 🗜️ Compaction starting · trigger=auto — 5s',
     );
   });
 
-  it('AC5 followup: manual trigger + sub-second duration renders as `Nms`', () => {
-    const session = baseSession({
+  it('ticker update renders minute-scale elapsed as `Xm Ys`', () => {
+    expect(buildCompactStartingMessage({ trigger: 'auto', elapsedMs: 65_000 })).toBe(
+      '⏳ 🗜️ Compaction starting · trigger=auto — 1m 5s',
+    );
+  });
+
+  it('ticker update renders whole-minute elapsed as `Xm` (no trailing 0s)', () => {
+    expect(buildCompactStartingMessage({ trigger: 'auto', elapsedMs: 180_000 })).toBe(
+      '⏳ 🗜️ Compaction starting · trigger=auto — 3m',
+    );
+  });
+
+  it('elapsedMs=0 on first tick → does NOT append `— 0s` (noise)', () => {
+    expect(buildCompactStartingMessage({ trigger: 'auto', elapsedMs: 0 })).toBe(
+      '⏳ 🗜️ Compaction starting · trigger=auto',
+    );
+  });
+
+  it('unknown trigger + elapsed → elapsed still appended', () => {
+    expect(buildCompactStartingMessage({ trigger: null, elapsedMs: 7_000 })).toBe(
+      '⏳ 🗜️ Compaction starting — 7s',
+    );
+  });
+});
+
+describe('buildCompactCompleteMessage — SDK-authoritative 2-line complete message', () => {
+  it('full SDK data → header with trigger+duration, Context line with compact token counts', () => {
+    const session = withOverrides({
+      preCompactUsagePct: 80,
+      lastKnownUsagePct: 16,
+      compactPreTokens: 160_000,
+      compactPostTokens: 35_000,
+      compactTrigger: 'auto',
+      compactDurationMs: 5_200,
+      compactionCount: 3,
+    });
+    // Default model → 200k context window fallback.
+    expect(buildCompactCompleteMessage(session)).toBe(
+      '🟢 🗜️ Compaction completed · trigger=auto (5.2s)\n' +
+        'Context: now 16% (35k/200k) ← was 80% (160k/200k) · compaction #3',
+    );
+  });
+
+  it('manual trigger + sub-second duration renders as `Nms` in header', () => {
+    const session = withOverrides({
       preCompactUsagePct: 85,
       lastKnownUsagePct: 40,
       compactPreTokens: 170_000,
       compactPostTokens: 80_000,
       compactTrigger: 'manual',
       compactDurationMs: 250,
+      compactionCount: 1,
     });
     expect(buildCompactCompleteMessage(session)).toBe(
-      '✅ Compaction complete · was ~85% (170,000 tok) → now ~40% (80,000 tok) · trigger=manual · 250ms',
+      '🟢 🗜️ Compaction completed · trigger=manual (250ms)\n' +
+        'Context: now 40% (80k/200k) ← was 85% (170k/200k) · compaction #1',
     );
   });
 
-  it('AC5 followup: tokens present, no trigger/duration → only tokens appended', () => {
-    const session = baseSession({
+  it('no trigger / no duration / no compactionCount → header collapses, Context only has tokens', () => {
+    const session = withOverrides({
       preCompactUsagePct: 90,
       lastKnownUsagePct: 20,
       compactPreTokens: 180_000,
       compactPostTokens: 40_000,
+      compactionCount: 0, // zero treated as "not yet populated" per impl
     });
     expect(buildCompactCompleteMessage(session)).toBe(
-      '✅ Compaction complete · was ~90% (180,000 tok) → now ~20% (40,000 tok)',
+      '🟢 🗜️ Compaction completed\n' + 'Context: now 20% (40k/200k) ← was 90% (180k/200k)',
     );
   });
 
-  it('AC5 followup: legacy path — no token data → unchanged from prior format', () => {
-    // Ensures backward compatibility with sessions that were compacted by an
-    // older SDK that didn't emit compact_metadata.
-    const session = baseSession({ preCompactUsagePct: 83, lastKnownUsagePct: 45 });
-    expect(buildCompactCompleteMessage(session)).toBe('✅ Compaction complete · was ~83% → now ~45%');
+  it('legacy path — no token data, only pct snapshots → `~X%` fallback for both sides', () => {
+    const session = withOverrides({ preCompactUsagePct: 83, lastKnownUsagePct: 45, compactionCount: 2 });
+    expect(buildCompactCompleteMessage(session)).toBe(
+      '🟢 🗜️ Compaction completed\n' + 'Context: now ~45% ← was ~83% · compaction #2',
+    );
   });
 
-  it('AC5 followup: completely absent data → `?` fallback for both sides', () => {
+  it('completely absent data → `?` fallback on both sides', () => {
     const session = baseSession();
-    expect(buildCompactCompleteMessage(session)).toBe('✅ Compaction complete · was ~?% → now ~?%');
+    expect(buildCompactCompleteMessage(session)).toBe(
+      '🟢 🗜️ Compaction completed\n' + 'Context: now ~?% ← was ~?%',
+    );
   });
 
-  it('AC5 followup: only post_tokens available → post side shows tokens, pre side does not', () => {
-    // Defensive: SDK type marks post_tokens optional. If only post_tokens is
-    // delivered we should still enrich the `now` side without lying about `was`.
-    const session = baseSession({
+  it('only post_tokens present → post side shows compact tokens, pre side falls back', () => {
+    const session = withOverrides({
       preCompactUsagePct: null,
       lastKnownUsagePct: 12,
       compactPreTokens: null,
@@ -102,19 +157,37 @@ describe('buildCompactCompleteMessage — SDK-authoritative fields (#617 followu
       compactTrigger: 'auto',
     });
     expect(buildCompactCompleteMessage(session)).toBe(
-      '✅ Compaction complete · was ~?% → now ~12% (24,000 tok) · trigger=auto',
+      '🟢 🗜️ Compaction completed · trigger=auto\n' + 'Context: now 12% (24k/200k) ← was ~?%',
     );
   });
 
-  it('AC5 followup: token counts with thousand-separators render en-US locale', () => {
-    const session = baseSession({
+  it('mega-scale tokens render as `1.5M` / `300k`', () => {
+    const session = withOverrides({
       preCompactUsagePct: 50,
       lastKnownUsagePct: 10,
       compactPreTokens: 1_500_000,
       compactPostTokens: 300_500,
+      model: 'claude-opus-4-7', // 1M context window
     });
-    expect(buildCompactCompleteMessage(session)).toBe(
-      '✅ Compaction complete · was ~50% (1,500,000 tok) → now ~10% (300,500 tok)',
-    );
+    const msg = buildCompactCompleteMessage(session);
+    // Sanity: header + Context line shape
+    expect(msg).toContain('🟢 🗜️ Compaction completed');
+    expect(msg).toContain('Context: now 10%');
+    expect(msg).toContain('was 50%');
+    // Mega formatting
+    expect(msg).toContain('1.5M/');
+    expect(msg).toContain('301k/');
+  });
+
+  it('sub-1000 tokens (defensive edge case) render as plain integer', () => {
+    const session = withOverrides({
+      preCompactUsagePct: 0,
+      lastKnownUsagePct: 0,
+      compactPreTokens: 500,
+      compactPostTokens: 10,
+    });
+    const msg = buildCompactCompleteMessage(session);
+    expect(msg).toContain('(500/200k)');
+    expect(msg).toContain('(10/200k)');
   });
 });

--- a/src/slack/hooks/compact-complete-message.test.ts
+++ b/src/slack/hooks/compact-complete-message.test.ts
@@ -81,9 +81,7 @@ describe('buildCompactStartingMessage — live "Compaction starting" indicator',
   });
 
   it('unknown trigger + elapsed → elapsed still appended', () => {
-    expect(buildCompactStartingMessage({ trigger: null, elapsedMs: 7_000 })).toBe(
-      '⏳ 🗜️ Compaction starting — 7s',
-    );
+    expect(buildCompactStartingMessage({ trigger: null, elapsedMs: 7_000 })).toBe('⏳ 🗜️ Compaction starting — 7s');
   });
 });
 
@@ -143,9 +141,7 @@ describe('buildCompactCompleteMessage — SDK-authoritative 2-line complete mess
 
   it('completely absent data → `?` fallback on both sides', () => {
     const session = baseSession();
-    expect(buildCompactCompleteMessage(session)).toBe(
-      '🟢 🗜️ Compaction completed\n' + 'Context: now ~?% ← was ~?%',
-    );
+    expect(buildCompactCompleteMessage(session)).toBe('🟢 🗜️ Compaction completed\n' + 'Context: now ~?% ← was ~?%');
   });
 
   it('only post_tokens present → post side shows compact tokens, pre side falls back', () => {

--- a/src/slack/hooks/compact-fallback.test.ts
+++ b/src/slack/hooks/compact-fallback.test.ts
@@ -3,20 +3,19 @@
  * `status === 'compacting'` stream signal in stream-executor must still
  * post a thread-visible "starting" message and mark the epoch.
  *
- * The fallback code lives in `stream-executor.ts:836-861` (onStatusUpdate
- * branch). These tests reproduce that exact sequence against the shared
- * epoch helpers and `slackApi.postSystemMessage` mock to verify:
+ * The fallback code lives in `stream-executor.ts::onStatusUpdate('compacting')`
+ * and calls `postCompactStartingIfNeeded` with the `'unknown (fallback)'`
+ * trigger. Since this function is the actual SUT, these tests invoke it
+ * directly (rather than an inline replica) so any drift between "what the
+ * fallback posts" and "what the real code posts" is caught immediately.
  *
- *   1. PreCompact never fires → fallback posts once, epoch bumped, pre=true.
- *   2. PreCompact fires first  → fallback sees pre=true → skips (no duplicate).
- *
- * We reproduce the sequence inline (vs. booting StreamExecutor) because the
- * full executor requires ~15 unrelated deps; the invariant under test is the
- * epoch/marker contract, not the executor plumbing.
+ * Regression follow-up (#617 v2): the literal `trigger=unknown (fallback)`
+ * noise was removed — when trigger is unknown we drop the `· trigger=…`
+ * segment entirely rather than print a lie.
  */
 
 import type { PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../session/compaction-context-builder', () => ({
   buildCompactionContext: vi.fn().mockReturnValue('<context/>'),
@@ -25,7 +24,7 @@ vi.mock('../../session/compaction-context-builder', () => ({
 
 import type { ConversationSession } from '../../types';
 import type { SlackApiHelper } from '../slack-api-helper';
-import { beginCompactionCycleIfNeeded, buildCompactHooks } from './compact-hooks';
+import { buildCompactHooks, postCompactStartingIfNeeded } from './compact-hooks';
 
 function makeSession(): ConversationSession {
   return {
@@ -37,89 +36,98 @@ function makeSession(): ConversationSession {
     compactionRehydratedByEpoch: {},
     preCompactUsagePct: null,
     lastKnownUsagePct: 70,
+    compactPreTokens: null,
+    compactPostTokens: null,
+    compactTrigger: null,
+    compactDurationMs: null,
+    compactStartingMessageTs: null,
+    compactStartedAtMs: null,
+    compactTickInterval: undefined,
     autoCompactPending: false,
     pendingUserText: null,
     pendingEventContext: null,
   } as ConversationSession;
 }
 
-/**
- * Inline replica of the fallback block at stream-executor.ts:844-861.
- * Keeps tests honest — any divergence from the real block will be caught
- * when the fallback test is re-read against the source.
- */
-async function runCompactingFallback(
-  session: ConversationSession,
-  slackApi: { postSystemMessage: ReturnType<typeof vi.fn> },
-): Promise<void> {
-  const epoch = beginCompactionCycleIfNeeded(session);
-  const marker = (session.compactPostedByEpoch ??= {})[epoch];
-  if (marker && !marker.pre) {
-    session.preCompactUsagePct = session.lastKnownUsagePct ?? null;
-    await (slackApi.postSystemMessage as (...args: any[]) => Promise<void>)(
-      'C1',
-      '🗜️ Compaction starting · trigger=unknown (fallback)',
-      { threadTs: 'T1' },
-    );
-    marker.pre = true;
+function stopTicker(session: ConversationSession): void {
+  if (session.compactTickInterval) {
+    clearInterval(session.compactTickInterval);
+    session.compactTickInterval = undefined;
   }
 }
 
-describe('PreCompact fallback via status="compacting" (#617 AC4 fallback)', () => {
-  let slackApi: { postSystemMessage: ReturnType<typeof vi.fn> };
+describe('PreCompact fallback via status="compacting" (#617 AC4 fallback, v2)', () => {
+  let slackApi: {
+    postSystemMessage: ReturnType<typeof vi.fn>;
+    updateMessage: ReturnType<typeof vi.fn>;
+  };
   let session: ConversationSession;
 
   beforeEach(() => {
-    slackApi = { postSystemMessage: vi.fn().mockResolvedValue(undefined) };
+    slackApi = {
+      postSystemMessage: vi.fn().mockResolvedValue({ ts: '1700000000.000100', channel: 'C1' }),
+      updateMessage: vi.fn().mockResolvedValue(undefined),
+    };
     session = makeSession();
   });
 
-  it('AC4 fallback: PreCompact never fires → fallback posts once, epoch bumped, pre=true', async () => {
-    await runCompactingFallback(session, slackApi);
+  afterEach(() => {
+    stopTicker(session);
+  });
+
+  const preCompactPayload = (trigger: 'manual' | 'auto'): PreCompactHookInput =>
+    ({
+      session_id: 'sess-1',
+      transcript_path: '/tmp/t',
+      cwd: '/tmp',
+      hook_event_name: 'PreCompact',
+      trigger,
+      custom_instructions: null,
+    }) as unknown as PreCompactHookInput;
+
+  it('AC4 v2: fallback posts "⏳ 🗜️ Compaction starting" (no trigger suffix for unknown)', async () => {
+    await postCompactStartingIfNeeded(
+      { session, channel: 'C1', threadTs: 'T1', slackApi: slackApi as unknown as SlackApiHelper },
+      'unknown (fallback)',
+    );
 
     expect(session.compactEpoch).toBe(1);
     expect(session.compactPostedByEpoch?.[1]?.pre).toBe(true);
     expect(session.preCompactUsagePct).toBe(70); // snapshotted from lastKnownUsagePct
-    expect(slackApi.postSystemMessage).toHaveBeenCalledWith(
-      'C1',
-      '🗜️ Compaction starting · trigger=unknown (fallback)',
-      { threadTs: 'T1' },
-    );
+    expect(slackApi.postSystemMessage).toHaveBeenCalledWith('C1', '⏳ 🗜️ Compaction starting', { threadTs: 'T1' });
     expect(slackApi.postSystemMessage).toHaveBeenCalledTimes(1);
   });
 
-  it('AC4 fallback: PreCompact fires first → fallback sees pre=true → skips (idempotent by epoch pre flag)', async () => {
-    // 1. PreCompact hook fires first (primary path).
+  it('AC4 v2: PreCompact fires first → fallback sees pre=true → skips (no duplicate post)', async () => {
+    // 1. PreCompact hook fires first (primary path) with the REAL trigger.
     const hooks = buildCompactHooks({
       session,
       channel: 'C1',
       threadTs: 'T1',
       slackApi: slackApi as unknown as SlackApiHelper,
     });
-    const payload: PreCompactHookInput = {
-      session_id: 'sess-1',
-      transcript_path: '/tmp/t',
-      cwd: '/tmp',
-      hook_event_name: 'PreCompact',
-      trigger: 'manual',
-      custom_instructions: null,
-    } as unknown as PreCompactHookInput;
-
-    await hooks.PreCompact(payload as any);
+    await hooks.PreCompact(preCompactPayload('manual') as any);
     expect(slackApi.postSystemMessage).toHaveBeenCalledTimes(1);
     expect(slackApi.postSystemMessage.mock.calls[0][1]).toContain('trigger=manual');
 
     // 2. Then the `compacting` status event arrives — fallback must skip.
-    await runCompactingFallback(session, slackApi);
+    await postCompactStartingIfNeeded(
+      { session, channel: 'C1', threadTs: 'T1', slackApi: slackApi as unknown as SlackApiHelper },
+      'unknown (fallback)',
+    );
 
-    // Still exactly one post; no "(fallback)" duplicate.
+    // Still exactly one post; no fallback duplicate.
     expect(slackApi.postSystemMessage).toHaveBeenCalledTimes(1);
-    expect(slackApi.postSystemMessage.mock.calls[0][1]).not.toContain('fallback');
+    expect(slackApi.postSystemMessage.mock.calls[0][1]).toContain('trigger=manual');
   });
 
-  it('AC4 fallback: reverse order — fallback first then PreCompact → only fallback post (hook dedupes)', async () => {
-    await runCompactingFallback(session, slackApi);
+  it('AC4 v2: reverse order — fallback first then PreCompact → only fallback post (hook dedupes)', async () => {
+    await postCompactStartingIfNeeded(
+      { session, channel: 'C1', threadTs: 'T1', slackApi: slackApi as unknown as SlackApiHelper },
+      'unknown (fallback)',
+    );
     expect(slackApi.postSystemMessage).toHaveBeenCalledTimes(1);
+    expect(slackApi.postSystemMessage.mock.calls[0][1]).toBe('⏳ 🗜️ Compaction starting');
 
     // Now the real PreCompact hook fires later; it must see pre=true and skip.
     const hooks = buildCompactHooks({
@@ -128,23 +136,20 @@ describe('PreCompact fallback via status="compacting" (#617 AC4 fallback)', () =
       threadTs: 'T1',
       slackApi: slackApi as unknown as SlackApiHelper,
     });
-    const payload: PreCompactHookInput = {
-      session_id: 'sess-1',
-      transcript_path: '/tmp/t',
-      cwd: '/tmp',
-      hook_event_name: 'PreCompact',
-      trigger: 'manual',
-      custom_instructions: null,
-    } as unknown as PreCompactHookInput;
+    await hooks.PreCompact(preCompactPayload('manual') as any);
 
-    await hooks.PreCompact(payload as any);
     expect(slackApi.postSystemMessage).toHaveBeenCalledTimes(1);
-    expect(slackApi.postSystemMessage.mock.calls[0][1]).toContain('fallback');
   });
 
-  it('AC4 fallback: second fallback invocation inside same open cycle does NOT re-post', async () => {
-    await runCompactingFallback(session, slackApi);
-    await runCompactingFallback(session, slackApi);
+  it('AC4 v2: second fallback invocation inside same open cycle does NOT re-post', async () => {
+    await postCompactStartingIfNeeded(
+      { session, channel: 'C1', threadTs: 'T1', slackApi: slackApi as unknown as SlackApiHelper },
+      'unknown (fallback)',
+    );
+    await postCompactStartingIfNeeded(
+      { session, channel: 'C1', threadTs: 'T1', slackApi: slackApi as unknown as SlackApiHelper },
+      'unknown (fallback)',
+    );
     expect(slackApi.postSystemMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/slack/hooks/compact-hooks.test.ts
+++ b/src/slack/hooks/compact-hooks.test.ts
@@ -134,11 +134,9 @@ describe('buildCompactHooks — PreCompact (#617 AC4, live ticker v2)', () => {
     expect(res.continue).toBe(true);
     expect(session.compactEpoch).toBe(1);
     expect(session.preCompactUsagePct).toBe(82);
-    expect(slackApi.postSystemMessage).toHaveBeenCalledWith(
-      'C1',
-      '⏳ 🗜️ Compaction starting · trigger=manual',
-      { threadTs: 'T1' },
-    );
+    expect(slackApi.postSystemMessage).toHaveBeenCalledWith('C1', '⏳ 🗜️ Compaction starting · trigger=manual', {
+      threadTs: 'T1',
+    });
     expect(session.compactPostedByEpoch?.[1]?.pre).toBe(true);
     // Runtime handles captured for the ticker path.
     expect(session.compactStartingMessageTs).toBe('1700000000.000100');
@@ -154,11 +152,9 @@ describe('buildCompactHooks — PreCompact (#617 AC4, live ticker v2)', () => {
       slackApi: slackApi as unknown as SlackApiHelper,
     });
     await hooks.PreCompact(payloadOf('auto') as any);
-    expect(slackApi.postSystemMessage).toHaveBeenCalledWith(
-      'C1',
-      '⏳ 🗜️ Compaction starting · trigger=auto',
-      { threadTs: 'T1' },
-    );
+    expect(slackApi.postSystemMessage).toHaveBeenCalledWith('C1', '⏳ 🗜️ Compaction starting · trigger=auto', {
+      threadTs: 'T1',
+    });
   });
 
   it('AC4 v2: second PreCompact call inside same cycle does NOT re-post (pre=true dedupe)', async () => {

--- a/src/slack/hooks/compact-hooks.test.ts
+++ b/src/slack/hooks/compact-hooks.test.ts
@@ -1,5 +1,5 @@
 import type { PostCompactHookInput, PreCompactHookInput, SessionStartHookInput } from '@anthropic-ai/claude-agent-sdk';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock compaction-context-builder before importing the module under test.
 // buildCompactionContext returning a truthy string is what flips
@@ -24,11 +24,30 @@ function makeSession(overrides: Partial<ConversationSession> = {}): Conversation
     compactionRehydratedByEpoch: {},
     preCompactUsagePct: null,
     lastKnownUsagePct: null,
+    compactPreTokens: null,
+    compactPostTokens: null,
+    compactTrigger: null,
+    compactDurationMs: null,
+    compactStartingMessageTs: null,
+    compactStartedAtMs: null,
+    compactTickInterval: undefined,
     autoCompactPending: false,
     pendingUserText: null,
     pendingEventContext: null,
     ...overrides,
   } as ConversationSession;
+}
+
+/**
+ * Teardown guard: tests that post a "starting" message leave behind a live
+ * setInterval handle on the session. Clear it here so vitest doesn't hold
+ * the worker open.
+ */
+function clearStartingTicker(session: ConversationSession): void {
+  if (session.compactTickInterval) {
+    clearInterval(session.compactTickInterval);
+    session.compactTickInterval = undefined;
+  }
 }
 
 /**
@@ -73,13 +92,24 @@ describe('Epoch helpers (#617 AC6 dedupe foundation)', () => {
   });
 });
 
-describe('buildCompactHooks — PreCompact (#617 AC4)', () => {
-  let slackApi: { postSystemMessage: ReturnType<typeof vi.fn> };
+describe('buildCompactHooks — PreCompact (#617 AC4, live ticker v2)', () => {
+  let slackApi: {
+    postSystemMessage: ReturnType<typeof vi.fn>;
+    updateMessage: ReturnType<typeof vi.fn>;
+  };
   let session: ConversationSession;
 
   beforeEach(() => {
-    slackApi = { postSystemMessage: vi.fn().mockResolvedValue(undefined) };
+    slackApi = {
+      postSystemMessage: vi.fn().mockResolvedValue({ ts: '1700000000.000100', channel: 'C1' }),
+      updateMessage: vi.fn().mockResolvedValue(undefined),
+    };
     session = makeSession({ lastKnownUsagePct: 82 });
+  });
+
+  afterEach(() => {
+    clearStartingTicker(session);
+    vi.useRealTimers();
   });
 
   const payloadOf = (trigger: 'manual' | 'auto'): PreCompactHookInput =>
@@ -92,7 +122,7 @@ describe('buildCompactHooks — PreCompact (#617 AC4)', () => {
       custom_instructions: null,
     }) as unknown as PreCompactHookInput;
 
-  it('AC4: posts "starting · trigger=manual" and bumps epoch + snapshots preCompactUsagePct', async () => {
+  it('AC4 v2: posts "⏳ 🗜️ Compaction starting · trigger=manual", bumps epoch, snapshots preCompactUsagePct, captures message ts', async () => {
     const hooks = buildCompactHooks({
       session,
       channel: 'C1',
@@ -104,13 +134,19 @@ describe('buildCompactHooks — PreCompact (#617 AC4)', () => {
     expect(res.continue).toBe(true);
     expect(session.compactEpoch).toBe(1);
     expect(session.preCompactUsagePct).toBe(82);
-    expect(slackApi.postSystemMessage).toHaveBeenCalledWith('C1', '🗜️ Compaction starting · trigger=manual', {
-      threadTs: 'T1',
-    });
+    expect(slackApi.postSystemMessage).toHaveBeenCalledWith(
+      'C1',
+      '⏳ 🗜️ Compaction starting · trigger=manual',
+      { threadTs: 'T1' },
+    );
     expect(session.compactPostedByEpoch?.[1]?.pre).toBe(true);
+    // Runtime handles captured for the ticker path.
+    expect(session.compactStartingMessageTs).toBe('1700000000.000100');
+    expect(typeof session.compactStartedAtMs).toBe('number');
+    expect(session.compactTickInterval).toBeDefined();
   });
 
-  it('AC4: posts "trigger=auto" for auto trigger', async () => {
+  it('AC4 v2: auto trigger → starting text includes `trigger=auto`', async () => {
     const hooks = buildCompactHooks({
       session,
       channel: 'C1',
@@ -118,12 +154,14 @@ describe('buildCompactHooks — PreCompact (#617 AC4)', () => {
       slackApi: slackApi as unknown as SlackApiHelper,
     });
     await hooks.PreCompact(payloadOf('auto') as any);
-    expect(slackApi.postSystemMessage).toHaveBeenCalledWith('C1', '🗜️ Compaction starting · trigger=auto', {
-      threadTs: 'T1',
-    });
+    expect(slackApi.postSystemMessage).toHaveBeenCalledWith(
+      'C1',
+      '⏳ 🗜️ Compaction starting · trigger=auto',
+      { threadTs: 'T1' },
+    );
   });
 
-  it('AC4: second PreCompact call inside same cycle does NOT re-post (pre=true dedupe)', async () => {
+  it('AC4 v2: second PreCompact call inside same cycle does NOT re-post (pre=true dedupe)', async () => {
     const hooks = buildCompactHooks({
       session,
       channel: 'C1',
@@ -134,20 +172,64 @@ describe('buildCompactHooks — PreCompact (#617 AC4)', () => {
     await hooks.PreCompact(payloadOf('manual') as any);
     expect(slackApi.postSystemMessage).toHaveBeenCalledTimes(1);
   });
+
+  it('AC4 v2: ticker fires chat.update with elapsed `— 3s` / `— 6s` as time advances', async () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'Date'] });
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    const hooks = buildCompactHooks({
+      session,
+      channel: 'C1',
+      threadTs: 'T1',
+      slackApi: slackApi as unknown as SlackApiHelper,
+    });
+
+    await hooks.PreCompact(payloadOf('auto') as any);
+    expect(slackApi.updateMessage).not.toHaveBeenCalled();
+
+    // First tick at T+3s
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      '1700000000.000100',
+      '⏳ 🗜️ Compaction starting · trigger=auto — 3s',
+    );
+
+    // Second tick at T+6s
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(slackApi.updateMessage).toHaveBeenLastCalledWith(
+      'C1',
+      '1700000000.000100',
+      '⏳ 🗜️ Compaction starting · trigger=auto — 6s',
+    );
+  });
 });
 
-describe('buildCompactHooks — PostCompact (#617 AC5)', () => {
-  let slackApi: { postSystemMessage: ReturnType<typeof vi.fn> };
+describe('buildCompactHooks — PostCompact (#617 AC5, chat.update v2)', () => {
+  let slackApi: {
+    postSystemMessage: ReturnType<typeof vi.fn>;
+    updateMessage: ReturnType<typeof vi.fn>;
+  };
   let eventRouter: { dispatchPendingUserMessage: ReturnType<typeof vi.fn> };
   let session: ConversationSession;
 
   beforeEach(() => {
-    slackApi = { postSystemMessage: vi.fn().mockResolvedValue(undefined) };
+    slackApi = {
+      postSystemMessage: vi.fn().mockResolvedValue({ ts: undefined, channel: 'C1' }),
+      updateMessage: vi.fn().mockResolvedValue(undefined),
+    };
     eventRouter = { dispatchPendingUserMessage: vi.fn().mockResolvedValue(undefined) };
     session = makeSession({ preCompactUsagePct: 83, lastKnownUsagePct: 45 });
     // Open a cycle so PostCompact has a marker to flip.
     beginCompactionCycleIfNeeded(session);
     session.compactPostedByEpoch![1].pre = true;
+    // Simulate the ticker state left behind by a prior `postCompactStartingIfNeeded` call.
+    session.compactStartingMessageTs = '1700000000.000100';
+    session.compactStartedAtMs = Date.now();
+  });
+
+  afterEach(() => {
+    clearStartingTicker(session);
   });
 
   const postPayload = (): PostCompactHookInput =>
@@ -160,7 +242,7 @@ describe('buildCompactHooks — PostCompact (#617 AC5)', () => {
       compact_summary: 'summary',
     }) as unknown as PostCompactHookInput;
 
-  it('AC5: posts "complete · was ~83% → now ~45%" on first PostCompact call', async () => {
+  it('AC5 v2: replaces the starting message in-place via chat.update, not postSystemMessage', async () => {
     const hooks = buildCompactHooks({
       session,
       channel: 'C1',
@@ -169,16 +251,28 @@ describe('buildCompactHooks — PostCompact (#617 AC5)', () => {
       eventRouter: eventRouter as unknown as EventRouter,
     });
     await hooks.PostCompact(postPayload() as any);
-    expect(slackApi.postSystemMessage).toHaveBeenCalledWith('C1', '✅ Compaction complete · was ~83% → now ~45%', {
-      threadTs: 'T1',
-    });
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      '1700000000.000100',
+      '🟢 🗜️ Compaction completed\nContext: now ~45% ← was ~83%',
+    );
+    expect(slackApi.postSystemMessage).not.toHaveBeenCalled();
     expect(session.compactPostedByEpoch?.[1]?.post).toBe(true);
     expect(session.autoCompactPending).toBe(false);
+    // Runtime-only START tracking cleared.
+    expect(session.compactStartingMessageTs).toBeNull();
+    expect(session.compactStartedAtMs).toBeNull();
   });
 
-  it('AC5: falls back to "?" when preCompactUsagePct is null', async () => {
-    session.preCompactUsagePct = null;
-    session.lastKnownUsagePct = 30;
+  it('AC5 v2: with full SDK metadata → rich 2-line completed message', async () => {
+    session.compactPreTokens = 160_000;
+    session.compactPostTokens = 35_000;
+    session.preCompactUsagePct = 80;
+    session.lastKnownUsagePct = 16;
+    session.compactTrigger = 'auto';
+    session.compactDurationMs = 5_200;
+    session.compactionCount = 3;
+
     const hooks = buildCompactHooks({
       session,
       channel: 'C1',
@@ -186,9 +280,46 @@ describe('buildCompactHooks — PostCompact (#617 AC5)', () => {
       slackApi: slackApi as unknown as SlackApiHelper,
     });
     await hooks.PostCompact(postPayload() as any);
-    expect(slackApi.postSystemMessage).toHaveBeenCalledWith('C1', '✅ Compaction complete · was ~?% → now ~30%', {
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      '1700000000.000100',
+      '🟢 🗜️ Compaction completed · trigger=auto (5.2s)\n' +
+        'Context: now 16% (35k/200k) ← was 80% (160k/200k) · compaction #3',
+    );
+  });
+
+  it('AC5 v2: no starting ts captured (Slack failed on START) → falls back to fresh postSystemMessage', async () => {
+    session.compactStartingMessageTs = null;
+    const hooks = buildCompactHooks({
+      session,
+      channel: 'C1',
       threadTs: 'T1',
+      slackApi: slackApi as unknown as SlackApiHelper,
     });
+    await hooks.PostCompact(postPayload() as any);
+    expect(slackApi.updateMessage).not.toHaveBeenCalled();
+    expect(slackApi.postSystemMessage).toHaveBeenCalledWith(
+      'C1',
+      '🟢 🗜️ Compaction completed\nContext: now ~45% ← was ~83%',
+      { threadTs: 'T1' },
+    );
+  });
+
+  it('AC5 v2: chat.update fails → falls back to fresh postSystemMessage (no silent drop)', async () => {
+    slackApi.updateMessage = vi.fn().mockRejectedValueOnce(new Error('message_not_found'));
+    const hooks = buildCompactHooks({
+      session,
+      channel: 'C1',
+      threadTs: 'T1',
+      slackApi: slackApi as unknown as SlackApiHelper,
+    });
+    await hooks.PostCompact(postPayload() as any);
+    expect(slackApi.updateMessage).toHaveBeenCalledTimes(1);
+    expect(slackApi.postSystemMessage).toHaveBeenCalledWith(
+      'C1',
+      '🟢 🗜️ Compaction completed\nContext: now ~45% ← was ~83%',
+      { threadTs: 'T1' },
+    );
   });
 
   it('AC6 dedupe: second PostCompact in same epoch does NOT re-post', async () => {
@@ -200,7 +331,8 @@ describe('buildCompactHooks — PostCompact (#617 AC5)', () => {
     });
     await hooks.PostCompact(postPayload() as any);
     await hooks.PostCompact(postPayload() as any);
-    expect(slackApi.postSystemMessage).toHaveBeenCalledTimes(1);
+    expect(slackApi.updateMessage).toHaveBeenCalledTimes(1);
+    expect(slackApi.postSystemMessage).not.toHaveBeenCalled();
   });
 
   it('AC3 re-dispatch: PostCompact consumes pendingUserText via eventRouter exactly once', async () => {

--- a/src/slack/hooks/compact-hooks.ts
+++ b/src/slack/hooks/compact-hooks.ts
@@ -33,6 +33,7 @@ import type {
   SessionStartHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
 import { Logger } from '../../logger';
+import { resolveContextWindow } from '../../metrics/model-registry';
 import { buildCompactionContext, snapshotFromSession } from '../../session/compaction-context-builder';
 import type { ConversationSession } from '../../types';
 import type { EventRouter } from '../event-router';
@@ -169,10 +170,16 @@ function fmtPct(pct: number | null | undefined): string {
   return pct === null || pct === undefined ? '?' : String(pct);
 }
 
-/** Format a token count with thousands separators; `?` when missing. */
-function fmtTokens(tokens: number | null | undefined): string {
+/**
+ * Compact token formatter: `35k`, `1.2M`, `500`. Returns `?` when missing.
+ * Used inside the "Context: now X% (Nk/Wk)" summary line — full-precision
+ * thousands-separator counts are too noisy for a 1-line status.
+ */
+function fmtTokensCompact(tokens: number | null | undefined): string {
   if (tokens === null || tokens === undefined) return '?';
-  return tokens.toLocaleString('en-US');
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
+  return String(tokens);
 }
 
 /** Format ms → `1.2s` / `120ms`. Returns null when unset so callers can omit. */
@@ -183,38 +190,133 @@ function fmtDuration(ms: number | null | undefined): string | null {
 }
 
 /**
- * Build the "compaction complete" thread message. Emits all SDK-reported
- * fields that are available on the session: pre/post usage %, absolute token
- * counts, trigger, duration. When a field is missing (SDK didn't report it)
- * we fall back to `?` for the % pair and simply omit the optional segments
- * (trigger, duration, tokens) so the message doesn't lie about unknowns.
+ * Format elapsed seconds for the live "starting" message. Matches the
+ * MCP-status convention (`Xs` / `Xm Ys`). Input is wall-clock ms.
+ */
+function fmtElapsed(ms: number): string {
+  if (ms < 0) ms = 0;
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return s === 0 ? `${m}m` : `${m}m ${s}s`;
+}
+
+/**
+ * Decide which trigger string to show on the live "starting" message. The
+ * PreCompact hook provides the real `'manual'|'auto'` value; the
+ * `onStatusUpdate('compacting')` fallback passes `'unknown (fallback)'` —
+ * that's noise the user complained about, so we drop it from the rendered
+ * line. If the SDK later populates `session.compactTrigger` via
+ * `onCompactBoundary`, ticking picks it up.
  *
- * Examples:
- *   ✅ Compaction complete · was ~83% (166,000 tok) → now ~12% (24,000 tok) · trigger=auto · 1.2s
- *   ✅ Compaction complete · was ~?% → now ~?%                                          (no data)
+ * Returns `null` when we genuinely don't know the trigger — callers omit the
+ * `· trigger=…` suffix rather than print a lie.
+ */
+function resolveStartingTrigger(session: ConversationSession, initialTrigger: string): 'manual' | 'auto' | null {
+  if (session.compactTrigger === 'manual' || session.compactTrigger === 'auto') return session.compactTrigger;
+  if (initialTrigger === 'manual' || initialTrigger === 'auto') return initialTrigger;
+  return null;
+}
+
+/**
+ * Build the live "Compaction starting" thread message. Shape:
+ *   ⏳ 🗜️ Compaction starting · trigger=auto           (initial post, no elapsed yet)
+ *   ⏳ 🗜️ Compaction starting · trigger=auto — 5s      (ticker update)
+ *   ⏳ 🗜️ Compaction starting                           (no known trigger, fallback path)
+ */
+export function buildCompactStartingMessage(opts: { trigger: 'manual' | 'auto' | null; elapsedMs?: number }): string {
+  const parts: string[] = ['⏳ 🗜️ Compaction starting'];
+  if (opts.trigger) parts.push(`trigger=${opts.trigger}`);
+  let text = parts.join(' · ');
+  if (typeof opts.elapsedMs === 'number' && opts.elapsedMs > 0) {
+    text += ` — ${fmtElapsed(opts.elapsedMs)}`;
+  }
+  return text;
+}
+
+/**
+ * Build the "Compaction completed" thread message. Now a 2-line block that
+ * captures every SDK-reported field plus the full context-window snapshot the
+ * user asked for (#617 followup v2).
+ *
+ * Line 1: `🟢 🗜️ Compaction completed · trigger=auto (5.2s)`
+ * Line 2: `Context: now 16% (35k/200k) ← was 80% (160k/200k) · compaction #3`
+ *
+ * Trigger/duration/compaction-count segments are omitted when the
+ * corresponding field is absent — the message never prints a lie about
+ * unknown data. If nothing is known at all (no pre/post tokens and no pct
+ * snapshot), line 2 falls back to `Context: now ~?% ← was ~?%`.
  */
 export function buildCompactCompleteMessage(session: ConversationSession): string {
+  const headerParts: string[] = ['🟢 🗜️ Compaction completed'];
+  if (session.compactTrigger) headerParts.push(`trigger=${session.compactTrigger}`);
+  let header = headerParts.join(' · ');
+  const dur = fmtDuration(session.compactDurationMs);
+  if (dur) header += ` (${dur})`;
+
+  const contextWindow = resolveContextWindow(session.model);
+  const windowLabel = fmtTokensCompact(contextWindow);
+
   const hasPreTokens = typeof session.compactPreTokens === 'number';
   const hasPostTokens = typeof session.compactPostTokens === 'number';
 
-  const waseg = hasPreTokens
-    ? `was ~${fmtPct(session.preCompactUsagePct)}% (${fmtTokens(session.compactPreTokens)} tok)`
-    : `was ~${fmtPct(session.preCompactUsagePct)}%`;
-  const nowseg = hasPostTokens
-    ? `now ~${fmtPct(session.lastKnownUsagePct)}% (${fmtTokens(session.compactPostTokens)} tok)`
-    : `now ~${fmtPct(session.lastKnownUsagePct)}%`;
+  const nowSeg =
+    hasPostTokens && contextWindow > 0
+      ? `now ${fmtPct(session.lastKnownUsagePct)}% (${fmtTokensCompact(session.compactPostTokens)}/${windowLabel})`
+      : `now ~${fmtPct(session.lastKnownUsagePct)}%`;
+  const wasSeg =
+    hasPreTokens && contextWindow > 0
+      ? `was ${fmtPct(session.preCompactUsagePct)}% (${fmtTokensCompact(session.compactPreTokens)}/${windowLabel})`
+      : `was ~${fmtPct(session.preCompactUsagePct)}%`;
 
-  const parts: string[] = [`✅ Compaction complete · ${waseg} → ${nowseg}`];
-  if (session.compactTrigger) parts.push(`trigger=${session.compactTrigger}`);
-  const dur = fmtDuration(session.compactDurationMs);
-  if (dur) parts.push(dur);
-  return parts.join(' · ');
+  const contextParts = [`Context: ${nowSeg} ← ${wasSeg}`];
+  if (typeof session.compactionCount === 'number' && session.compactionCount > 0) {
+    contextParts.push(`compaction #${session.compactionCount}`);
+  }
+
+  return `${header}\n${contextParts.join(' · ')}`;
+}
+
+/**
+ * Tick interval for the live "starting" message elapsed-time updates.
+ * 3s matches the MCP-status tracker's adaptive floor — fast enough to feel
+ * live, slow enough to stay well inside Slack's chat.update rate limits.
+ */
+const COMPACT_STARTING_TICK_MS = 3_000;
+
+/**
+ * Safety ceiling for the ticker. If the SDK never emits
+ * `compact_boundary`/`PostCompact` (catastrophic failure mode), we stop
+ * spamming chat.update after this budget.
+ */
+const COMPACT_STARTING_TICKER_MAX_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Clear the live-starting ticker + its tracking fields. Idempotent —
+ * `postCompactCompleteIfNeeded` calls this regardless of whether a ticker is
+ * actually running (fallback-only codepaths never start one).
+ */
+function stopStartingTicker(session: ConversationSession): void {
+  if (session.compactTickInterval) {
+    clearInterval(session.compactTickInterval);
+    session.compactTickInterval = undefined;
+  }
 }
 
 /**
  * Shared START-post helper. Called by both the PreCompact hook and the
  * `status === 'compacting'` fallback in stream-executor.ts so the two paths
  * agree on epoch bookkeeping and the "starting" message text.
+ *
+ * On the first START signal per epoch we:
+ *   1. Post the initial "⏳ 🗜️ Compaction starting · trigger=X" line.
+ *   2. Capture its Slack ts on the session.
+ *   3. Start a setInterval that `chat.update`s the message every 3s with
+ *      elapsed time (MCP-status style live indicator).
+ *
+ * The ticker is cleared by `postCompactCompleteIfNeeded`; if that never
+ * fires (SDK failure), a 10-minute safety ceiling stops the ticker anyway.
  *
  * Idempotent within a cycle via `marker.pre`.
  */
@@ -228,15 +330,53 @@ export async function postCompactStartingIfNeeded(deps: CompactHookDeps, trigger
   const marker = ensurePostedMap(session)[epoch];
   if (!marker || marker.pre) return;
 
-  await slackApi.postSystemMessage(channel, `🗜️ Compaction starting · trigger=${trigger}`, { threadTs });
+  const resolvedTrigger = resolveStartingTrigger(session, trigger);
+  const startedAtMs = Date.now();
+  const initialText = buildCompactStartingMessage({ trigger: resolvedTrigger });
+
+  const result = await slackApi.postSystemMessage(channel, initialText, { threadTs });
   marker.pre = true;
+
+  // Track the live-message ts so the completion handler can chat.update it
+  // in-place rather than posting a second message.
+  session.compactStartedAtMs = startedAtMs;
+  session.compactStartingMessageTs = result.ts ?? null;
+
+  if (!result.ts) return; // Slack post failed — nothing to tick against.
+
+  // Start the ticker. Each tick re-resolves the trigger from the session —
+  // covers the "fallback path posted first, then onCompactBoundary filled in
+  // session.compactTrigger" case so the live message self-corrects.
+  const tsForUpdate = result.ts;
+  session.compactTickInterval = setInterval(() => {
+    const elapsedMs = Date.now() - startedAtMs;
+    if (elapsedMs >= COMPACT_STARTING_TICKER_MAX_MS) {
+      stopStartingTicker(session);
+      return;
+    }
+    const tickTrigger = resolveStartingTrigger(session, trigger);
+    const text = buildCompactStartingMessage({ trigger: tickTrigger, elapsedMs });
+    // chat.update is fire-and-forget here; a single failure is harmless
+    // because the next tick (or the completion update) will retry.
+    slackApi.updateMessage(channel, tsForUpdate, text).catch((err) => {
+      logger.debug('compact-starting ticker update failed (will retry next tick)', {
+        error: (err as Error)?.message ?? String(err),
+      });
+    });
+  }, COMPACT_STARTING_TICK_MS);
 }
 
 /**
  * Shared END-post helper. Called by both the PostCompact hook and the
- * `onCompactBoundary` stream callback. Posts the "complete" message once per
- * epoch, marks the epoch rehydrated, clears `autoCompactPending`, and
- * re-dispatches any captured user message atomically.
+ * `onCompactBoundary` stream callback. On first call per epoch:
+ *   1. Stops the live-starting ticker.
+ *   2. Builds the rich 2-line completion message with SDK-reported
+ *      pre/post tokens, trigger, duration, and Context-window snapshot.
+ *   3. Replaces the "starting" message in-place via `chat.update` when we
+ *      still have its ts (typical path), or posts a fresh system message as
+ *      a fallback (e.g. the ts wasn't captured — Slack post failure on START).
+ *   4. Marks the epoch rehydrated, clears `autoCompactPending`, and
+ *      re-dispatches any captured user message atomically.
  *
  * The Slack post and the pending re-dispatch are independent → run in parallel.
  */
@@ -246,12 +386,37 @@ export async function postCompactCompleteIfNeeded(deps: CompactHookDeps): Promis
   const marker = ensurePostedMap(session)[epoch];
   if (!marker) return;
 
+  // Stop the ticker BEFORE posting so a racing tick cannot clobber the
+  // "completed" text back to "starting".
+  stopStartingTicker(session);
+
   const postPromise =
     marker.post === true
       ? Promise.resolve()
       : (async () => {
-          await slackApi.postSystemMessage(channel, buildCompactCompleteMessage(session), { threadTs });
+          const text = buildCompactCompleteMessage(session);
+          const ts = session.compactStartingMessageTs;
+          if (ts) {
+            // Replace the live "starting" message in-place. If the update
+            // fails (message deleted, edit window expired, etc.) fall back
+            // to posting a fresh system message so the user still sees the
+            // completion signal.
+            try {
+              await slackApi.updateMessage(channel, ts, text);
+            } catch (err) {
+              logger.warn('compact complete: chat.update failed, falling back to new message', {
+                error: (err as Error)?.message ?? String(err),
+              });
+              await slackApi.postSystemMessage(channel, text, { threadTs });
+            }
+          } else {
+            // No starting ts (fallback-only path) → post a fresh message.
+            await slackApi.postSystemMessage(channel, text, { threadTs });
+          }
           marker.post = true;
+          // Clear runtime-only START tracking now that the cycle is sealed.
+          session.compactStartingMessageTs = null;
+          session.compactStartedAtMs = null;
         })();
 
   // Rehydration dedupe: whichever END signal fires first marks the epoch so

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,6 +265,16 @@ export interface ConversationSession {
   compactPostTokens?: number | null;
   compactTrigger?: 'manual' | 'auto' | null;
   compactDurationMs?: number | null;
+  // #617 followup (live "compacting" indicator): runtime-only fields — NOT
+  // serialized to disk (same convention as `pendingRetryTimer`). `…MessageTs`
+  // is the Slack message ts of the live "Compaction starting" post; we
+  // chat.update it with elapsed time while compacting and flip it to the
+  // "completed" state atomically when onCompactBoundary/PostCompact fires.
+  // `…StartedAtMs` is the wall-clock at START; `…TickInterval` is the
+  // setInterval handle for the ticker (cleared on completion).
+  compactStartingMessageTs?: string | null;
+  compactStartedAtMs?: number | null;
+  compactTickInterval?: ReturnType<typeof setInterval>;
   // Threshold-checker → input-processor signal that next /compact-threshold-violating user turn must be compacted.
   autoCompactPending?: boolean;
   // User message text captured when auto-compact intercepts the turn; re-dispatched after PostCompact.


### PR DESCRIPTION
## Summary

Deploy PR #640 to dev.

**What ships:**
- Live elapsed-time ticker on `Compaction starting` (MCP-style updates)
- Rich 2-line completion message with `Context: now X% (Nk/Wk) ← was Y% (Mk/Wk)`
- Drops `trigger=unknown (fallback)` noise
- In-place chat.update replaces starting message with completed form

**Included commits:**
- f725ed3 fix(compact): live ticker + rich 2-line completion message (#617 v2)
- f8db638 style: biome auto-format (collapse multi-line toBe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <z@2lab.ai>