### PR TITLE
feat(cct): always-visible slot info + hourly OAuth refresh worker

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -155,6 +155,33 @@ export const config = {
      */
     cardOpenTimeoutMs: parsePositiveIntEnv('USAGE_ON_OPEN_TIMEOUT_MS', 1_500, 500),
   },
+  /**
+   * CCT OAuth-token refresh scheduler knobs (#653 M2). Default 1-hour
+   * cadence surfaces stale refreshTokens within an hour rather than
+   * waiting for a dispatch to touch the slot, and keeps the "OAuth
+   * refreshes in X" hint on the card honest.
+   */
+  oauthRefresh: {
+    /**
+     * Emergency-off: set OAUTH_REFRESH_ENABLED=0 to disable the hourly pump.
+     * Default-on: any other value (or unset) leaves the scheduler active,
+     * which is the intended behaviour — operators must explicitly opt out.
+     */
+    enabled: process.env.OAUTH_REFRESH_ENABLED !== '0',
+    /**
+     * ms between ticks; default 1 hour. Floor is 5 minutes — below that,
+     * the scheduler churns refresh endpoints faster than the 8-hour token
+     * TTL warrants, which burns Anthropic-side rate limit for no gain.
+     */
+    intervalMs: parsePositiveIntEnv('OAUTH_REFRESH_INTERVAL_MS', 60 * 60_000, 5 * 60_000),
+    /**
+     * ms deadline for each fan-out; default 30s. Per-slot HTTP call has
+     * its own 10s timeout inside `refreshClaudeCredentials`, so 30s is
+     * enough headroom for a ~3-slot fleet. Floor 5s prevents ops setting
+     * this to a value that cancels every refresh before it completes.
+     */
+    fanOutTimeoutMs: parsePositiveIntEnv('OAUTH_REFRESH_TIMEOUT_MS', 30_000, 5_000),
+  },
 };
 
 export function validateConfig() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,12 @@ import { discoverInstallations, getGitHubAppAuth, isGitHubAppConfigured } from '
 import { Logger } from './logger';
 import { McpManager } from './mcp-manager';
 import { startReportScheduler, stopReportScheduler } from './metrics';
-import { startUsageRefreshScheduler, type UsageRefreshScheduler } from './oauth';
+import {
+  type OAuthRefreshScheduler,
+  startOAuthRefreshScheduler,
+  startUsageRefreshScheduler,
+  type UsageRefreshScheduler,
+} from './oauth';
 import { acquirePidLock, releasePidLock } from './pid-lock';
 import { PluginManager } from './plugin/plugin-manager';
 import { getVersionInfo, notifyRelease } from './release-notifier';
@@ -109,6 +114,19 @@ async function start() {
       enabled: config.usage.refreshEnabled,
     });
     timing('Usage refresh scheduler wired');
+
+    // #653 M2 — Start CCT OAuth-token refresh scheduler. Hourly fan-out
+    // force-refreshes every attached slot's access_token via
+    // `TokenManager.refreshAllAttachedOAuthTokens`. Surfaces stale
+    // refreshTokens as `refresh_failed` within 1h (rather than waiting
+    // for a dispatch to touch the slot) and keeps the card's "OAuth
+    // refreshes in X" hint honest. Null when OAUTH_REFRESH_ENABLED=0.
+    const oauthRefreshScheduler: OAuthRefreshScheduler | null = startOAuthRefreshScheduler(tokenManager, {
+      intervalMs: config.oauthRefresh.intervalMs,
+      timeoutMs: config.oauthRefresh.fanOutTimeoutMs,
+      enabled: config.oauthRefresh.enabled,
+    });
+    timing('OAuth refresh scheduler wired');
 
     logger.info('Starting Claude Code Slack bot', {
       debug: config.debug,
@@ -710,6 +728,15 @@ async function start() {
         // Stop CCT usage refresh scheduler before TM so no pump fires mid-teardown
         if (usageRefreshScheduler) {
           usageRefreshScheduler.stop();
+        }
+
+        // Stop CCT OAuth refresh scheduler before TM for the same reason —
+        // a tick firing mid-teardown could end up refreshing into a store
+        // whose handles have already been released. Must come before the
+        // token-manager teardown call immediately below (invariant locked
+        // by `oauth-refresh-scheduler.test.ts`).
+        if (oauthRefreshScheduler) {
+          oauthRefreshScheduler.stop();
         }
 
         // Stop TokenManager lease reaper

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -11,6 +11,13 @@ export {
   parseRateLimitHeaders,
   type RateLimitHint,
 } from './header-parser';
+export {
+  DEFAULT_OAUTH_REFRESH_INTERVAL_MS,
+  DEFAULT_OAUTH_REFRESH_TIMEOUT_MS,
+  OAuthRefreshScheduler,
+  type OAuthRefreshSchedulerOpts,
+  startOAuthRefreshScheduler,
+} from './oauth-refresh-scheduler';
 export type { OAuthCredentials } from './refresher';
 export {
   CLAUDE_OAUTH_CLIENT_ID,

--- a/src/oauth/oauth-refresh-scheduler.test.ts
+++ b/src/oauth/oauth-refresh-scheduler.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// RED tests for the hourly OAuth token refresh scheduler (#653 M2).
+// Module lives at src/oauth/oauth-refresh-scheduler.ts. Mirrors the
+// UsageRefreshScheduler test pattern: injectable fake clock so the
+// scheduler is deterministic under vi.fn timers without spinning
+// real wall-clock time.
+
+import {
+  DEFAULT_OAUTH_REFRESH_INTERVAL_MS,
+  DEFAULT_OAUTH_REFRESH_TIMEOUT_MS,
+  OAuthRefreshScheduler,
+  type OAuthRefreshSchedulerOpts,
+  startOAuthRefreshScheduler,
+} from './oauth-refresh-scheduler';
+
+type Tick = () => void;
+
+function makeFakeClock(): {
+  clock: NonNullable<OAuthRefreshSchedulerOpts['clock']>;
+  fireTick: () => void;
+  intervalMs: () => number | undefined;
+} {
+  let storedFn: Tick | null = null;
+  let storedMs: number | undefined;
+  const setIntervalFn = vi.fn((fn: Tick, ms: number) => {
+    storedFn = fn;
+    storedMs = ms;
+    return { id: 'fake' } as unknown as ReturnType<typeof setInterval>;
+  });
+  const clearIntervalFn = vi.fn(() => {
+    storedFn = null;
+  });
+  const clock: NonNullable<OAuthRefreshSchedulerOpts['clock']> = {
+    setInterval: setIntervalFn as unknown as NonNullable<OAuthRefreshSchedulerOpts['clock']>['setInterval'],
+    clearInterval: clearIntervalFn as unknown as NonNullable<OAuthRefreshSchedulerOpts['clock']>['clearInterval'],
+  };
+  return {
+    clock,
+    fireTick: () => {
+      if (storedFn) storedFn();
+    },
+    intervalMs: () => storedMs,
+  };
+}
+
+function makeTm(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    refreshAllAttachedOAuthTokens: vi.fn(async () => ({})),
+    ...overrides,
+  } as any;
+}
+
+describe('OAuthRefreshScheduler (#653 M2)', () => {
+  it('DEFAULT_OAUTH_REFRESH_INTERVAL_MS is exactly 1 hour (user spec)', () => {
+    // User explicitly called for "1 hour" cadence — lock the constant so
+    // a future "I made it faster" commit can't silently drop to 5min
+    // without a PR discussion.
+    expect(DEFAULT_OAUTH_REFRESH_INTERVAL_MS).toBe(60 * 60 * 1_000);
+  });
+
+  it('first tick calls tm.refreshAllAttachedOAuthTokens once with the configured timeoutMs', async () => {
+    const { clock, fireTick } = makeFakeClock();
+    const tm = makeTm();
+    const s = new OAuthRefreshScheduler(tm, {
+      intervalMs: 60 * 60_000,
+      timeoutMs: 30_000,
+      enabled: true,
+      clock,
+    });
+    s.start();
+    fireTick();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(tm.refreshAllAttachedOAuthTokens).toHaveBeenCalledTimes(1);
+    const args = tm.refreshAllAttachedOAuthTokens.mock.calls[0][0];
+    expect(args.timeoutMs).toBe(30_000);
+  });
+
+  it('interval forwarded to setInterval matches the provided intervalMs', () => {
+    const { clock, intervalMs } = makeFakeClock();
+    const tm = makeTm();
+    const s = new OAuthRefreshScheduler(tm, {
+      intervalMs: 60 * 60_000,
+      timeoutMs: 30_000,
+      enabled: true,
+      clock,
+    });
+    s.start();
+    expect(intervalMs()).toBe(60 * 60_000);
+  });
+
+  it('enabled:false → factory returns null, never arms the interval, no tick', () => {
+    const { clock, fireTick } = makeFakeClock();
+    const tm = makeTm();
+    const scheduler = startOAuthRefreshScheduler(tm, {
+      intervalMs: 60 * 60_000,
+      timeoutMs: 30_000,
+      enabled: false,
+      clock,
+    });
+    expect(scheduler).toBeNull();
+    expect(clock.setInterval).not.toHaveBeenCalled();
+    fireTick();
+    expect(tm.refreshAllAttachedOAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it('after stop() further fake ticks do not call tm.*', async () => {
+    const { clock, fireTick } = makeFakeClock();
+    const tm = makeTm();
+    const s = new OAuthRefreshScheduler(tm, {
+      intervalMs: 60 * 60_000,
+      timeoutMs: 30_000,
+      enabled: true,
+      clock,
+    });
+    s.start();
+    s.stop();
+    fireTick();
+    await Promise.resolve();
+    expect(tm.refreshAllAttachedOAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it('tick throwing does not stop the scheduler — next interval still calls tm.*', async () => {
+    const { clock, fireTick } = makeFakeClock();
+    const tm = makeTm({
+      refreshAllAttachedOAuthTokens: vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({}),
+    });
+    const s = new OAuthRefreshScheduler(tm, {
+      intervalMs: 60 * 60_000,
+      timeoutMs: 30_000,
+      enabled: true,
+      clock,
+    });
+    s.start();
+    fireTick();
+    await new Promise((r) => setImmediate(r));
+    fireTick();
+    await new Promise((r) => setImmediate(r));
+    expect(tm.refreshAllAttachedOAuthTokens).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-entrancy: overlapping ticks still call tm.* (dedupe lives inside TM)', async () => {
+    const { clock, fireTick } = makeFakeClock();
+    let release!: () => void;
+    const pending = new Promise<Record<string, 'ok' | 'error'>>((resolve) => {
+      release = () => resolve({});
+    });
+    const tm = makeTm({
+      refreshAllAttachedOAuthTokens: vi
+        .fn()
+        .mockImplementationOnce(() => pending)
+        .mockResolvedValue({}),
+    });
+    const s = new OAuthRefreshScheduler(tm, {
+      intervalMs: 60 * 60_000,
+      timeoutMs: 30_000,
+      enabled: true,
+      clock,
+    });
+    s.start();
+    fireTick();
+    fireTick();
+    fireTick();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(tm.refreshAllAttachedOAuthTokens).toHaveBeenCalledTimes(3);
+    release();
+    await pending;
+  });
+
+  it('timeoutMs defaults to DEFAULT_OAUTH_REFRESH_TIMEOUT_MS when omitted', async () => {
+    const { clock, fireTick } = makeFakeClock();
+    const tm = makeTm();
+    const s = new OAuthRefreshScheduler(tm, {
+      intervalMs: 60 * 60_000,
+      enabled: true,
+      clock,
+    });
+    s.start();
+    fireTick();
+    await Promise.resolve();
+    await Promise.resolve();
+    const args = tm.refreshAllAttachedOAuthTokens.mock.calls[0][0];
+    expect(args.timeoutMs).toBe(DEFAULT_OAUTH_REFRESH_TIMEOUT_MS);
+  });
+
+  it('INVARIANT: shutdown path stops OAuth scheduler BEFORE tokenManager (pump must not fire mid-teardown)', async () => {
+    // Read the source of src/index.ts and lock the textual ordering.
+    // Mirrors the usage-scheduler's own shutdown-order invariant test.
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/index.ts'), 'utf8');
+    const schedIdx = source.indexOf('oauthRefreshScheduler.stop()');
+    const tmIdx = source.indexOf('tokenManager.stop()');
+    expect(schedIdx).toBeGreaterThan(-1);
+    expect(tmIdx).toBeGreaterThan(-1);
+    expect(schedIdx).toBeLessThan(tmIdx);
+  });
+
+  it('INVARIANT: bootstrap wires startOAuthRefreshScheduler after startUsageRefreshScheduler', async () => {
+    // Document-by-test the bootstrap order so a refactor that puts
+    // the OAuth scheduler before usage (or drops it entirely) is caught.
+    // The two schedulers are independent but sharing the order keeps the
+    // timing-log output predictable for operators reading startup logs.
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/index.ts'), 'utf8');
+    const usageIdx = source.indexOf('startUsageRefreshScheduler(tokenManager');
+    const oauthIdx = source.indexOf('startOAuthRefreshScheduler(tokenManager');
+    expect(usageIdx).toBeGreaterThan(-1);
+    expect(oauthIdx).toBeGreaterThan(-1);
+    expect(usageIdx).toBeLessThan(oauthIdx);
+  });
+});

--- a/src/oauth/oauth-refresh-scheduler.ts
+++ b/src/oauth/oauth-refresh-scheduler.ts
@@ -1,0 +1,166 @@
+/**
+ * OAuthRefreshScheduler — boot-time tick wrapper around
+ * `TokenManager.refreshAllAttachedOAuthTokens` (#653 M2).
+ *
+ * Purpose:
+ *   Every registered OAuth-attached CCT slot gets its access_token
+ *   force-refreshed on a fixed cadence (default 1 hour), regardless of
+ *   whether the SDK dispatch path has touched it. This guarantees:
+ *     - Stale `refreshToken` gets surfaced as `refresh_failed` within
+ *       one tick (1h) rather than waiting for the next dispatch.
+ *     - `subscriptionType` / `rateLimitTier` mutations on the Anthropic
+ *       side propagate to the local snapshot within 1h.
+ *     - The "OAuth refreshes in X" hint on the card matches the
+ *       scheduler's actual cadence — users stop seeing week-old hints
+ *       on idle slots.
+ *
+ * Why a separate module (not folded into UsageRefreshScheduler):
+ *   - Different cadence — usage needs 5min ticks to stay fresh, OAuth
+ *     tokens have 8h TTLs and hourly refresh is the right cost/benefit
+ *     balance (8x redundancy against 1 missed tick).
+ *   - Different semantics — usage fan-out respects per-slot throttles
+ *     (`nextUsageFetchAllowedAt`); OAuth refresh has no such throttle
+ *     (the Anthropic endpoint has its own server-side rate limit, and
+ *     we expect <50 slots per bot).
+ *   - Failure surface — a usage tick failure is silently backed off;
+ *     an OAuth refresh failure marks the slot's authState, which is
+ *     a durable signal we want visible in logs.
+ *
+ * Invariant (locked by test in `oauth-refresh-scheduler.test.ts`):
+ *   The scheduler must NEVER be disabled silently. `enabled: false`
+ *   returns null + logs a warning so operators notice the missing
+ *   background refresh (which is what lets stale refreshTokens
+ *   eventually surface). Default is ON.
+ */
+
+import { Logger } from '../logger';
+import type { TokenManager } from '../token-manager';
+
+const logger = new Logger('OAuthRefreshScheduler');
+
+/** Default 1 hour between ticks — the user spec explicitly calls this out. */
+export const DEFAULT_OAUTH_REFRESH_INTERVAL_MS = 60 * 60 * 1_000;
+/** Default 30s per-fan-out deadline (`refreshClaudeCredentials` has its own 10s timeout per slot). */
+export const DEFAULT_OAUTH_REFRESH_TIMEOUT_MS = 30_000;
+
+export interface OAuthRefreshSchedulerOpts {
+  /** Interval between ticks, ms. */
+  intervalMs: number;
+  /** Per-fan-out deadline (ms) forwarded to `refreshAllAttachedOAuthTokens`. */
+  timeoutMs?: number;
+  /** When false, the factory returns null and never starts. */
+  enabled?: boolean;
+  /** Injection seam for tests (fake clock). Default: Node's setInterval. */
+  clock?: {
+    setInterval: (fn: () => void, ms: number) => ReturnType<typeof setInterval>;
+    clearInterval: (h: ReturnType<typeof setInterval>) => void;
+  };
+}
+
+/**
+ * Thin scheduler that pumps `TokenManager.refreshAllAttachedOAuthTokens`
+ * on a fixed interval. Re-entrancy-safe: if a previous tick's async
+ * work hasn't resolved when the next interval fires, the scheduler kicks
+ * off another tick — the TokenManager's per-keyId `refreshInFlight`
+ * dedupe (composite key: `${keyId}:${attachedAt}`) ensures overlapping
+ * ticks share in-flight HTTP calls rather than stacking them.
+ */
+export class OAuthRefreshScheduler {
+  readonly #tm: TokenManager;
+  readonly #intervalMs: number;
+  readonly #timeoutMs: number;
+  readonly #clock: NonNullable<OAuthRefreshSchedulerOpts['clock']>;
+  #handle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(tm: TokenManager, opts: OAuthRefreshSchedulerOpts) {
+    this.#tm = tm;
+    this.#intervalMs = opts.intervalMs;
+    this.#timeoutMs = opts.timeoutMs ?? DEFAULT_OAUTH_REFRESH_TIMEOUT_MS;
+    this.#clock = opts.clock ?? {
+      setInterval: (fn, ms) => setInterval(fn, ms),
+      clearInterval: (h) => clearInterval(h),
+    };
+  }
+
+  /** Start pumping. Idempotent — a second call is a no-op. */
+  start(): void {
+    if (this.#handle) return;
+    this.#handle = this.#clock.setInterval(() => {
+      void this.tickNow();
+    }, this.#intervalMs);
+    // Don't keep Node alive solely for this timer under scripts / tests.
+    const h = this.#handle as unknown as { unref?: () => void };
+    if (typeof h?.unref === 'function') h.unref();
+  }
+
+  /**
+   * Stop pumping. Safe to call multiple times.
+   *
+   * KNOWN LIMITATION (mirrors UsageRefreshScheduler): does NOT await an
+   * in-flight tickNow() — a tick fired just before stop() may settle
+   * after. Production is safe because (a) the fan-out has its own
+   * timeoutMs deadline and (b) the only side effect is a store mutate
+   * which is itself atomic under CAS.
+   */
+  stop(): void {
+    if (!this.#handle) return;
+    this.#clock.clearInterval(this.#handle);
+    this.#handle = null;
+  }
+
+  /**
+   * Run one tick synchronously and return the awaitable promise. Tests
+   * use this after poking the fake clock; production reaches it only
+   * via the interval closure. Errors are logged and swallowed so the
+   * next tick still fires.
+   */
+  async tickNow(): Promise<void> {
+    const startedAt = Date.now();
+    try {
+      const results = await this.#tm.refreshAllAttachedOAuthTokens({
+        timeoutMs: this.#timeoutMs,
+      });
+      const total = Object.keys(results).length;
+      const errors = Object.values(results).filter((r) => r === 'error').length;
+      logger.info('OAuth refresh tick complete', {
+        total,
+        ok: total - errors,
+        errors,
+        durationMs: Date.now() - startedAt,
+      });
+    } catch (err) {
+      logger.warn('OAuth refresh tick failed (next interval will retry)', {
+        err,
+        durationMs: Date.now() - startedAt,
+        timeoutMs: this.#timeoutMs,
+        intervalMs: this.#intervalMs,
+      });
+    }
+  }
+}
+
+/**
+ * Factory. Returns `null` when `opts.enabled === false` so the caller
+ * does not need to branch on the feature flag. Mirrors the
+ * `startUsageRefreshScheduler` contract so bootstrap wiring reads
+ * identically for both schedulers.
+ */
+export function startOAuthRefreshScheduler(
+  tm: TokenManager,
+  opts: OAuthRefreshSchedulerOpts,
+): OAuthRefreshScheduler | null {
+  if (opts.enabled === false) {
+    logger.warn(
+      'OAuth refresh scheduler DISABLED (OAUTH_REFRESH_ENABLED=0). ' +
+        'Stale refreshTokens will not be surfaced until next dispatch touches the slot.',
+    );
+    return null;
+  }
+  const scheduler = new OAuthRefreshScheduler(tm, opts);
+  scheduler.start();
+  logger.info('OAuth refresh scheduler started', {
+    intervalMs: opts.intervalMs,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_OAUTH_REFRESH_TIMEOUT_MS,
+  });
+  return scheduler;
+}

--- a/src/slack/cct/actions.ts
+++ b/src/slack/cct/actions.ts
@@ -252,7 +252,7 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
     }
   });
 
-  // #653 M2 — Per-slot [Activate] button. Admin gate + `applyToken(keyId)`
+  // Per-slot [Activate] button. Admin gate + `applyToken(keyId)`
   // + re-post card. Button is only emitted for non-active, non-api_key
   // slots (see `buildSlotRow`); the handler re-validates server-side so
   // a stale card (where the user already rotated elsewhere) can't force

--- a/src/slack/cct/actions.ts
+++ b/src/slack/cct/actions.ts
@@ -236,7 +236,9 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
     }
   });
 
-  // Set active.
+  // Set active via fallback dropdown (kept for accessibility + bulk
+  // navigation on wide fleets). The per-slot inline [Activate] button
+  // registered below is the primary affordance for single-slot activation.
   app.action(CCT_ACTION_IDS.set_active, async ({ ack, body, client, respond }) => {
     await ack();
     try {
@@ -247,6 +249,38 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
       await respondWithCard({ tokenManager, respond, body, client });
     } catch (err) {
       logger.error('cct_set_active failed', err);
+    }
+  });
+
+  // #653 M2 — Per-slot [Activate] button. Admin gate + `applyToken(keyId)`
+  // + re-post card. Button is only emitted for non-active, non-api_key
+  // slots (see `buildSlotRow`); the handler re-validates server-side so
+  // a stale card (where the user already rotated elsewhere) can't force
+  // a runtime exception into `applyToken`'s api_key reject path.
+  app.action(CCT_ACTION_IDS.activate_slot, async ({ ack, body, client, respond }) => {
+    await ack();
+    try {
+      if (!requireAdmin(body)) return;
+      const bodyAction = (body as any).actions?.[0];
+      const targetKeyId = typeof bodyAction?.value === 'string' ? bodyAction.value : undefined;
+      if (!targetKeyId) {
+        logger.warn('cct_activate_slot: missing keyId on action value');
+        return;
+      }
+      const snap = await tokenManager.getSnapshot();
+      const target = snap.registry.slots.find((s) => s.keyId === targetKeyId);
+      if (!target) {
+        logger.warn('cct_activate_slot: target slot not found', { targetKeyId });
+        return;
+      }
+      if (target.kind === 'api_key') {
+        logger.warn('cct_activate_slot: target is api_key (not runtime-selectable)', { targetKeyId });
+        return;
+      }
+      await tokenManager.applyToken(targetKeyId);
+      await respondWithCard({ tokenManager, respond, body, client });
+    } catch (err) {
+      logger.error('cct_activate_slot failed', err);
     }
   });
 
@@ -284,11 +318,21 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
     }
   });
 
-  // Per-slot "Refresh" — admin gate + `{ force: true }` bypasses the
-  // local throttle for this single slot. When `fetchAndStoreUsage`
-  // returns `null` (throttled or failed), post the same ephemeral banner
-  // the Refresh-all handler uses for its all-null branch so the admin
-  // sees actionable feedback instead of an unchanged re-render.
+  // Per-slot "Refresh" — force-refresh BOTH the OAuth access_token AND
+  // the usage snapshot. Rationale (#653 M2): operators clicking Refresh
+  // expect the "OAuth refreshes in X" hint on the card to reset, not
+  // just the usage percentages. Previously the button refreshed only
+  // usage (which internally only triggered a token refresh if the
+  // access_token was within the 7h REFRESH_BUFFER_MS window), so a fresh
+  // token with 6h left would show the same expiry before and after
+  // click. Now we call `forceRefreshOAuth` first (ignoring "still fresh"
+  // short-circuit) then `fetchAndStoreUsage({force:true})`.
+  //
+  // Admin gate + `{ force: true }` on usage fetch bypasses the local
+  // throttle for this single slot. OAuth refresh failures are logged
+  // but don't abort the usage fetch — a `revoked` token will surface
+  // via `authState` on the re-posted card, so the user sees the failure
+  // mode.
   app.action(CCT_ACTION_IDS.refresh_usage_slot, async ({ ack, body, client }) => {
     await ack();
     try {
@@ -298,6 +342,18 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
       if (!targetKeyId) {
         logger.warn('cct_refresh_usage_slot: missing keyId on action value');
         return;
+      }
+      // Force-refresh OAuth first. `forceRefreshOAuth` is a no-op when
+      // the slot has no attachment. Failures (401/403) mark the slot's
+      // authState but don't throw past here — we still want the usage
+      // fetch to run so the card shows the latest state + the error.
+      try {
+        await tokenManager.forceRefreshOAuth(targetKeyId);
+      } catch (err) {
+        logger.warn('cct_refresh_usage_slot: OAuth force-refresh failed (continuing with usage fetch)', {
+          targetKeyId,
+          err,
+        });
       }
       const result = await tokenManager.fetchAndStoreUsage(targetKeyId, { force: true });
       if (result === null) {

--- a/src/slack/cct/builder.test.ts
+++ b/src/slack/cct/builder.test.ts
@@ -62,7 +62,7 @@ describe('buildSlotRow', () => {
     expect(section.text.text).toContain('ToS-risk');
   });
 
-  it('includes rate-limit timestamp + source in the context row (M1-S2 moves usage out of context)', () => {
+  it('#653 M2 — rate-limit timestamp + source render in the section multi-line body (always, not gated on isActive)', () => {
     const slot = setupSlot();
     const state: SlotState = {
       authState: 'healthy',
@@ -76,25 +76,26 @@ describe('buildSlotRow', () => {
       },
     };
     const now = Date.parse('2026-04-18T03:42:00Z');
-    // isActive=true so the context + usage-panel stack is emitted (#644
-    // review — inactive slots are compacted to 2 blocks to fit Slack's
-    // 50-block cap).
+    // #653 M2 collapses the former separate context block into a
+    // multi-line `section` body so the line-1 identity and line-2 live
+    // status fit in one Slack block. isActive is irrelevant — the
+    // status line is emitted for every row now.
     const blocks = buildSlotRow(slot, state, true, now, 'Asia/Seoul');
-    const context = blocks[1] as any;
-    expect(context.type).toBe('context');
-    const text = context.elements[0].text as string;
+    const section = blocks[0] as any;
+    expect(section.type).toBe('section');
+    const text = section.text.text as string;
     expect(text).toContain('rate-limited');
     expect(text).toContain('12:37 KST');
     expect(text).toContain('via response_header');
-    // M1-S2 — old one-line `usage 5h X% 7d Y%` is removed; the usage panel
-    // now lives in a dedicated section/context block rendered after this
-    // one. The context row MUST NOT contain the legacy single-line string.
-    expect(text).not.toMatch(/5h\s+72%/);
-    expect(text).not.toMatch(/7d\s+33%/);
+    // Old one-line `usage 5h X% 7d Y%` literal must never re-appear.
+    expect(text).not.toMatch(/usage 5h \d+% 7d \d+%/);
   });
 
   it('honours 0..100 utilization values in the progress bar panel', () => {
-    const slot = setupSlot();
+    // #653 M2 — usage panel only renders for slots with an oauthAttachment
+    // (the only ones with live usage data). Use an attached slot so the
+    // panel surfaces.
+    const slot = oauthSlot();
     const state: SlotState = {
       authState: 'healthy',
       activeLeases: [],
@@ -103,14 +104,13 @@ describe('buildSlotRow', () => {
         fiveHour: { utilization: 77, resetsAt: '2026-04-18T05:00:00Z' },
       },
     };
-    // isActive=true so the usage panel is emitted.
     const blocks = buildSlotRow(slot, state, true, Date.parse('2026-04-18T00:01:00Z'));
     const flat = JSON.stringify(blocks);
     // Pass-through path: 77 > 1 → rendered as 77%.
     expect(flat).toMatch(/77%/);
   });
 
-  it('shows cooldown suffix when still in future', () => {
+  it('shows cooldown suffix when still in future (#653 M2: suffix lives on the section multi-line body)', () => {
     const slot = setupSlot();
     const now = Date.parse('2026-04-18T03:42:00Z');
     const state: SlotState = {
@@ -118,15 +118,18 @@ describe('buildSlotRow', () => {
       activeLeases: [],
       cooldownUntil: '2026-04-18T04:42:00Z',
     };
-    // isActive=true so the context row is emitted (#644 review fix).
     const blocks = buildSlotRow(slot, state, true, now, 'Asia/Seoul');
-    const text = (blocks[1] as any).elements[0].text as string;
+    const text = (blocks[0] as any).text.text as string;
     expect(text).toMatch(/cooldown until/);
   });
 
-  // #644 review P1 — inactive slots must collapse to section + actions + divider
-  // so a 15-slot card stays under Slack's 50-block cap.
-  it('inactive slot collapses to section + actions only (no context, no usage panel)', () => {
+  // #653 M2 — the OLD "inactive collapses to section + actions only" rule is
+  // explicitly reversed: the user wants tier/5h/7d/rate-limited visible on
+  // EVERY slot, not just the active one. This test locks the new contract:
+  // inactive slots still carry the authState+rate-limited segments on their
+  // section multi-line body. (Block budget is preserved via trimBlocksToSlackCap
+  // in `buildCctCardBlocks`; the N=15 cap tests below still pass.)
+  it('#653 M2 — inactive slot DOES render rate-limited + authState on its section body', () => {
     const slot = setupSlot();
     const state: SlotState = {
       authState: 'refresh_failed',
@@ -139,15 +142,88 @@ describe('buildSlotRow', () => {
     };
     const now = Date.parse('2026-04-18T03:42:00Z');
     const blocks = buildSlotRow(slot, state, false, now, 'Asia/Seoul');
-    const types = blocks.map((b: any) => b.type);
-    // Exactly two blocks: a section (headline) + an actions row.
-    expect(types).toEqual(['section', 'actions']);
+    const section = blocks[0] as any;
+    expect(section.type).toBe('section');
+    const text = section.text.text as string;
+    // The rate-limited timestamp + refresh_failed badge are now visible for
+    // inactive slots (inverts the M1 review-P1 behaviour which hid them).
+    expect(text).toMatch(/rate-limited/);
+    expect(text).toMatch(/refresh_failed/);
+    // The inactive row still skips the usage panel when there's no
+    // oauthAttachment, so no progress-bar glyphs leak in.
     const flat = JSON.stringify(blocks);
-    // No usage progress bars, no rate-limit banner — the context stack is
-    // suppressed for inactive rows.
     expect(flat).not.toMatch(/█/);
-    expect(flat).not.toMatch(/rate-limited/);
-    expect(flat).not.toMatch(/refresh_failed/);
+  });
+
+  // #653 M2 — the [Activate] button appears on every non-active slot that
+  // can be activated (i.e. cct slots, not api_key). Lock the button shape
+  // + styling + value so the actions.ts router keeps routing correctly.
+  it('#653 M2 — non-active cct slot gets [Activate] button with style=primary and value=keyId', () => {
+    const slot = setupSlot('cct-foo', 'slot-foo');
+    const blocks = buildSlotRow(slot, undefined, false, Date.parse('2026-04-21T00:00:00Z'));
+    const actions = blocks.find((b: any) => b.type === 'actions') as any;
+    const activateBtn = actions.elements.find((e: any) => e.action_id === CCT_ACTION_IDS.activate_slot);
+    expect(activateBtn).toBeDefined();
+    expect(activateBtn.style).toBe('primary');
+    expect(activateBtn.value).toBe('slot-foo');
+  });
+
+  it('#653 M2 — active cct slot does NOT get [Activate] button (already active)', () => {
+    const slot = setupSlot();
+    const blocks = buildSlotRow(slot, undefined, true, Date.parse('2026-04-21T00:00:00Z'));
+    const actions = blocks.find((b: any) => b.type === 'actions') as any;
+    const activateBtn = actions.elements.find((e: any) => e.action_id === CCT_ACTION_IDS.activate_slot);
+    expect(activateBtn).toBeUndefined();
+  });
+
+  it('#653 M2 — OAuth expiry hint appears on attached slots and updates with time', () => {
+    const nowMs = Date.parse('2026-04-21T00:00:00Z');
+    const slot: AuthKey = {
+      kind: 'cct',
+      source: 'setup',
+      keyId: 'slot-oauth',
+      name: 'oauth-s',
+      setupToken: 'sk-ant-oat01-x',
+      oauthAttachment: {
+        accessToken: 't',
+        refreshToken: 'r',
+        expiresAtMs: nowMs + 2 * 3_600_000 + 15 * 60_000, // 2h 15m ahead
+        scopes: ['user:profile'],
+        acknowledgedConsumerTosRisk: true,
+      },
+      createdAt: '',
+    };
+    const blocks = buildSlotRow(slot, undefined, false, nowMs);
+    const section = blocks[0] as any;
+    expect(section.text.text as string).toMatch(/OAuth refreshes in 2h 15m/);
+    // Bare setup-token slots (no attachment) do NOT display an expiry hint.
+    const bareSlot = setupSlot();
+    const bareBlocks = buildSlotRow(bareSlot, undefined, false, nowMs);
+    const bareSection = bareBlocks[0] as any;
+    expect(bareSection.text.text as string).not.toMatch(/OAuth refreshes in/);
+  });
+
+  it('#653 M2 — expired OAuth attachment surfaces :warning: expired (no negative durations)', () => {
+    const nowMs = Date.parse('2026-04-21T00:00:00Z');
+    const slot: AuthKey = {
+      kind: 'cct',
+      source: 'legacy-attachment',
+      keyId: 'slot-exp',
+      name: 'expired',
+      oauthAttachment: {
+        accessToken: 't',
+        refreshToken: 'r',
+        expiresAtMs: nowMs - 3_600_000, // 1h ago
+        scopes: ['user:profile'],
+        acknowledgedConsumerTosRisk: true,
+      },
+      createdAt: '',
+    };
+    const blocks = buildSlotRow(slot, undefined, false, nowMs);
+    const section = blocks[0] as any;
+    const text = section.text.text as string;
+    expect(text).toContain(':warning: OAuth expired');
+    expect(text).not.toMatch(/OAuth refreshes in -/); // no negative duration
   });
 
   it('emits per-slot Remove/Rename buttons with value = keyId', () => {
@@ -710,6 +786,7 @@ describe('CCT_ACTION_IDS / CCT_BLOCK_IDS literal lock (#644 review)', () => {
       attach_tos_ack: 'cct_attach_tos_ack_value',
       refresh_usage_all: 'cct_refresh_usage_all',
       refresh_usage_slot: 'cct_refresh_usage_slot',
+      activate_slot: 'cct_activate_slot',
     });
   });
 

--- a/src/slack/cct/builder.test.ts
+++ b/src/slack/cct/builder.test.ts
@@ -62,7 +62,7 @@ describe('buildSlotRow', () => {
     expect(section.text.text).toContain('ToS-risk');
   });
 
-  it('#653 M2 — rate-limit timestamp + source render in the section multi-line body (always, not gated on isActive)', () => {
+  it('rate-limit timestamp + source render in the section multi-line body (always, not gated on isActive)', () => {
     const slot = setupSlot();
     const state: SlotState = {
       authState: 'healthy',
@@ -92,7 +92,7 @@ describe('buildSlotRow', () => {
   });
 
   it('honours 0..100 utilization values in the progress bar panel', () => {
-    // #653 M2 — usage panel only renders for slots with an oauthAttachment
+    // usage panel only renders for slots with an oauthAttachment
     // (the only ones with live usage data). Use an attached slot so the
     // panel surfaces.
     const slot = oauthSlot();
@@ -123,13 +123,13 @@ describe('buildSlotRow', () => {
     expect(text).toMatch(/cooldown until/);
   });
 
-  // #653 M2 — the OLD "inactive collapses to section + actions only" rule is
+  // the OLD "inactive collapses to section + actions only" rule is
   // explicitly reversed: the user wants tier/5h/7d/rate-limited visible on
   // EVERY slot, not just the active one. This test locks the new contract:
   // inactive slots still carry the authState+rate-limited segments on their
   // section multi-line body. (Block budget is preserved via trimBlocksToSlackCap
   // in `buildCctCardBlocks`; the N=15 cap tests below still pass.)
-  it('#653 M2 — inactive slot DOES render rate-limited + authState on its section body', () => {
+  it('inactive slot DOES render rate-limited + authState on its section body', () => {
     const slot = setupSlot();
     const state: SlotState = {
       authState: 'refresh_failed',
@@ -155,10 +155,10 @@ describe('buildSlotRow', () => {
     expect(flat).not.toMatch(/█/);
   });
 
-  // #653 M2 — the [Activate] button appears on every non-active slot that
+  // the [Activate] button appears on every non-active slot that
   // can be activated (i.e. cct slots, not api_key). Lock the button shape
   // + styling + value so the actions.ts router keeps routing correctly.
-  it('#653 M2 — non-active cct slot gets [Activate] button with style=primary and value=keyId', () => {
+  it('non-active cct slot gets [Activate] button with style=primary and value=keyId', () => {
     const slot = setupSlot('cct-foo', 'slot-foo');
     const blocks = buildSlotRow(slot, undefined, false, Date.parse('2026-04-21T00:00:00Z'));
     const actions = blocks.find((b: any) => b.type === 'actions') as any;
@@ -168,7 +168,7 @@ describe('buildSlotRow', () => {
     expect(activateBtn.value).toBe('slot-foo');
   });
 
-  it('#653 M2 — active cct slot does NOT get [Activate] button (already active)', () => {
+  it('active cct slot does NOT get [Activate] button (already active)', () => {
     const slot = setupSlot();
     const blocks = buildSlotRow(slot, undefined, true, Date.parse('2026-04-21T00:00:00Z'));
     const actions = blocks.find((b: any) => b.type === 'actions') as any;
@@ -176,7 +176,7 @@ describe('buildSlotRow', () => {
     expect(activateBtn).toBeUndefined();
   });
 
-  it('#653 M2 — OAuth expiry hint appears on attached slots and updates with time', () => {
+  it('OAuth expiry hint appears on attached slots and updates with time', () => {
     const nowMs = Date.parse('2026-04-21T00:00:00Z');
     const slot: AuthKey = {
       kind: 'cct',
@@ -203,7 +203,7 @@ describe('buildSlotRow', () => {
     expect(bareSection.text.text as string).not.toMatch(/OAuth refreshes in/);
   });
 
-  it('#653 M2 — expired OAuth attachment surfaces :warning: expired (no negative durations)', () => {
+  it('expired OAuth attachment surfaces :warning: expired (no negative durations)', () => {
     const nowMs = Date.parse('2026-04-21T00:00:00Z');
     const slot: AuthKey = {
       kind: 'cct',
@@ -594,6 +594,24 @@ describe('buildCctCardBlocks — Slack 50-block hard cap (#644 review P1)', () =
   it.each([1, 7, 10, 15])('N=%d attached slots → block count ≤ 50 (with slot-0 active)', (n) => {
     const blocks = buildNSlotCard(n);
     expect(blocks.length).toBeLessThanOrEqual(50);
+  });
+
+  // Overflow guard identifies usage panels by stable `block_id` prefix,
+  // not by text content. Lock the contract so a future card-format
+  // tweak (e.g. dropping the code fence) doesn't silently break the
+  // overflow guard.
+  it('usage panels carry the stable `cct_usage_panel:` block_id prefix', () => {
+    const blocks = buildNSlotCard(3);
+    const usagePanels = blocks.filter(
+      (b) =>
+        (b as { type?: string }).type === 'context' &&
+        typeof (b as { block_id?: string }).block_id === 'string' &&
+        ((b as { block_id: string }).block_id as string).startsWith('cct_usage_panel:'),
+    );
+    expect(usagePanels.length).toBe(3);
+    // Each panel's block_id ends with the slot keyId — proves uniqueness.
+    const suffixes = usagePanels.map((b) => (b as { block_id: string }).block_id.split(':')[1]);
+    expect(new Set(suffixes).size).toBe(3);
   });
 });
 

--- a/src/slack/cct/builder.ts
+++ b/src/slack/cct/builder.ts
@@ -13,6 +13,7 @@ import type { ZBlock } from '../z/types';
 import {
   CCT_ACTION_IDS,
   CCT_BLOCK_IDS,
+  CCT_CARD_BLOCK_ID_PREFIX,
   CCT_VIEW_IDS,
   OAUTH_BLOB_HELP,
   OAUTH_BLOB_WARN_THRESHOLD,
@@ -170,7 +171,7 @@ function formatSubscriptionType(raw: string): string {
  * context block. Returns `null` when the slot has no usage data — callers
  * simply skip the panel in that case (no placeholder rendered).
  */
-function buildUsagePanelBlock(usage: UsageSnapshot, nowMs: number): ZBlock | null {
+function buildUsagePanelBlock(usage: UsageSnapshot, nowMs: number, keyId: string): ZBlock | null {
   const rows: string[] = [];
   if (usage.fiveHour) {
     rows.push(formatUsageBar(usage.fiveHour.utilization, usage.fiveHour.resetsAt, nowMs, '5h'));
@@ -183,9 +184,14 @@ function buildUsagePanelBlock(usage: UsageSnapshot, nowMs: number): ZBlock | nul
   }
   if (rows.length === 0) return null;
   // Wrap in a code fence so Slack preserves the monospace alignment that
-  // the padded labels rely on.
+  // the padded labels rely on. `block_id` is prefixed so the overflow
+  // guard can identify usage panels by id rather than by text content.
   const text = '```\n' + rows.join('\n') + '\n```';
-  return { type: 'context', elements: [{ type: 'mrkdwn', text }] };
+  return {
+    type: 'context',
+    block_id: `${CCT_CARD_BLOCK_ID_PREFIX.usagePanel}${keyId}`,
+    elements: [{ type: 'mrkdwn', text }],
+  };
 }
 
 function authStateBadge(state: AuthState): string {
@@ -264,7 +270,7 @@ function buildSlotStatusLine(
 /**
  * Render a single slot row.
  *
- * Layout (#653 M2 — subscription tier + 5h/7d/OAuth expiry for EVERY slot):
+ * Layout (subscription tier + 5h/7d/OAuth expiry for EVERY slot):
  *   1. section  — multi-line header: name+kind+tier+ToS-risk on line 1,
  *                  healthy/rate-limited/OAuth-expiry segments on line 2.
  *   2. actions  — per-slot buttons: Activate (if not active & not api_key),
@@ -378,7 +384,7 @@ export function buildSlotRow(
   // the block-budget overflow guard in `buildCctCardBlocks` collapses
   // these first if the card would exceed Slack's 50-block cap.
   if (state?.usage && isCctSlot(slot) && slot.oauthAttachment !== undefined) {
-    const panel = buildUsagePanelBlock(state.usage, nowMs);
+    const panel = buildUsagePanelBlock(state.usage, nowMs, slot.keyId);
     if (panel) blocks.push(panel);
   }
 
@@ -426,18 +432,20 @@ function trimBlocksToSlackCap(blocks: ZBlock[]): ZBlock[] {
   // Phase 1: strip dividers.
   for (let i = blocks.length - 1; i >= 0; i--) {
     if (blocks.length <= SLACK_BLOCK_SOFT_CAP) break;
-    if ((blocks[i] as any).type === 'divider') blocks.splice(i, 1);
+    if ((blocks[i] as { type?: string }).type === 'divider') blocks.splice(i, 1);
   }
   if (blocks.length <= SLACK_BLOCK_SOFT_CAP) return blocks;
-  // Phase 2: strip usage-context blocks. Heuristic — a `context` block
-  // whose mrkdwn element starts with a code fence is the usage panel
-  // emitted by `buildUsagePanelBlock`.
+  // Phase 2: strip usage-context blocks. Matches on the stable
+  // `CCT_CARD_BLOCK_ID_PREFIX.usagePanel` prefix stamped by
+  // `buildUsagePanelBlock` — resilient to future formatting changes in
+  // the panel body (e.g. dropping the code fence).
   for (let i = blocks.length - 1; i >= 0; i--) {
     if (blocks.length <= SLACK_BLOCK_SOFT_CAP) break;
-    const b = blocks[i] as any;
+    const b = blocks[i] as { type?: string; block_id?: string };
     if (b.type !== 'context') continue;
-    const text = b.elements?.[0]?.text as string | undefined;
-    if (typeof text === 'string' && text.startsWith('```')) blocks.splice(i, 1);
+    if (typeof b.block_id === 'string' && b.block_id.startsWith(CCT_CARD_BLOCK_ID_PREFIX.usagePanel)) {
+      blocks.splice(i, 1);
+    }
   }
   return blocks;
 }

--- a/src/slack/cct/builder.ts
+++ b/src/slack/cct/builder.ts
@@ -205,9 +205,84 @@ function authStateBadge(state: AuthState): string {
 }
 
 /**
- * Render a single slot row — one section block plus (when meta is
- * present) a context block with the rate-limit timestamp, usage, and
- * cooldown.
+ * Format an absolute epoch-ms expiry delta as "OAuth refreshes in Xh Ym".
+ * Delegates to `formatUsageResetDelta` for consistent formatting with the
+ * usage-panel "resets in" hint. Negative delta (already expired) returns
+ * the `:warning: expired` sentinel — we don't dress it up because the
+ * operator needs to notice.
+ */
+function formatOAuthExpiryHint(expiresAtMs: number, nowMs: number): string {
+  if (!Number.isFinite(expiresAtMs)) return '';
+  const delta = expiresAtMs - nowMs;
+  if (delta <= 0) return ':warning: OAuth expired';
+  return `OAuth refreshes in ${formatUsageResetDelta(delta)}`;
+}
+
+/**
+ * Build the status/meta line rendered directly under the name. Always
+ * includes the authState badge (defaults to `healthy` when state is
+ * absent). Optionally appends `active`, OAuth expiry hint, rate-limited
+ * timestamp + source, cooldown-until, tombstoned flag, and live lease
+ * count — only when the underlying field is truthy.
+ *
+ * The line is always emitted for every slot (even bare setup-only slots)
+ * so every row carries the `healthy` / `refresh_failed` / `revoked`
+ * badge per #653 M2 — no more active-only gating.
+ */
+function buildSlotStatusLine(
+  slot: AuthKey,
+  state: SlotState | undefined,
+  isActive: boolean,
+  nowMs: number,
+  userTz: string,
+): string {
+  const segments: string[] = [];
+  segments.push(authStateBadge(state?.authState ?? 'healthy'));
+  if (isActive) segments.push('active');
+  // OAuth expiry — only for CCT slots that carry an attachment. `api_key`
+  // and bare setup slots have no OAuth to refresh so they're omitted.
+  if (isCctSlot(slot) && slot.oauthAttachment !== undefined) {
+    const hint = formatOAuthExpiryHint(slot.oauthAttachment.expiresAtMs, nowMs);
+    if (hint) segments.push(hint);
+  }
+  if (state?.rateLimitedAt) {
+    const ts = formatRateLimitedAt(state.rateLimitedAt, userTz, nowMs);
+    const source = state.rateLimitSource ? ` via ${state.rateLimitSource}` : '';
+    segments.push(`rate-limited ${ts}${source}`);
+  }
+  if (state?.cooldownUntil) {
+    const untilMs = new Date(state.cooldownUntil).getTime();
+    if (Number.isFinite(untilMs) && untilMs > nowMs) {
+      segments.push(`cooldown until ${formatRateLimitedAt(state.cooldownUntil, userTz, nowMs).split(' / ')[0]}`);
+    }
+  }
+  if (state?.tombstoned) segments.push(':wastebasket: tombstoned (drain in progress)');
+  if (state && state.activeLeases.length > 0) segments.push(`leases: ${state.activeLeases.length}`);
+  return segments.join(' · ');
+}
+
+/**
+ * Render a single slot row.
+ *
+ * Layout (#653 M2 — subscription tier + 5h/7d/OAuth expiry for EVERY slot):
+ *   1. section  — multi-line header: name+kind+tier+ToS-risk on line 1,
+ *                  healthy/rate-limited/OAuth-expiry segments on line 2.
+ *   2. actions  — per-slot buttons: Activate (if not active & not api_key),
+ *                  Refresh (if attached), Attach|Detach OAuth (setup source),
+ *                  Rename, Remove.
+ *   3. context  — usage panel (5h/7d/7d-sonnet progress bars), only when
+ *                  the slot is attached and has a persisted usage snapshot.
+ *   4. divider  — stripped by `buildCctCardBlocks` when the total block
+ *                  count would exceed Slack's 50-block hard cap.
+ *
+ * Block budget (Slack hard cap: 50 blocks total):
+ *   rich attached slot   = section + actions + usage-context + divider = 4
+ *   bare/api_key slot    = section + actions + divider                 = 3
+ *   card chrome          = header + card-actions + set-active-actions  = 3
+ *   typical fleet (≤11)  = 3 + 11*4 = 47  (under cap)
+ *   worst case (15 rich) = 3 + 15*4 = 63  (`buildCctCardBlocks`
+ *                          strips dividers, then drops usage-context if
+ *                          still over)
  */
 export function buildSlotRow(
   slot: AuthKey,
@@ -217,101 +292,57 @@ export function buildSlotRow(
   userTz: string = 'Asia/Seoul',
 ): ZBlock[] {
   const blocks: ZBlock[] = [];
-  // #641 M1 block-overflow fix: inline-badges (subscription tier + active
-  // marker) are emitted only for the active slot so the "focused" row carries
-  // the full signal while inactive rows stay compact. tosBadge is kept for
-  // every slot because it surfaces a risk label (users need that visible even
-  // when the slot is not active).
-  const headLine = [
-    ':key:',
-    `*${escapeMrkdwn(slot.name)}*`,
-    isActive ? '· active' : '',
-    displayKindTag(slot),
-    isActive ? subscriptionBadge(slot) : '',
-    tosBadge(slot),
-  ]
+  // Line 1: identity (name · kind · tier · ToS-risk). Tier + active marker
+  // are now emitted for EVERY slot — #653 M2 removes the prior isActive
+  // gating so inactive rows carry the full signal (user specifically wants
+  // tier + 5h + 7d always visible, not just on the currently-selected row).
+  const line1 = [':key:', `*${escapeMrkdwn(slot.name)}*`, displayKindTag(slot), subscriptionBadge(slot), tosBadge(slot)]
     .filter(Boolean)
     .join(' ');
-
+  // Line 2: live status (auth state + active flag + OAuth expiry +
+  // rate-limited / cooldown). Always non-empty because `authStateBadge`
+  // returns a badge even for an absent state.
+  const line2 = buildSlotStatusLine(slot, state, isActive, nowMs, userTz);
   blocks.push({
     type: 'section',
-    text: { type: 'mrkdwn', text: headLine },
+    text: { type: 'mrkdwn', text: `${line1}\n${line2}` },
   });
 
-  // Block-budget invariant (Slack's 50-block hard cap):
-  //   active slot   = section + authState-context + usage-context + actions + divider = 5
-  //   inactive slot = section + actions + divider                                     = 3
-  //   card chrome   = header + card-actions + set-active-actions                      = 3
-  //   N=15 worst case: 3 + 5 + 14*3 = 50  (right at the cap)
-  //
-  // Inactive-row one-line usage summary + inline Activate affordance is
-  // M2 scope (issue #653) because adding any per-inactive-slot block
-  // overflows the cap at N≥16.
-  if (isActive) {
-    // Context line — only when we have something meaningful.
-    const segments: string[] = [];
-    if (state) {
-      segments.push(authStateBadge(state.authState));
-      if (state.rateLimitedAt) {
-        const ts = formatRateLimitedAt(state.rateLimitedAt, userTz, nowMs);
-        const source = state.rateLimitSource ? ` via ${state.rateLimitSource}` : '';
-        segments.push(`rate-limited ${ts}${source}`);
-      }
-      if (state.cooldownUntil) {
-        const untilMs = new Date(state.cooldownUntil).getTime();
-        if (Number.isFinite(untilMs) && untilMs > nowMs) {
-          segments.push(`cooldown until ${formatRateLimitedAt(state.cooldownUntil, userTz, nowMs).split(' / ')[0]}`);
-        }
-      }
-      if (state.tombstoned) {
-        segments.push(':wastebasket: tombstoned (drain in progress)');
-      }
-      if (state.activeLeases.length > 0) {
-        segments.push(`leases: ${state.activeLeases.length}`);
-      }
-    } else {
-      segments.push(authStateBadge('healthy'));
-    }
-    if (segments.length > 0) {
-      blocks.push({
-        type: 'context',
-        elements: [{ type: 'mrkdwn', text: segments.join(' · ') }],
-      });
-    }
-
-    // Three-line progress-bar panel rendered after the authState context.
-    if (state?.usage) {
-      const panel = buildUsagePanelBlock(state.usage, nowMs);
-      if (panel) blocks.push(panel);
-    }
+  // Per-slot action row. Ordering by intent:
+  //   1. Activate (primary, first) — only when slot is NOT active and
+  //      NOT an api_key (api_key is store-only in phase 1).
+  //   2. Refresh — only when the slot carries an OAuth attachment (the
+  //      precondition for `/api/oauth/usage` AND the OAuth-token refresh
+  //      endpoint). Force-refreshes BOTH the OAuth access_token AND the
+  //      usage snapshot — the `Refresh` handler orchestrates both calls
+  //      so the card reflects new expiresAtMs + new usage on the same
+  //      click (see actions.ts cct_refresh_usage_slot).
+  //   3. Attach or Detach OAuth — only for setup-source cct slots.
+  //   4. Rename — always.
+  //   5. Remove — always, last (danger).
+  const actionElements: ZBlock[] = [];
+  if (!isActive && slot.kind !== 'api_key') {
+    actionElements.push({
+      type: 'button',
+      action_id: CCT_ACTION_IDS.activate_slot,
+      style: 'primary',
+      text: { type: 'plain_text', text: ':arrow_forward: Activate', emoji: true },
+      value: slot.keyId,
+    });
   }
-
-  // Per-slot action row: Remove / Rename + Z2 Attach-or-Detach for
-  // setup-source cct slots (only that arm of the union can toggle an
-  // oauthAttachment — legacy-attachment slots carry a mandatory one,
-  // api_key has no attachment surface at all). The button `value` carries
-  // the keyId so the open handler routes to the clicked slot.
-  const actionElements: ZBlock[] = [
-    {
+  if (isCctSlot(slot) && slot.oauthAttachment !== undefined) {
+    actionElements.push({
       type: 'button',
-      action_id: CCT_ACTION_IDS.remove,
-      style: 'danger',
-      text: { type: 'plain_text', text: ':wastebasket: Remove', emoji: true },
+      action_id: CCT_ACTION_IDS.refresh_usage_slot,
+      text: { type: 'plain_text', text: ':arrows_counterclockwise: Refresh', emoji: true },
       value: slot.keyId,
-    },
-    {
-      type: 'button',
-      action_id: CCT_ACTION_IDS.rename,
-      text: { type: 'plain_text', text: ':pencil2: Rename', emoji: true },
-      value: slot.keyId,
-    },
-  ];
+    });
+  }
   if (isCctSlot(slot) && slot.source === 'setup') {
     if (slot.oauthAttachment === undefined) {
       actionElements.push({
         type: 'button',
         action_id: CCT_ACTION_IDS.attach,
-        style: 'primary',
         text: { type: 'plain_text', text: ':link: Attach OAuth', emoji: true },
         value: slot.keyId,
       });
@@ -324,22 +355,32 @@ export function buildSlotRow(
       });
     }
   }
-  // M1-S4 — per-slot Refresh. Only emitted for CCT slots that carry an
-  // OAuth attachment (that is the precondition for `/api/oauth/usage`).
-  // api_key slots and bare setup-source slots without an attachment have
-  // no usage endpoint to refresh against.
-  if (isCctSlot(slot) && slot.oauthAttachment !== undefined) {
-    actionElements.push({
-      type: 'button',
-      action_id: CCT_ACTION_IDS.refresh_usage_slot,
-      text: { type: 'plain_text', text: ':arrows_counterclockwise: Refresh', emoji: true },
-      value: slot.keyId,
-    });
-  }
+  actionElements.push({
+    type: 'button',
+    action_id: CCT_ACTION_IDS.rename,
+    text: { type: 'plain_text', text: ':pencil2: Rename', emoji: true },
+    value: slot.keyId,
+  });
+  actionElements.push({
+    type: 'button',
+    action_id: CCT_ACTION_IDS.remove,
+    style: 'danger',
+    text: { type: 'plain_text', text: ':wastebasket: Remove', emoji: true },
+    value: slot.keyId,
+  });
   blocks.push({
     type: 'actions',
     elements: actionElements,
   });
+
+  // Usage panel — only when the slot has a persisted usage snapshot. The
+  // panel is emitted for EVERY attached slot (no longer isActive-gated);
+  // the block-budget overflow guard in `buildCctCardBlocks` collapses
+  // these first if the card would exceed Slack's 50-block cap.
+  if (state?.usage && isCctSlot(slot) && slot.oauthAttachment !== undefined) {
+    const panel = buildUsagePanelBlock(state.usage, nowMs);
+    if (panel) blocks.push(panel);
+  }
 
   return blocks;
 }
@@ -360,6 +401,45 @@ export function appendStoreReadFailureBanner(blocks: ZBlock[]): void {
       },
     ],
   });
+}
+
+/**
+ * Safety margin under Slack's 50-block hard cap per message / ephemeral.
+ * Stops the card assembly well short of the cap so adjacent banners
+ * (store-read failure, api_key hidden context) still fit.
+ */
+const SLACK_BLOCK_SOFT_CAP = 48;
+
+/**
+ * Post-assembly overflow guard. Invoked only when the rich layout
+ * (section + actions + usage-context + divider per slot) would push the
+ * card over Slack's 50-block hard cap.
+ *
+ * Collapse order (least-to-most information-loss):
+ *   1. strip all dividers  — visual-only, no signal lost
+ *   2. drop usage-context  — usage panel still reachable via /cct usage
+ *
+ * Walks `blocks` in-place and returns the mutated reference for clarity.
+ */
+function trimBlocksToSlackCap(blocks: ZBlock[]): ZBlock[] {
+  if (blocks.length <= SLACK_BLOCK_SOFT_CAP) return blocks;
+  // Phase 1: strip dividers.
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    if (blocks.length <= SLACK_BLOCK_SOFT_CAP) break;
+    if ((blocks[i] as any).type === 'divider') blocks.splice(i, 1);
+  }
+  if (blocks.length <= SLACK_BLOCK_SOFT_CAP) return blocks;
+  // Phase 2: strip usage-context blocks. Heuristic — a `context` block
+  // whose mrkdwn element starts with a code fence is the usage panel
+  // emitted by `buildUsagePanelBlock`.
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    if (blocks.length <= SLACK_BLOCK_SOFT_CAP) break;
+    const b = blocks[i] as any;
+    if (b.type !== 'context') continue;
+    const text = b.elements?.[0]?.text as string | undefined;
+    if (typeof text === 'string' && text.startsWith('```')) blocks.splice(i, 1);
+  }
+  return blocks;
 }
 
 /**
@@ -391,11 +471,12 @@ export function buildCctCardBlocks(input: CctCardInput): ZBlock[] {
     }
   }
 
-  // Card-level action row: Next / Add / Refresh-all. Per-slot
-  // Remove/Rename buttons live on each slot row (emitted by
-  // `buildSlotRow`) so they carry the correct slotId via the button's
-  // `value`. M1-S4 appends the Refresh-all button last so the existing
-  // action positions stay stable for muscle-memory.
+  // Card-level action row: Next rotate / Add / Refresh all. Per-slot
+  // [Activate] / [Refresh] / [Rename] / [Remove] / [Attach|Detach] live on
+  // each slot row (see `buildSlotRow`). `set_active` is retained as a
+  // fallback dropdown only when there are >1 slots, for screen-reader
+  // accessibility and bulk-navigation (#653 M2: inline [Activate] button
+  // is the primary affordance; dropdown is backup).
   const actionElements: ZBlock[] = [
     {
       type: 'button',
@@ -419,7 +500,10 @@ export function buildCctCardBlocks(input: CctCardInput): ZBlock[] {
   ];
   blocks.push({ type: 'actions', elements: actionElements });
 
-  // Set-active selector (only when >1 slot).
+  // Set-active selector (only when >1 slot). Kept as a fallback for large
+  // fleets where the overflow guard may have dropped inline [Activate]
+  // affordances along with their actions rows (defensive — today the
+  // guard only strips dividers and usage-context blocks).
   if (input.slots.length > 1) {
     const options = input.slots.map((s) => ({
       text: { type: 'plain_text', text: s.name, emoji: false },
@@ -437,7 +521,10 @@ export function buildCctCardBlocks(input: CctCardInput): ZBlock[] {
       ],
     });
   }
-  return blocks;
+
+  // Apply the overflow guard AFTER chrome is added so dividers inside
+  // slot rows (not chrome) are the first casualty.
+  return trimBlocksToSlackCap(blocks);
 }
 
 /* ------------------------------------------------------------------ *

--- a/src/slack/cct/views.ts
+++ b/src/slack/cct/views.ts
@@ -69,6 +69,10 @@ export const CCT_ACTION_IDS = {
   // existing IDs above are unchanged.
   refresh_usage_all: 'cct_refresh_usage_all',
   refresh_usage_slot: 'cct_refresh_usage_slot',
+  // #653 M2 — per-slot Activate button. Replaces the card-level
+  // `set_active` dropdown for direct single-click activation. Non-
+  // active rows emit this button; the active row omits it.
+  activate_slot: 'cct_activate_slot',
 } as const;
 
 export type CctViewId = (typeof CCT_VIEW_IDS)[keyof typeof CCT_VIEW_IDS];

--- a/src/slack/cct/views.ts
+++ b/src/slack/cct/views.ts
@@ -43,6 +43,16 @@ export const CCT_BLOCK_IDS = {
   attach_tos_ack: 'cct_attach_tos_ack',
 } as const;
 
+/**
+ * Stable block_id prefix for per-slot card blocks emitted by
+ * `buildSlotRow`. The overflow guard (`trimBlocksToSlackCap`) matches
+ * these by prefix so fragile text-content heuristics are avoided.
+ */
+export const CCT_CARD_BLOCK_ID_PREFIX = {
+  /** Per-slot usage-context block (stripped first under overflow). */
+  usagePanel: 'cct_usage_panel:',
+} as const;
+
 /** Action_ids stable across `views.update`. Preserves typed values. */
 export const CCT_ACTION_IDS = {
   next: 'cct_next',
@@ -69,7 +79,7 @@ export const CCT_ACTION_IDS = {
   // existing IDs above are unchanged.
   refresh_usage_all: 'cct_refresh_usage_all',
   refresh_usage_slot: 'cct_refresh_usage_slot',
-  // #653 M2 — per-slot Activate button. Replaces the card-level
+  // per-slot Activate button. Replaces the card-level
   // `set_active` dropdown for direct single-click activation. Non-
   // active rows emit this button; the active row omits it.
   activate_slot: 'cct_activate_slot',

--- a/src/token-manager.test.ts
+++ b/src/token-manager.test.ts
@@ -1839,6 +1839,177 @@ describe('TokenManager (AuthKey v2, keyId-keyed)', () => {
     });
   });
 
+  // ── #653 M2 — forceRefreshOAuth + refreshAllAttachedOAuthTokens ──
+
+  describe('forceRefreshOAuth (#653 M2)', () => {
+    it('force-refreshes a single attached slot regardless of TTL (no 7h-buffer short-circuit)', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const slot = await tm.addSlot({
+        name: 'o',
+        kind: 'oauth_credentials',
+        // fresh token, expires 10h out — well outside the 7h refresh buffer
+        credentials: makeOAuthCreds({
+          accessToken: 'old-access',
+          refreshToken: 'ref-1',
+          expiresAtMs: Date.now() + 10 * 60 * 60 * 1000,
+        }),
+        acknowledgedConsumerTosRisk: true,
+      });
+      refreshClaudeCredentialsMock.mockReset();
+      refreshClaudeCredentialsMock.mockResolvedValue({
+        accessToken: 'new-access',
+        refreshToken: 'ref-2',
+        expiresAtMs: Date.now() + 8 * 60 * 60 * 1000,
+        scopes: [...VALID_OAUTH_SCOPES],
+      });
+      // The legacy `refreshCredentialsIfNeeded` would SKIP this call because
+      // expiresAtMs is 10h out (> 7h REFRESH_BUFFER_MS). The new public
+      // method must bypass that short-circuit.
+      await tm.refreshCredentialsIfNeeded(slot.keyId);
+      expect(refreshClaudeCredentialsMock).not.toHaveBeenCalled();
+      // forceRefreshOAuth fires the HTTP call.
+      await tm.forceRefreshOAuth(slot.keyId);
+      expect(refreshClaudeCredentialsMock).toHaveBeenCalledTimes(1);
+      // Persisted — the active access token is the new one.
+      const accessToken = await activeAccessToken(tm);
+      expect(accessToken).toBe('new-access');
+    });
+
+    it('no-op when slot has no oauthAttachment (bare setup-token / api_key / unknown keyId)', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const api = await tm.addSlot({ name: 'a', kind: 'api_key', value: 'sk-ant-api03-abcdefgh' });
+      const bare = await tm.addSlot({ name: 'b', kind: 'setup_token', value: 'sk-ant-oat01-xyz' });
+      refreshClaudeCredentialsMock.mockReset();
+      await tm.forceRefreshOAuth(api.keyId);
+      await tm.forceRefreshOAuth(bare.keyId);
+      await tm.forceRefreshOAuth('unknown-keyid');
+      expect(refreshClaudeCredentialsMock).not.toHaveBeenCalled();
+    });
+
+    it('propagates OAuthRefreshError (401→refresh_failed / 403→revoked) for caller awareness', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const slot = await tm.addSlot({
+        name: 'o',
+        kind: 'oauth_credentials',
+        credentials: makeOAuthCreds(),
+        acknowledgedConsumerTosRisk: true,
+      });
+      const { OAuthRefreshError } = await import('./oauth/refresher');
+      refreshClaudeCredentialsMock.mockReset();
+      refreshClaudeCredentialsMock.mockRejectedValue(
+        new OAuthRefreshError(401, '{"error":"invalid_grant"}', 'invalid_grant'),
+      );
+      await expect(tm.forceRefreshOAuth(slot.keyId)).rejects.toThrow(/invalid_grant/);
+      // Side-effect — authState transitions to refresh_failed on 401.
+      const snap = await tm.getSnapshot();
+      expect(snap.state[slot.keyId]?.authState).toBe('refresh_failed');
+    });
+  });
+
+  describe('refreshAllAttachedOAuthTokens (#653 M2)', () => {
+    it('fans out force-refresh to every attached slot, skipping api_key + bare setup', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      await tm.addSlot({ name: 'api', kind: 'api_key', value: 'sk-ant-api03-abcdefgh' });
+      await tm.addSlot({ name: 'bare', kind: 'setup_token', value: 'sk-ant-oat01-bare' });
+      const a = await tm.addSlot({
+        name: 'oa',
+        kind: 'oauth_credentials',
+        credentials: makeOAuthCreds({ accessToken: 'a1', refreshToken: 'r1' }),
+        acknowledgedConsumerTosRisk: true,
+      });
+      const b = await tm.addSlot({
+        name: 'ob',
+        kind: 'oauth_credentials',
+        credentials: makeOAuthCreds({ accessToken: 'a2', refreshToken: 'r2' }),
+        acknowledgedConsumerTosRisk: true,
+      });
+      refreshClaudeCredentialsMock.mockReset();
+      refreshClaudeCredentialsMock.mockImplementation(async (current: any) => ({
+        accessToken: current.accessToken + '-refreshed',
+        refreshToken: current.refreshToken,
+        expiresAtMs: Date.now() + 8 * 60 * 60 * 1000,
+        scopes: [...VALID_OAUTH_SCOPES],
+      }));
+      const results = await tm.refreshAllAttachedOAuthTokens({ timeoutMs: 5_000 });
+      expect(Object.keys(results).sort()).toEqual([a.keyId, b.keyId].sort());
+      expect(results[a.keyId]).toBe('ok');
+      expect(results[b.keyId]).toBe('ok');
+      expect(refreshClaudeCredentialsMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('per-slot error surfaces as "error" in the result map without poisoning the tick', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const ok = await tm.addSlot({
+        name: 'ok',
+        kind: 'oauth_credentials',
+        credentials: makeOAuthCreds({ refreshToken: 'good' }),
+        acknowledgedConsumerTosRisk: true,
+      });
+      const bad = await tm.addSlot({
+        name: 'bad',
+        kind: 'oauth_credentials',
+        credentials: makeOAuthCreds({ refreshToken: 'stale' }),
+        acknowledgedConsumerTosRisk: true,
+      });
+      const { OAuthRefreshError } = await import('./oauth/refresher');
+      refreshClaudeCredentialsMock.mockReset();
+      refreshClaudeCredentialsMock.mockImplementation(async (current: any) => {
+        if (current.refreshToken === 'stale')
+          throw new OAuthRefreshError(401, '{"error":"invalid_grant"}', 'invalid_grant');
+        return {
+          accessToken: 'new-good',
+          refreshToken: 'good',
+          expiresAtMs: Date.now() + 8 * 60 * 60 * 1000,
+          scopes: [...VALID_OAUTH_SCOPES],
+        };
+      });
+      const results = await tm.refreshAllAttachedOAuthTokens({ timeoutMs: 5_000 });
+      expect(results[ok.keyId]).toBe('ok');
+      expect(results[bad.keyId]).toBe('error');
+      // The healthy slot completed despite the bad one throwing.
+      expect(refreshClaudeCredentialsMock).toHaveBeenCalledTimes(2);
+      // Bad slot's authState transitioned to refresh_failed.
+      const snap = await tm.getSnapshot();
+      expect(snap.state[bad.keyId]?.authState).toBe('refresh_failed');
+    });
+
+    it('returns partial results within timeoutMs when upstream hangs', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      await tm.addSlot({
+        name: 'hang',
+        kind: 'oauth_credentials',
+        credentials: makeOAuthCreds(),
+        acknowledgedConsumerTosRisk: true,
+      });
+      refreshClaudeCredentialsMock.mockReset();
+      refreshClaudeCredentialsMock.mockImplementation(async () => new Promise(() => {}));
+      const t0 = Date.now();
+      const results = await tm.refreshAllAttachedOAuthTokens({ timeoutMs: 60 });
+      const elapsed = Date.now() - t0;
+      expect(elapsed).toBeLessThan(500);
+      // No keys land because the deadline fires first.
+      expect(Object.keys(results).length).toBe(0);
+    });
+  });
+
   // ── Reaper timer ──────────────────────────────────────────
 
   describe('reaper timer', () => {

--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -1103,6 +1103,73 @@ export class TokenManager {
   }
 
   /**
+   * #653 M2 — Force-refresh the OAuth access_token for a single slot
+   * regardless of its current TTL. Used by the per-slot Refresh button
+   * (so the "OAuth refreshes in X" hint resets immediately on click)
+   * and by the hourly `OAuthRefreshScheduler`.
+   *
+   * No-op for slots without an OAuth attachment (api_key or bare setup
+   * tokens). Reuses `refreshAccessToken`'s in-process dedupe + attachment-
+   * generation fingerprint guard, so concurrent force-refreshes for the
+   * same slot share a single HTTP round-trip and a detach/re-attach race
+   * can't resurrect stale credentials.
+   *
+   * Throws `OAuthRefreshError` on 401/403. The authState has already
+   * been marked `refresh_failed` / `revoked` before the throw, so callers
+   * can surface the error (or swallow it if the cached authState alone
+   * is enough signal).
+   */
+  async forceRefreshOAuth(keyId: string): Promise<void> {
+    const snap = await this.store.load();
+    const slot = snap.registry.slots.find((s) => s.keyId === keyId);
+    if (!slot || !hasOAuthAttachment(slot)) return;
+    await this.refreshAccessToken(slot);
+  }
+
+  /**
+   * #653 M2 — Fan-out force-refresh of every OAuth-attached CCT slot.
+   * Returns a `Record<keyId, 'ok' | 'error'>` so the scheduler (and
+   * future card-level "Refresh OAuth all" button) can report per-slot
+   * outcomes.
+   *
+   * Parallel execution under a single deadline (default 10s — the
+   * `refreshClaudeCredentials` HTTP call has its own 10s timeout, so 10s
+   * overall is tight but realistic for a 1-2 slot fleet. Scheduler wires
+   * a longer deadline for larger fleets).
+   *
+   * Contract mirrors `fetchUsageForAllAttached`: timeouts return whatever
+   * has landed so far; per-slot errors are caught and surfaced in the
+   * returned map (not thrown) so a single bad slot doesn't poison the
+   * whole tick.
+   */
+  async refreshAllAttachedOAuthTokens(opts?: { timeoutMs?: number }): Promise<Record<string, 'ok' | 'error'>> {
+    const snap = await this.store.load();
+    const keyIds = snap.registry.slots
+      .filter((s) => s.kind === 'cct' && s.oauthAttachment !== undefined)
+      .map((s) => s.keyId);
+    const results: Record<string, 'ok' | 'error'> = {};
+    const promises = keyIds.map(async (keyId) => {
+      try {
+        await this.forceRefreshOAuth(keyId);
+        results[keyId] = 'ok';
+      } catch (err) {
+        results[keyId] = 'error';
+        logger.warn('refreshAllAttachedOAuthTokens: per-slot refresh failed', {
+          keyId,
+          err,
+        });
+      }
+    });
+    const timeoutMs = opts?.timeoutMs ?? 30_000;
+    const timeout = new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, timeoutMs);
+      if (typeof t.unref === 'function') t.unref();
+    });
+    await Promise.race([Promise.allSettled(promises), timeout]);
+    return results;
+  }
+
+  /**
    * In-process dedupe: callers racing to refresh the same slot share a
    * single Promise. The actual HTTP call happens OUTSIDE any cct-store
    * lock; we acquire the lock only to persist the result.


### PR DESCRIPTION
## Summary

Addresses three pain points flagged on the `/cct` dashboard:

1. **구독 티어 / 5h / 7d always visible** — every slot row renders subscription tier, 5h / 7d / 7d-sonnet usage bars, authState, rate-limited timestamp, cooldown, and OAuth expiry. Previously these were gated on `isActive`, so inactive rows looked empty.
2. **OAuth 남은 시간 표시 + Refresh 시 실제 리프레시** — the card now shows `OAuth refreshes in Xh Ym` per attached slot. The per-slot `Refresh` button now force-refreshes the OAuth access_token AND fetches usage, so the hint resets on click (was only usage-refresh — token rotation only happened inside the 7h REFRESH_BUFFER_MS window).
3. **1시간 주기 OAuth 리프레시 워커** — new `OAuthRefreshScheduler` pumps `TokenManager.refreshAllAttachedOAuthTokens` every 1 hour. Stale refresh tokens surface as `refresh_failed` within 1h rather than waiting for dispatch. `OAUTH_REFRESH_ENABLED=0` opt-out; interval + timeout tunable.

Plus: inline `[Activate]` button per row (action_id `cct_activate_slot`), replacing the hidden bottom-dropdown as the primary activate affordance. Dropdown kept as accessibility fallback for wide fleets.

## Layout (TO-BE)

Per slot, 4 blocks in the rich case:
- `section` (multi-line): `:key: *name* · cct/setup · Max 20x :warning: ToS-risk` / `:large_green_circle: healthy · active · OAuth refreshes in 7h 23m · rate-limited ...`
- `actions`: `[Activate] [Refresh] [Attach|Detach OAuth] [Rename] [Remove]`
- `context` (usage panel 5h / 7d / 7d-sonnet, if attached with usage data)
- `divider`

Block-budget overflow guard (`trimBlocksToSlackCap`) strips dividers, then usage-context blocks, if the card would exceed Slack's 50-block hard cap. N=15-slot card stays ≤50 blocks (regression-tested).

## Contract locks

- `DEFAULT_OAUTH_REFRESH_INTERVAL_MS === 60m` (user spec)
- shutdown order: OAuth scheduler stops **before** tokenManager
- bootstrap order: OAuth scheduler starts **after** usage scheduler
- `CCT_ACTION_IDS` literal-string lock picks up `cct_activate_slot`
- Generation-fingerprint guard on `refreshAccessToken` path inherited (detach+reattach race-safe)

## Test plan

- [x] `src/slack/cct/builder.test.ts` — 49 tests (added: OAuth expiry hint, expired sentinel, inactive-row-status-visible, Activate button, N=15 ≤50 cap)
- [x] `src/slack/cct/actions.test.ts` — 39 tests (existing + Refresh path tolerates OAuth force-refresh failure)
- [x] `src/token-manager.test.ts` — 81 tests (added: forceRefreshOAuth single-slot + no-op + error-propagation; refreshAllAttachedOAuthTokens fan-out + per-slot error isolation + timeout)
- [x] `src/oauth/oauth-refresh-scheduler.test.ts` — 10 tests (fake-clock pattern; shutdown + bootstrap ordering invariants)
- [x] 260 scoped tests passing; `biome check` 0 errors; `tsc --noEmit` 0 errors
- [ ] Manual: open `/cct`, verify every row shows tier + usage + OAuth expiry
- [ ] Manual: click `[Refresh]` on a slot — expiry hint should jump to ~8h
- [ ] Manual: wait ~1h idle, verify log line `OAuth refresh tick complete {total,ok,errors}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <z@2lab.ai>
