### PR TITLE
feat(slack): P3 B3 choice block single-writer (#665)

### DIFF
--- a/docs/slack-ui-phase3.md
+++ b/docs/slack-ui-phase3.md
@@ -290,12 +290,24 @@ the P3 classifier and resolves normally.
 ```
 posted (askUser/askUserForm)
   → pendingChoice set + persistAndBroadcast
-    → (user clicks matching) p3 resolve → pendingChoice cleared + persistAndBroadcast
+    → (user clicks matching single) p3 resolve → pendingChoice cleared + persistAndBroadcast
+    → (user submits one chunk of N) per-chunk resolve → shrink formIds, keep pendingChoice live
+      → (last chunk submitted) formIds empty → clear pendingChoice
     → (user clicks stale) stale marker, no state change
     → (new question supersedes) defensive prelude → pendingChoice cleared + persistAndBroadcast
     → (post-failure partial rollback) defensive clear → persistAndBroadcast
     → (24h TTL via session-registry GC) silently expires
 ```
+
+**Per-chunk multi-choice submit (important):** When a multi-choice question
+chunks into N forms (>6 sub-questions), each form has its own Submit button.
+Submitting one chunk resolves ONLY that chunk's Slack message in place and
+removes the chunk's `formId` from `pendingChoice.formIds`. Remaining chunks
+stay live — the user answers them independently. This matches legacy
+per-chunk semantics (each chunk fires its own `messageHandler` dispatch) and
+prevents the bug where submitting chunk 1 would prematurely mark chunks
+2..N as "completed" while they still had unanswered questions. Only when
+`formIds` empties does the entire `pendingChoice` record clear.
 
 Turn `end()` / `fail()` do **NOT** touch `pendingChoice`. The question may
 legitimately outlive the turn that posted it (e.g. a user who steps away

--- a/docs/slack-ui-phase3.md
+++ b/docs/slack-ui-phase3.md
@@ -1,0 +1,336 @@
+# Slack UI Phase 3 — B3 choice block single-writer
+
+Scope: issue [#665](https://github.com/2lab-ai/soma-work/issues/665),
+umbrella [#669](https://github.com/2lab-ai/soma-work/issues/669) (successor
+of [#525](https://github.com/2lab-ai/soma-work/issues/525) plan v2). Phase 2
+(PR #664) consolidated the **B2 plan block** into `TurnSurface.renderTasks`.
+Phase 3 collapses the **B3 question/choice block** from a two-path write
+(inline choice message + header embed state) into a single-writer Slack
+message owned by `TurnSurface`, gated on `SOMA_UI_5BLOCK_PHASE>=3`.
+
+## What Phase 3 changes
+
+The 5-block per-turn UI:
+
+| Block | Owner after P3 | Status in this PR |
+|---|---|---|
+| **B1** stream | `TurnSurface` (P1+P2) | unchanged |
+| **B2** plan | `TurnSurface.renderTasks` (P2) | unchanged |
+| **B3** choice / question | `TurnSurface.askUser` / `askUserForm` / `resolveChoice` / `resolveMultiChoice` | **migrated** |
+| **B4** AI working indicator | `AssistantStatusManager` (legacy) | unchanged — P4 |
+| **B5** `<작업 완료>` marker | `TurnNotifier` + `CompletionMessageTracker` (legacy) | unchanged — P5 |
+
+Under PHASE>=3, B3 acquires:
+
+- **one writer** (`TurnSurface`) per posted choice/form message
+- **payload identity** (`turnId` embedded in Slack button `value` JSON + modal
+  `private_metadata`), so click handlers can unambiguously route a click to
+  the turn that originated it
+- **session state** (`session.actionPanel.pendingChoice`) as the authoritative
+  lifecycle record, persisted via `session-registry` and broadcast to the
+  dashboard websocket on every transition
+
+Message-ownership table (PHASE>=3):
+
+| Slack message ts | Owner | Written by |
+|---|---|---|
+| `streamTs` (B1) | `TurnSurface` | `begin` / `appendText` / `end` / `fail` |
+| `planTs` (B2) | `TurnSurface` | `renderTasks` |
+| **`choiceTs` (B3 single)** | **`TurnSurface`** | **`askUser` / `resolveChoice`** |
+| **`formIds[].messageTs` (B3 multi)** | **`TurnSurface`** | **`askUserForm` / `resolveMultiChoice`** |
+| `headerTs` (combined header + panel) | `ThreadSurface` | `updatePanel` / `refreshAndRender` |
+
+The header continues to render a **link section** pointing at the choice
+message (`ActionPanelBuilder.buildChoiceLinkSection` via
+`session.actionPanel.choiceMessageLink`). This is **not** the legacy "embed
+the buttons into the header" path — that rendering never happened in the
+current codebase — so no header-side change is needed.
+
+The old `resolveChoiceSyncMessageTs(sessionKey, messageTs, completionTs)`
+helper continues to exist for PHASE<3 callers. Under PHASE>=3 it is
+effectively singleton (the three possible ts values collapse to one) and
+is **not on the P3 code path** — the P3 resolve uses
+`TurnSurface.resolveChoice` / `resolveMultiChoice` directly.
+
+## Scope summary
+
+In scope for P3:
+
+- `ThreadPanel.askUser` / `askUserForm` — post question + write session state
+  synchronously + trigger permalink warm (fire-and-forget)
+- `ThreadPanel.resolveChoice` / `resolveMultiChoice` — in-place update posted
+  message + clear pending record
+- `TurnSurface.askUser` / `askUserForm` / `resolveChoice` / `resolveMultiChoice`
+  — raw Slack writer methods; no state mutation
+- `ThreadSurface.setChoiceMeta` — lightweight permalink/header sync (no
+  `choiceBlocks` write)
+- Click handlers (`choice-action-handler.ts`, `form-action-handler.ts`) —
+  unified 3-way classifier (legacy / p3 / stale)
+- Stream-executor — defensive prelude that supersedes any prior
+  `pendingChoice` before a new ask; threads `turnId` into the render chain;
+  pre-allocates formIds + registers in `PendingFormStore` with turnId
+- `PendingFormStore` — new optional `turnId` field on `PendingChoiceFormData`
+
+Out of scope for P3:
+
+- Legacy 2-path removal (`attachChoice` / `clearChoice` / header link section
+  all still exist for PHASE<3 and share the permalink/choiceMessageLink
+  contract with P3)
+- B2 / B4 / B5 changes
+- Dashboard web-UI choice rendering internals (only the pending-question
+  write contract is touched — dashboard consumes `pendingQuestion` as before)
+
+## Rollout flag
+
+```bash
+# cumulative prefix: N enables P1..PN, everything > N stays legacy
+# valid values: 0 (default) | 1 | 2 | 3 | 4 | 5
+# any value outside [0..5] → warn + fallback to 0 (fail closed)
+SOMA_UI_5BLOCK_PHASE=0
+```
+
+Parsed in `src/config.ts` as `config.ui.fiveBlockPhase`. Every new code path
+reads this value **per call** (not cached), so a restart with a new value
+takes effect immediately on the next turn.
+
+### Rollout sequence
+
+1. Merge this PR with `SOMA_UI_5BLOCK_PHASE=2` in dev (already set from P2).
+   Prod stays PHASE<=2 → zero B3 behavior change.
+2. **PHASE flip gate** — before flipping dev to `SOMA_UI_5BLOCK_PHASE=3`,
+   run the `ui-test choice` + `ui-test choice multi` smoke on **iOS**,
+   **Android**, and **desktop web**. Both the single-choice "1️⃣..4️⃣"
+   button row and the multi-choice 6-questions-per-form chunking must
+   render correctly AND click-resolve to "✅ 선택: …". If any client fails,
+   **hold the flip**. Deploy gate, not merge gate.
+3. Flip dev to `SOMA_UI_5BLOCK_PHASE=3`. Smoke matrix:
+   - single choice → click → in-place update
+   - multi choice, 6Q chunk×2 → partial answers → submit → all chunks
+     update
+   - stale click (fire a question, supersede with a new one, click the old
+     → must show "⏱️ _이 질문은 더 이상 유효하지 않습니다._" and NOT dispatch)
+   - restart with a live pending question → reload session → click still
+     resolves (see §Restart semantics)
+   - dashboard hero "일괄 추천 제출" still dispatches correctly
+4. 1-week soak on dev → flip prod to `SOMA_UI_5BLOCK_PHASE=3`. Monitor:
+   - ghost-click dispatches (expected: 0)
+   - stranded `pendingChoice` on disk after resolve (expected: 0; resolve
+     calls `persistAndBroadcast` after clear)
+   - duplicate choice messages per turn (expected: 0 — single-writer)
+5. If any red flag, flip back to `2`. See §Rollback caveat.
+
+### Rollback caveat
+
+Downgrading PHASE=3 → PHASE=2 while a P3-era choice message is still
+open in Slack is **deterministic**:
+
+- The button's `value` JSON carries `turnId`. Under PHASE<3 the click
+  handler IGNORES that extra key and runs the legacy resolver path. No
+  ghost-dispatch, no error.
+- The hero multi-choice button's `value` shape is **unchanged** (`{formId,
+  sessionKey, n, m}`), so the downgrade path also works for multi-choice.
+
+Upgrading PHASE=2 → PHASE=3 with a pre-flip choice message still open:
+
+- The button value has no `turnId`, and no `session.actionPanel.pendingChoice`
+  was ever written for that message. The click handler's classifier returns
+  `'legacy'` (truly pre-flip) and runs the legacy resolver path — which
+  still works because `choiceMessageTs` / `choiceMessageLink` were written
+  during the PHASE=2 post.
+
+Both rollback directions are **covered by tests**. See
+`choice-action-handler.test.ts` P3 classifier tests.
+
+## Architecture
+
+### Session state (authoritative)
+
+A new optional field on `ActionPanelState` (`src/types.ts`):
+
+```ts
+pendingChoice?: {
+  turnId: string;
+  kind: 'single' | 'multi';
+  choiceTs?: string;        // single: message ts; multi: primary (first form) ts
+  formIds: string[];        // multi only; empty for single
+  question: UserChoice | UserChoices;
+  createdAt: number;
+};
+```
+
+- **Written synchronously** after a successful Slack post, BEFORE any
+  `await` for permalink resolution, so a live button click during the
+  permalink warm-up still finds a matching pendingChoice (closes v6 P1
+  race from codex review).
+- **Cleared synchronously** on resolve (by `ThreadPanel.resolveChoice` /
+  `resolveMultiChoice`) and on defensive prelude supersession.
+- Co-mutated with `choiceMessageTs`, `choiceMessageLink`,
+  `waitingForChoice`, and (existing) `pendingQuestion`. Every mutation is
+  followed by `sessionRegistry.persistAndBroadcast(sessionKey)` so disk
+  + dashboard websocket stay in sync.
+
+`PendingFormStore` (`src/slack/actions/pending-form-store.ts`) gains a new
+optional `turnId?: string` on `PendingChoiceFormData`. Populated at form
+registration under PHASE>=3. Read by click handlers to classify
+multi-choice clicks (the hero button value `{formId, sessionKey, n, m}`
+has no turnId, so the only reliable turnId source for multi is the
+formStore).
+
+### Payload identity
+
+Embedded in Slack button `value` JSON (additive trailing key):
+
+| Surface | Shape | turnId location |
+|---|---|---|
+| single-choice button | `{sessionKey, choiceId, label, question, turnId?}` | in `value` |
+| custom-input single button | `{sessionKey, question, type, turnId?}` | in `value` |
+| custom-input modal | — | in `private_metadata` |
+| multi-choice select option | per-option JSON | **not added** — lookup via `formId` → `pendingForm.turnId` |
+| hero "일괄 추천 제출" button | `{formId, sessionKey, n, m}` **exact shape** | **not added** — lookup via `formId` → `pendingForm.turnId` |
+
+The hero button shape is asserted byte-exact by
+`choice-message-builder.test.ts:517-532` — adding `turnId` there would
+break those tests and the downstream parser. Multi-choice identity lives
+in the formStore instead.
+
+`turnId` is **omitted** from the value JSON entirely (not `"turnId":null`)
+when the builder is called without it. PHASE<2 payloads are byte-identical
+to pre-P3 output.
+
+### Click classifier (3-way)
+
+Every click handler runs this gate before any state mutation:
+
+```ts
+classifyClick({ sessionKey, payloadTurnId?, messageTs?, formId? })
+  -> 'legacy' | 'p3' | 'stale'
+```
+
+Matrix:
+
+| PHASE | `payloadTurnId` | `pendingChoice` | Match | Branch |
+|-------|-----------------|-----------------|-------|--------|
+| <3    | any             | any             | —     | **legacy** |
+| >=3   | absent          | absent          | —     | **legacy** (truly pre-flip) |
+| >=3   | present         | absent          | —     | **stale** |
+| >=3   | present         | present         | matches (turnId + ts/formId) | **p3** |
+| >=3   | present         | present         | mismatches      | **stale** |
+| >=3   | absent          | present         | —     | **stale** (defensive) |
+
+- `'legacy'` — existing `resolveChoiceSyncMessageTs` + `Promise.all(updateMessage)`
+  + `clearChoice` + `messageHandler` dispatch. Body unchanged from PHASE<3.
+- `'p3'` — `ThreadPanel.resolveChoice` / `resolveMultiChoice` + common
+  terminus (clear `pendingQuestion`, transition activityState, dispatch,
+  `persistAndBroadcast`).
+- `'stale'` — `slackApi.updateMessage(channel, ts, '⏱️ _이 질문은 더 이상
+  유효하지 않습니다._', staleBlocks, [])`; **no dispatch**.
+
+The legacy branch under PHASE<3 is **strictly the old code**. New keys in
+the payload (`turnId`) are tolerated but ignored.
+
+The stale branch is reached only under PHASE>=3. It never falls through to
+legacy, because the legacy resolver unions the clicked ts with the current
+`session.actionPanel.choiceMessageTs` — under P3 that could mean updating
+the **live** pendingChoice message with a stale click's answer. Dedicated
+stale handling keeps ghost/stale clicks from resurrecting through the
+legacy sync path.
+
+### Defensive supersede prelude
+
+Before a new P3 ask, `stream-executor.supersedePriorPendingChoice` clears
+any prior `pendingChoice` record:
+
+- for `'multi'` kind: best-effort updates each prior chunk message to
+  "⏱️ _새 질문으로 대체되었습니다._" AND removes the formStore entries
+- clears `pendingChoice` / `choiceMessageTs` / `choiceMessageLink` /
+  `waitingForChoice` on session.actionPanel
+- `persistAndBroadcast(sessionKey)`
+
+This protects against split-brain if a prior post succeeded but resolve
+never fired (e.g. dashboard/dm ambiguity, lost websocket, restart gap).
+
+### Partial-failure rollback
+
+`ThreadPanel.askUserForm` posts chunks in a loop. If chunk `i` throws
+after chunks `0..i-1` posted:
+
+1. Every posted chunk gets a best-effort Slack-side rewrite to
+   "⏱️ _폼 생성에 실패했습니다._".
+2. If `pendingChoice` was written (after chunk 0 posted), it's **defensively
+   cleared**.
+3. `persistAndBroadcast` fires for the cleared state.
+4. Stream-executor sees `{ok: false, reason: 'post-failed'}`, deletes every
+   pre-allocated formId from `PendingFormStore`, and falls back to the
+   legacy `sendCommandChoiceFallback` text rendering.
+
+### Restart semantics
+
+Both sides of the P3 state are persisted:
+
+| State | Store | Persistence trigger |
+|-------|-------|---------------------|
+| `session.actionPanel.pendingChoice` | session-registry (`sessions.json`) | explicit `persistAndBroadcast` on every mutation |
+| `session.actionPanel.pendingQuestion` | session-registry | same |
+| `pendingForm.turnId` | `PendingFormStore` (`pending-forms.json`) | `setPendingForm` → `formStore.set()` → `saveForms()` |
+| `pendingForm.messageTs` | `PendingFormStore` | same (fixed in this PR — was in-place mutation) |
+
+`setActivityState('waiting')` by itself does **not** persist (it only
+persists on transition to `'idle'`). The explicit `persistAndBroadcast`
+calls in the P3 path close that gap for the pendingChoice / pendingQuestion
+co-fields. The old PHASE<3 path had the same gap for `pendingQuestion`
+alone; it's closed by this PR too (now `pendingQuestion` persists on every
+write regardless of PHASE).
+
+After a restart within the session TTL (24h), `pendingChoice` + the
+matching `pendingForm` records are restored. The next click routes through
+the P3 classifier and resolves normally.
+
+## `pendingChoice` lifecycle
+
+```
+posted (askUser/askUserForm)
+  → pendingChoice set + persistAndBroadcast
+    → (user clicks matching) p3 resolve → pendingChoice cleared + persistAndBroadcast
+    → (user clicks stale) stale marker, no state change
+    → (new question supersedes) defensive prelude → pendingChoice cleared + persistAndBroadcast
+    → (post-failure partial rollback) defensive clear → persistAndBroadcast
+    → (24h TTL via session-registry GC) silently expires
+```
+
+Turn `end()` / `fail()` do **NOT** touch `pendingChoice`. The question may
+legitimately outlive the turn that posted it (e.g. a user who steps away
+for an hour then returns to answer). See codex review v2 P0.
+
+## Tests
+
+- `turn-surface.test.ts` — askUser / askUserForm posts + return ts;
+  resolveChoice/resolveMultiChoice update; `message_not_found` swallowed;
+  `end()` does not force-resolve pending choice; `askUserForm` per-chunk
+  state tracking.
+- `thread-surface.test.ts` — `setChoiceMeta` writes expected fields +
+  triggers permalink warm; `clearChoice` extension clears `pendingChoice`.
+- `thread-panel.test.ts` — askUser happy path + PHASE<3 sentinel + post-
+  failed; askUserForm 2-chunk success; askUserForm partial-failure rollback
+  (Slack rewrite + state clear + persistAndBroadcast); resolveChoice/
+  resolveMultiChoice clear + persist; PHASE<3 returns false.
+- `choice-action-handler.test.ts` — classifier matrix (6 rows), persist
+  on pendingQuestion clear, dashboard routing.
+- `form-action-handler.test.ts` — custom-input single + multi P3; modal
+  `private_metadata.turnId`; stale handling.
+- `stream-executor.test.ts` — PHASE=3 renderSingleChoice / renderMultiChoice
+  wiring; defensive prelude; post-failed → sendCommandChoiceFallback;
+  PHASE=0 byte-identical; `setPendingForm` persistence fix for messageTs
+  back-fill.
+- `choice-message-builder.test.ts` — additive turnId in single +
+  custom-input values; hero shape UNCHANGED.
+- `session-registry.test.ts` — `persistAndBroadcast` happy path + broadcast
+  error swallow.
+
+## References
+
+- Plan v2 SSOT: [#525 plan v2](https://github.com/2lab-ai/soma-work/issues/525#issuecomment-4270157443)
+- Epic: [#669](https://github.com/2lab-ai/soma-work/issues/669)
+- Phase 0 harness: `docs/slack-ui-phase0.md`
+- Phase 1 B1 streaming: `docs/slack-ui-phase1.md`
+- Phase 2 B2 plan block: `docs/slack-ui-phase2.md`
+- Upstream: [Slack Agents UI](https://docs.slack.dev/apis/assistant/)

--- a/src/session-registry.test.ts
+++ b/src/session-registry.test.ts
@@ -774,3 +774,38 @@ describe('SessionRegistry deserialize — model coerce', () => {
     expect(restored?.model).toBeUndefined();
   });
 });
+
+describe('persistAndBroadcast', () => {
+  beforeEach(() => {
+    if (fs.existsSync(TEST_DATA_DIR)) {
+      fs.rmSync(TEST_DATA_DIR, { recursive: true });
+    }
+    fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(TEST_DATA_DIR)) {
+      fs.rmSync(TEST_DATA_DIR, { recursive: true });
+    }
+  });
+
+  it('calls saveSessions + broadcast callback exactly once', () => {
+    const registry = new SessionRegistry();
+    const savesSpy = vi.spyOn(registry, 'saveSessions');
+    const broadcasts: number[] = [];
+    registry.setActivityStateChangeCallback(() => broadcasts.push(Date.now()));
+    registry.persistAndBroadcast('chan:thr');
+    expect(savesSpy).toHaveBeenCalledTimes(1);
+    expect(broadcasts.length).toBe(1);
+  });
+
+  it('swallows broadcast callback errors and still saves', () => {
+    const registry = new SessionRegistry();
+    const savesSpy = vi.spyOn(registry, 'saveSessions');
+    registry.setActivityStateChangeCallback(() => {
+      throw new Error('broadcast boom');
+    });
+    expect(() => registry.persistAndBroadcast('chan:thr')).not.toThrow();
+    expect(savesSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -211,6 +211,34 @@ export class SessionRegistry {
   }
 
   /**
+   * Persist all sessions to disk AND push a dashboard update.
+   *
+   * Use this after mutating session state that the dashboard consumes
+   * (pendingQuestion, pendingChoice, waitingForChoice, etc.) OUTSIDE of an
+   * activity-state transition. `setActivityState` only persists on transition
+   * to 'idle' and broadcasts only on state change, so holding state in 'waiting'
+   * while mutating pending fields would otherwise leave disk and dashboard stale.
+   *
+   * Cost: one disk write + one websocket push per call. Keep call sites bounded
+   * to real state transitions (set/clear of pendingChoice/pendingQuestion) —
+   * not every render.
+   *
+   * `sessionKey` parameter is currently advisory (for logging / future
+   * targeted broadcasts). The underlying broadcast API is global today.
+   */
+  public persistAndBroadcast(sessionKey: string): void {
+    this.saveSessions();
+    try {
+      this.onActivityStateChangeCallback?.();
+    } catch (err) {
+      this.logger.warn('persistAndBroadcast: broadcast callback raised', {
+        sessionKey,
+        error: (err as Error)?.message ?? String(err),
+      });
+    }
+  }
+
+  /**
    * Get session key - based on channel and thread only (shared session)
    */
   getSessionKey(channelId: string, threadTs?: string): string {

--- a/src/slack-handler.ts
+++ b/src/slack-handler.ts
@@ -124,12 +124,20 @@ export class SlackHandler {
     this.sessionUiManager = new SessionUiManager(claudeHandler, this.slackApi);
     this.sessionUiManager.setReactionManager(this.reactionManager);
     const completionMessageTracker = new CompletionMessageTracker();
+    // sessionRegistry is optional in ThreadPanelDeps (legacy tests construct
+    // ThreadPanel without it). Guard access here so test mocks that don't
+    // implement getSessionRegistry() keep passing.
+    const sessionRegistry =
+      typeof (this.claudeHandler as any).getSessionRegistry === 'function'
+        ? (this.claudeHandler as any).getSessionRegistry()
+        : undefined;
     this.threadPanel = new ThreadPanel({
       slackApi: this.slackApi,
       claudeHandler: this.claudeHandler,
       requestCoordinator: this.requestCoordinator,
       todoManager: this.todoManager,
       completionMessageTracker,
+      sessionRegistry,
     });
 
     // Command routing

--- a/src/slack/actions/choice-action-handler.test.ts
+++ b/src/slack/actions/choice-action-handler.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config } from '../../config';
 import { ChoiceActionHandler } from './choice-action-handler';
 
 function createFormStore() {
@@ -735,5 +736,209 @@ describe('ChoiceActionHandler', () => {
         /Recommendations incomplete/,
       );
     });
+  });
+});
+
+describe('ChoiceActionHandler — P3 (PHASE>=3) classifyClick', () => {
+  let formStore: ReturnType<typeof createFormStore>;
+  let slackApi: any;
+  let claudeHandler: any;
+  let messageHandler: any;
+  let threadPanel: any;
+  let sessionRegistry: any;
+  let handler: ChoiceActionHandler;
+  const sessionKey = 'C1:thread-root';
+
+  beforeEach(() => {
+    formStore = createFormStore();
+    slackApi = {
+      updateMessage: vi.fn().mockResolvedValue(undefined),
+      postEphemeral: vi.fn().mockResolvedValue(undefined),
+      postMessage: vi.fn().mockResolvedValue({ ts: 'posted' }),
+      deleteMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    sessionRegistry = { persistAndBroadcast: vi.fn() };
+    claudeHandler = {
+      getSessionByKey: vi.fn(),
+      setActivityStateByKey: vi.fn(),
+      getSessionRegistry: vi.fn(() => sessionRegistry),
+    };
+    messageHandler = vi.fn().mockResolvedValue(undefined);
+    threadPanel = {
+      clearChoice: vi.fn().mockResolvedValue(undefined),
+      attachChoice: vi.fn().mockResolvedValue(undefined),
+      resolveChoice: vi.fn().mockResolvedValue(true),
+      resolveMultiChoice: vi.fn().mockResolvedValue(true),
+    };
+
+    handler = new ChoiceActionHandler(
+      { slackApi, claudeHandler, messageHandler, threadPanel } as any,
+      formStore as any,
+    );
+  });
+
+  afterEach(() => {
+    config.ui.fiveBlockPhase = 0;
+  });
+
+  const clickBody = (turnId?: string, messageTs = 'msg-1') => ({
+    actions: [
+      {
+        value: JSON.stringify({
+          sessionKey,
+          choiceId: '2',
+          label: 'B',
+          question: 'Q?',
+          ...(turnId ? { turnId } : {}),
+        }),
+      },
+    ],
+    user: { id: 'U1' },
+    channel: { id: 'C1' },
+    message: { ts: messageTs },
+  });
+
+  it('PHASE<3 always legacy, ignores payload turnId', async () => {
+    config.ui.fiveBlockPhase = 2;
+    claudeHandler.getSessionByKey.mockReturnValue({
+      threadRootTs: 'thread-root',
+      threadTs: 'thread-root',
+      actionPanel: {
+        pendingChoice: { turnId: 'tOTHER', kind: 'single', choiceTs: 'msg-other', formIds: [] },
+        choiceMessageTs: 'thread-choice',
+      },
+    });
+    await handler.handleUserChoice(clickBody('tNEW', 'msg-1'));
+    expect(threadPanel.resolveChoice).not.toHaveBeenCalled();
+    expect(slackApi.updateMessage).toHaveBeenCalled(); // legacy path updates
+    expect(messageHandler).toHaveBeenCalled();
+  });
+
+  it('PHASE>=3 + matching pendingChoice + matching turnId → p3 path', async () => {
+    config.ui.fiveBlockPhase = 3;
+    claudeHandler.getSessionByKey.mockReturnValue({
+      threadRootTs: 'thread-root',
+      threadTs: 'thread-root',
+      channelId: 'C1',
+      actionPanel: {
+        pendingChoice: { turnId: 't1', kind: 'single', choiceTs: 'msg-1', formIds: [] },
+        choiceMessageTs: 'msg-1',
+      },
+    });
+    await handler.handleUserChoice(clickBody('t1', 'msg-1'));
+    expect(threadPanel.resolveChoice).toHaveBeenCalledWith(
+      expect.any(Object),
+      sessionKey,
+      'C1',
+      expect.stringContaining('선택'),
+      expect.any(Array),
+    );
+    expect(claudeHandler.setActivityStateByKey).toHaveBeenCalledWith(sessionKey, 'working');
+    expect(messageHandler).toHaveBeenCalled();
+  });
+
+  it('PHASE>=3 + payload turnId + no pendingChoice → stale (not legacy)', async () => {
+    config.ui.fiveBlockPhase = 3;
+    claudeHandler.getSessionByKey.mockReturnValue({
+      threadRootTs: 'thread-root',
+      threadTs: 'thread-root',
+      actionPanel: {},
+    });
+    await handler.handleUserChoice(clickBody('t1', 'msg-1'));
+    // Stale marker updateMessage
+    const firstCall = slackApi.updateMessage.mock.calls[0];
+    expect(firstCall[2]).toContain('더 이상 유효하지 않습니다');
+    expect(messageHandler).not.toHaveBeenCalled();
+    expect(threadPanel.resolveChoice).not.toHaveBeenCalled();
+  });
+
+  it('PHASE>=3 + no payload turnId + no pendingChoice → legacy', async () => {
+    config.ui.fiveBlockPhase = 3;
+    claudeHandler.getSessionByKey.mockReturnValue({
+      threadRootTs: 'thread-root',
+      threadTs: 'thread-root',
+      actionPanel: {},
+    });
+    await handler.handleUserChoice(clickBody(undefined, 'msg-1'));
+    expect(threadPanel.resolveChoice).not.toHaveBeenCalled();
+    expect(slackApi.updateMessage).toHaveBeenCalled();
+    expect(messageHandler).toHaveBeenCalled();
+  });
+
+  it('PHASE>=3 + pendingChoice present + turnId mismatch → stale', async () => {
+    config.ui.fiveBlockPhase = 3;
+    claudeHandler.getSessionByKey.mockReturnValue({
+      threadRootTs: 'thread-root',
+      threadTs: 'thread-root',
+      actionPanel: {
+        pendingChoice: { turnId: 't1', kind: 'single', choiceTs: 'msg-1', formIds: [] },
+      },
+    });
+    await handler.handleUserChoice(clickBody('t2', 'msg-1'));
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      'msg-1',
+      expect.stringContaining('더 이상 유효하지 않습니다'),
+      expect.any(Array),
+      [],
+    );
+    expect(messageHandler).not.toHaveBeenCalled();
+  });
+
+  it('PHASE>=3 + pendingChoice present + ts mismatch → stale', async () => {
+    config.ui.fiveBlockPhase = 3;
+    claudeHandler.getSessionByKey.mockReturnValue({
+      threadRootTs: 'thread-root',
+      threadTs: 'thread-root',
+      actionPanel: {
+        pendingChoice: { turnId: 't1', kind: 'single', choiceTs: 'msg-other', formIds: [] },
+      },
+    });
+    await handler.handleUserChoice(clickBody('t1', 'msg-1'));
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      'msg-1',
+      expect.stringContaining('더 이상 유효하지 않습니다'),
+      expect.any(Array),
+      [],
+    );
+    expect(messageHandler).not.toHaveBeenCalled();
+  });
+
+  it('PHASE>=3 + no payload turnId + pendingChoice present → stale (defensive)', async () => {
+    config.ui.fiveBlockPhase = 3;
+    claudeHandler.getSessionByKey.mockReturnValue({
+      threadRootTs: 'thread-root',
+      threadTs: 'thread-root',
+      actionPanel: {
+        pendingChoice: { turnId: 't1', kind: 'single', choiceTs: 'msg-1', formIds: [] },
+      },
+    });
+    await handler.handleUserChoice(clickBody(undefined, 'msg-1'));
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      'msg-1',
+      expect.stringContaining('더 이상 유효하지 않습니다'),
+      expect.any(Array),
+      [],
+    );
+    expect(messageHandler).not.toHaveBeenCalled();
+  });
+
+  it('P3 path persistAndBroadcast clears pendingQuestion', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = {
+      threadRootTs: 'thread-root',
+      threadTs: 'thread-root',
+      channelId: 'C1',
+      actionPanel: {
+        pendingChoice: { turnId: 't1', kind: 'single', choiceTs: 'msg-1', formIds: [] },
+        pendingQuestion: { type: 'user_choice' },
+      },
+    };
+    claudeHandler.getSessionByKey.mockReturnValue(session);
+    await handler.handleUserChoice(clickBody('t1', 'msg-1'));
+    expect(session.actionPanel.pendingQuestion).toBeUndefined();
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledWith(sessionKey);
   });
 });

--- a/src/slack/actions/choice-action-handler.test.ts
+++ b/src/slack/actions/choice-action-handler.test.ts
@@ -987,9 +987,7 @@ describe('ChoiceActionHandler — P3 (PHASE>=3) classifyClick', () => {
       await handler.completeMultiChoiceForm(formStore.get('form-A'), 'U1', 'C1', 'thread-root', 'ts-A');
 
       // Only chunk-A's Slack message updated (chunk-B ts NOT touched).
-      const updateCalls = slackApi.updateMessage.mock.calls.filter(
-        (c: any[]) => c[1] === 'ts-A' || c[1] === 'ts-B',
-      );
+      const updateCalls = slackApi.updateMessage.mock.calls.filter((c: any[]) => c[1] === 'ts-A' || c[1] === 'ts-B');
       expect(updateCalls.map((c: any[]) => c[1]).sort()).toEqual(['ts-A']);
 
       // pendingChoice shrinks (form-A removed, form-B survives).

--- a/src/slack/actions/choice-action-handler.test.ts
+++ b/src/slack/actions/choice-action-handler.test.ts
@@ -941,4 +941,90 @@ describe('ChoiceActionHandler — P3 (PHASE>=3) classifyClick', () => {
     expect(session.actionPanel.pendingQuestion).toBeUndefined();
     expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledWith(sessionKey);
   });
+
+  /**
+   * Regression guard for codex P1: multi-choice chunking (>6 questions) splits
+   * into N forms but `handleFormSubmit` only validates THIS form's answers.
+   * Submitting chunk 1 must NOT clear chunks 2..N — they remain live for the
+   * user to answer independently (matches legacy per-chunk semantics).
+   */
+  describe('completeMultiChoiceForm — P3 per-chunk submit (codex P1 regression guard)', () => {
+    const makeForm = (formId: string, messageTs: string, turnId: string) => ({
+      formId,
+      sessionKey,
+      channel: 'C1',
+      threadTs: 'thread-root',
+      messageTs,
+      questions: [{ id: 'q1', question: 'q?', choices: [{ id: '1', label: 'A' }] }],
+      selections: { q1: { choiceId: '1', label: 'A' } },
+      createdAt: 0,
+      turnId,
+    });
+
+    it('submitting chunk 1 of 2: only chunk 1 marked done, chunk 2 untouched, pendingChoice keeps chunk 2', async () => {
+      config.ui.fiveBlockPhase = 3;
+      formStore.set('form-A', makeForm('form-A', 'ts-A', 'turn-X'));
+      formStore.set('form-B', makeForm('form-B', 'ts-B', 'turn-X'));
+      const session = {
+        threadRootTs: 'thread-root',
+        threadTs: 'thread-root',
+        channelId: 'C1',
+        ownerId: 'U1',
+        actionPanel: {
+          pendingChoice: {
+            turnId: 'turn-X',
+            kind: 'multi',
+            choiceTs: 'ts-A',
+            formIds: ['form-A', 'form-B'],
+            question: { type: 'user_choices', questions: [] },
+            createdAt: 0,
+          },
+          pendingQuestion: { type: 'user_choices' },
+        },
+      };
+      claudeHandler.getSessionByKey.mockReturnValue(session);
+
+      await handler.completeMultiChoiceForm(formStore.get('form-A'), 'U1', 'C1', 'thread-root', 'ts-A');
+
+      // Only chunk-A's Slack message updated (chunk-B ts NOT touched).
+      const updateCalls = slackApi.updateMessage.mock.calls.filter(
+        (c: any[]) => c[1] === 'ts-A' || c[1] === 'ts-B',
+      );
+      expect(updateCalls.map((c: any[]) => c[1]).sort()).toEqual(['ts-A']);
+
+      // pendingChoice shrinks (form-A removed, form-B survives).
+      expect(session.actionPanel.pendingChoice).toBeDefined();
+      expect(session.actionPanel.pendingChoice!.formIds).toEqual(['form-B']);
+      // form-A deleted from store, form-B survives.
+      expect(formStore.get('form-A')).toBeUndefined();
+      expect(formStore.get('form-B')).toBeDefined();
+    });
+
+    it('submitting last chunk (only formId in pendingChoice): pendingChoice fully cleared', async () => {
+      config.ui.fiveBlockPhase = 3;
+      formStore.set('form-B', makeForm('form-B', 'ts-B', 'turn-X'));
+      const session = {
+        threadRootTs: 'thread-root',
+        threadTs: 'thread-root',
+        channelId: 'C1',
+        ownerId: 'U1',
+        actionPanel: {
+          pendingChoice: {
+            turnId: 'turn-X',
+            kind: 'multi',
+            choiceTs: 'ts-B',
+            formIds: ['form-B'],
+            question: { type: 'user_choices', questions: [] },
+            createdAt: 0,
+          },
+        },
+      };
+      claudeHandler.getSessionByKey.mockReturnValue(session);
+
+      await handler.completeMultiChoiceForm(formStore.get('form-B'), 'U1', 'C1', 'thread-root', 'ts-B');
+
+      expect(session.actionPanel.pendingChoice).toBeUndefined();
+      expect(formStore.get('form-B')).toBeUndefined();
+    });
+  });
 });

--- a/src/slack/actions/choice-action-handler.ts
+++ b/src/slack/actions/choice-action-handler.ts
@@ -7,14 +7,12 @@ import type { CompletionMessageTracker } from '../completion-message-tracker';
 import type { SlackApiHelper } from '../slack-api-helper';
 import type { ThreadPanel } from '../thread-panel';
 import { UserChoiceHandler } from '../user-choice-handler';
+import { classifyClick, markClickAsStale } from './click-classifier';
 import type { PendingFormStore } from './pending-form-store';
 import type { MessageHandler, PendingChoiceFormData, SayFn } from './types';
 
 /** Sentinel choiceId for custom text input (직접입력) */
 const CUSTOM_INPUT_CHOICE_ID = '직접입력';
-
-/** Stale-click marker shown on the button message after a superseded click. */
-const STALE_CLICK_TEXT = '⏱️ _이 질문은 더 이상 유효하지 않습니다._';
 
 interface ChoiceActionContext {
   slackApi: SlackApiHelper;
@@ -23,14 +21,6 @@ interface ChoiceActionContext {
   threadPanel?: ThreadPanel;
   completionMessageTracker?: CompletionMessageTracker;
 }
-
-/**
- * P3 (PHASE>=3) classifier result — `legacy` = run pre-P3 body unchanged,
- * `p3` = use ThreadPanel resolve + synchronized state clear, `stale` = click
- * is superseded by a newer pending question, mark the clicked message and
- * drop the input.
- */
-type ClickBranch = 'legacy' | 'p3' | 'stale';
 
 /**
  * 사용자 선택 액션 핸들러
@@ -58,7 +48,7 @@ export class ChoiceActionHandler {
 
       this.logger.info('User choice selected', { sessionKey, choiceId, label, userId });
 
-      const branch = this.classifyClick({ sessionKey, payloadTurnId, messageTs });
+      const branch = classifyClick(this.ctx.claudeHandler, { sessionKey, payloadTurnId, messageTs });
 
       if (branch === 'stale') {
         this.logger.info('User choice click classified as stale — marking and returning', {
@@ -67,7 +57,7 @@ export class ChoiceActionHandler {
           messageTs,
         });
         if (channel && messageTs) {
-          await this.markClickAsStale(channel, messageTs, sessionKey);
+          await markClickAsStale(this.ctx.slackApi, this.logger, channel, messageTs, sessionKey);
         }
         return;
       }
@@ -154,9 +144,8 @@ export class ChoiceActionHandler {
         if (session.actionPanel) {
           session.actionPanel.pendingQuestion = undefined;
         }
-        // P3 parity: pendingQuestion now persists (see stream-executor) so it
-        // must also be broadcast+persisted when cleared — otherwise a dashboard
-        // restart restores a stale pending question.
+        // pendingQuestion clear must persist+broadcast so dashboard restart
+        // doesn't restore a stale question.
         try {
           this.ctx.claudeHandler.getSessionRegistry?.()?.persistAndBroadcast?.(sessionKey);
         } catch (err) {
@@ -244,7 +233,7 @@ export class ChoiceActionHandler {
       // P3 (PHASE>=3) stale-click check. For multi, payload turnId comes from
       // the PendingFormStore entry (button values don't carry turnId for
       // multi — turnId lives on the form record).
-      const branch = this.classifyClick({
+      const branch = classifyClick(this.ctx.claudeHandler, {
         sessionKey,
         payloadTurnId: pendingForm.turnId,
         formId,
@@ -256,7 +245,7 @@ export class ChoiceActionHandler {
           questionId,
         });
         if (channel && messageTs) {
-          await this.markClickAsStale(channel, messageTs, sessionKey);
+          await markClickAsStale(this.ctx.slackApi, this.logger, channel, messageTs, sessionKey);
         }
         return;
       }
@@ -334,7 +323,7 @@ export class ChoiceActionHandler {
       }
 
       // P3 (PHASE>=3) stale-click guard for the submit button.
-      const branch = this.classifyClick({
+      const branch = classifyClick(this.ctx.claudeHandler, {
         sessionKey,
         payloadTurnId: pendingForm.turnId,
         formId,
@@ -345,7 +334,7 @@ export class ChoiceActionHandler {
           formId,
         });
         if (channel && messageTs) {
-          await this.markClickAsStale(channel, messageTs, sessionKey);
+          await markClickAsStale(this.ctx.slackApi, this.logger, channel, messageTs, sessionKey);
         }
         return;
       }
@@ -593,7 +582,7 @@ export class ChoiceActionHandler {
       if (session.actionPanel) {
         session.actionPanel.pendingQuestion = undefined;
       }
-      // P3 parity: also persist+broadcast the cleared pendingQuestion.
+      // pendingQuestion clear must persist+broadcast (dashboard restart parity).
       try {
         this.ctx.claudeHandler.getSessionRegistry?.()?.persistAndBroadcast?.(pendingForm.sessionKey);
       } catch (err) {
@@ -741,7 +730,7 @@ export class ChoiceActionHandler {
       }
 
       // P3 (PHASE>=3) stale-click guard for the hero button.
-      const heroBranch = this.classifyClick({
+      const heroBranch = classifyClick(this.ctx.claudeHandler, {
         sessionKey,
         payloadTurnId: pendingForm.turnId,
         formId,
@@ -752,7 +741,7 @@ export class ChoiceActionHandler {
           formId,
         });
         if (channel && messageTs) {
-          await this.markClickAsStale(channel, messageTs, sessionKey);
+          await markClickAsStale(this.ctx.slackApi, this.logger, channel, messageTs, sessionKey);
         }
         return;
       }
@@ -1344,65 +1333,6 @@ export class ChoiceActionHandler {
     }
 
     return [...targets];
-  }
-
-  /**
-   * P3 (PHASE>=3) click routing.
-   *
-   *   'legacy' — run the pre-P3 code path unchanged.
-   *   'p3'     — use ThreadPanel.resolveChoice / resolveMultiChoice.
-   *   'stale'  — update message to stale marker and drop the dispatch.
-   *
-   * Classification matrix (PHASE>=3 only — PHASE<3 always returns 'legacy'):
-   *
-   *  | payload turnId | pendingChoice | match (turnId+ts) | branch |
-   *  | absent         | absent        | —                 | legacy |
-   *  | present        | absent        | —                 | stale  |
-   *  | absent         | present       | —                 | stale  |
-   *  | present        | present       | yes               | p3     |
-   *  | present        | present       | no                | stale  |
-   */
-  private classifyClick(args: {
-    sessionKey: string;
-    payloadTurnId?: string;
-    messageTs?: string;
-    formId?: string;
-  }): ClickBranch {
-    if (config.ui.fiveBlockPhase < 3) return 'legacy';
-
-    const session = this.ctx.claudeHandler.getSessionByKey(args.sessionKey);
-    const pc = session?.actionPanel?.pendingChoice;
-
-    if (pc) {
-      const turnIdMatches = !!args.payloadTurnId && pc.turnId === args.payloadTurnId;
-      const tsMatches =
-        pc.kind === 'single'
-          ? !!args.messageTs && pc.choiceTs === args.messageTs
-          : !!args.formId && pc.formIds.includes(args.formId);
-      if (turnIdMatches && tsMatches) return 'p3';
-      return 'stale';
-    }
-
-    // No pendingChoice: payload carries P3 identity ⇒ stale (don't resurrect
-    // a click via the ts-union legacy resolver). No P3 identity ⇒ truly
-    // pre-flip legacy message; legacy path is safe.
-    if (args.payloadTurnId) return 'stale';
-    return 'legacy';
-  }
-
-  /** Apply the stale marker to the clicked message. Best-effort (logs on failure). */
-  private async markClickAsStale(channel: string, messageTs: string, sessionKey: string): Promise<void> {
-    if (!channel || !messageTs) return;
-    const staleBlocks = [{ type: 'section', text: { type: 'mrkdwn', text: STALE_CLICK_TEXT } }];
-    try {
-      await this.ctx.slackApi.updateMessage(channel, messageTs, STALE_CLICK_TEXT, staleBlocks, []);
-    } catch (err) {
-      this.logger.warn('markClickAsStale: updateMessage failed', {
-        sessionKey,
-        messageTs,
-        error: (err as Error)?.message ?? String(err),
-      });
-    }
   }
 
   /**

--- a/src/slack/actions/choice-action-handler.ts
+++ b/src/slack/actions/choice-action-handler.ts
@@ -512,13 +512,7 @@ export class ChoiceActionHandler {
     if (canUseP3 && session && channel && pc && pendingForm.messageTs) {
       // Slack update: mark ONLY this chunk's message done.
       try {
-        await this.ctx.slackApi.updateMessage(
-          channel,
-          pendingForm.messageTs,
-          '✅ 모든 선택 완료',
-          completedBlocks,
-          [],
-        );
+        await this.ctx.slackApi.updateMessage(channel, pendingForm.messageTs, '✅ 모든 선택 완료', completedBlocks, []);
       } catch (err) {
         this.logger.warn('P3 per-chunk resolve: updateMessage failed', {
           sessionKey: pendingForm.sessionKey,

--- a/src/slack/actions/choice-action-handler.ts
+++ b/src/slack/actions/choice-action-handler.ts
@@ -492,10 +492,14 @@ export class ChoiceActionHandler {
     const session = this.ctx.claudeHandler.getSessionByKey(pendingForm.sessionKey);
     const resolvedThreadTs = this.resolveSessionThreadTs(session, threadTs);
 
-    // P3 (PHASE>=3) — resolve via ThreadPanel.resolveMultiChoice so we update
-    // every chunk in pendingChoice.formIds via their tracked messageTs (not
-    // the ts-union resolver). Only when pendingChoice.kind === 'multi' and
-    // turnId matches this form's turnId (already checked by caller).
+    // P3 (PHASE>=3) — submit is per-chunk (handleFormSubmit only validates
+    // the submitted form's questions). Resolve only THIS chunk's messageTs
+    // in place. Remove this chunk's formId from pendingChoice.formIds; only
+    // when the last chunk is submitted does pendingChoice fully clear.
+    // Other chunks remain live so the user can answer them independently
+    // (matches legacy per-chunk semantics; prevents codex-flagged bug where
+    // submitting chunk 1 would clear chunks 2..N as "completed" while they
+    // were still unanswered).
     const pc = session?.actionPanel?.pendingChoice;
     const canUseP3 =
       config.ui.fiveBlockPhase >= 3 &&
@@ -505,56 +509,68 @@ export class ChoiceActionHandler {
       pc.kind === 'multi' &&
       pc.turnId === pendingForm.turnId;
 
-    if (canUseP3 && session && channel) {
-      // Build tsList from pendingChoice.formIds → pendingForm.messageTs via formStore
-      const tsList: string[] = [];
-      for (const fId of pc!.formIds) {
-        const form = this.formStore.get(fId);
-        if (form?.messageTs) tsList.push(form.messageTs);
-      }
-      // Delete the form *after* we've collected the tsList (so chunk lookup works).
-      this.formStore.delete(pendingForm.formId);
-      const resolved = await this.ctx
-        .threadPanel!.resolveMultiChoice(
-          session,
-          pendingForm.sessionKey,
+    if (canUseP3 && session && channel && pc && pendingForm.messageTs) {
+      // Slack update: mark ONLY this chunk's message done.
+      try {
+        await this.ctx.slackApi.updateMessage(
           channel,
-          tsList,
-          completedText,
+          pendingForm.messageTs,
+          '✅ 모든 선택 완료',
           completedBlocks,
-        )
-        .catch((err) => {
-          this.logger.warn('resolveMultiChoice threw — falling back to legacy UI update', {
-            sessionKey: pendingForm.sessionKey,
-            error: (err as Error)?.message ?? String(err),
-          });
-          return false;
+          [],
+        );
+      } catch (err) {
+        this.logger.warn('P3 per-chunk resolve: updateMessage failed', {
+          sessionKey: pendingForm.sessionKey,
+          formId: pendingForm.formId,
+          error: (err as Error)?.message ?? String(err),
         });
-      if (resolved) {
-        await this.afterP3Resolve(session, pendingForm.sessionKey, channel);
-        try {
-          const say = this.createSayFn(channel);
-          await this.ctx.messageHandler(
-            { user: userId, channel, thread_ts: resolvedThreadTs, ts: messageTs, text: combinedMessage },
-            say,
-          );
-        } catch (handlerError) {
-          this.logger.error('Multi-choice handler failed (P3), rolling back to waiting', {
-            sessionKey: pendingForm.sessionKey,
-            error: handlerError,
-          });
-          try {
-            this.ctx.claudeHandler.setActivityStateByKey(pendingForm.sessionKey, 'waiting');
-          } catch (rollbackError) {
-            this.logger.error('Failed to rollback activity state', {
-              sessionKey: pendingForm.sessionKey,
-              rollbackError,
-            });
-          }
-        }
-        return;
       }
-      // resolve returned false — fall through to legacy path.
+
+      // Remove this chunk from pendingChoice.formIds (and the formStore entry).
+      this.formStore.delete(pendingForm.formId);
+      const remainingFormIds = pc.formIds.filter((fId) => fId !== pendingForm.formId);
+      if (session.actionPanel) {
+        if (remainingFormIds.length === 0) {
+          // Last chunk submitted — clear the whole pending record.
+          session.actionPanel.pendingChoice = undefined;
+          session.actionPanel.choiceMessageTs = undefined;
+          session.actionPanel.choiceMessageLink = undefined;
+          session.actionPanel.waitingForChoice = false;
+          session.actionPanel.choiceBlocks = undefined;
+        } else {
+          // Chunks still outstanding — shrink formIds, keep pendingChoice live.
+          session.actionPanel.pendingChoice = {
+            ...pc,
+            formIds: remainingFormIds,
+          };
+        }
+      }
+
+      // afterP3Resolve handles the single persistAndBroadcast for both the
+      // formIds shrink/clear above and the pendingQuestion clear below.
+      await this.afterP3Resolve(session, pendingForm.sessionKey, channel);
+      try {
+        const say = this.createSayFn(channel);
+        await this.ctx.messageHandler(
+          { user: userId, channel, thread_ts: resolvedThreadTs, ts: messageTs, text: combinedMessage },
+          say,
+        );
+      } catch (handlerError) {
+        this.logger.error('Multi-choice handler failed (P3), rolling back to waiting', {
+          sessionKey: pendingForm.sessionKey,
+          error: handlerError,
+        });
+        try {
+          this.ctx.claudeHandler.setActivityStateByKey(pendingForm.sessionKey, 'waiting');
+        } catch (rollbackError) {
+          this.logger.error('Failed to rollback activity state', {
+            sessionKey: pendingForm.sessionKey,
+            rollbackError,
+          });
+        }
+      }
+      return;
     }
 
     this.formStore.delete(pendingForm.formId);

--- a/src/slack/actions/choice-action-handler.ts
+++ b/src/slack/actions/choice-action-handler.ts
@@ -1,4 +1,5 @@
 import type { ClaudeHandler } from '../../claude-handler';
+import { config } from '../../config';
 import { Logger } from '../../logger';
 import type { UserChoices } from '../../types';
 import { ChoiceMessageBuilder } from '../choice-message-builder';
@@ -12,6 +13,9 @@ import type { MessageHandler, PendingChoiceFormData, SayFn } from './types';
 /** Sentinel choiceId for custom text input (직접입력) */
 const CUSTOM_INPUT_CHOICE_ID = '직접입력';
 
+/** Stale-click marker shown on the button message after a superseded click. */
+const STALE_CLICK_TEXT = '⏱️ _이 질문은 더 이상 유효하지 않습니다._';
+
 interface ChoiceActionContext {
   slackApi: SlackApiHelper;
   claudeHandler: ClaudeHandler;
@@ -19,6 +23,14 @@ interface ChoiceActionContext {
   threadPanel?: ThreadPanel;
   completionMessageTracker?: CompletionMessageTracker;
 }
+
+/**
+ * P3 (PHASE>=3) classifier result — `legacy` = run pre-P3 body unchanged,
+ * `p3` = use ThreadPanel resolve + synchronized state clear, `stale` = click
+ * is superseded by a newer pending question, mark the clicked message and
+ * drop the input.
+ */
+type ClickBranch = 'legacy' | 'p3' | 'stale';
 
 /**
  * 사용자 선택 액션 핸들러
@@ -35,7 +47,7 @@ export class ChoiceActionHandler {
     try {
       const action = body.actions[0];
       const valueData = JSON.parse(action.value);
-      const { sessionKey, choiceId, label, question } = valueData;
+      const { sessionKey, choiceId, label, question, turnId: payloadTurnId } = valueData;
       const userId = body.user?.id;
       const session = this.ctx.claudeHandler.getSessionByKey(sessionKey);
       const channel = body.channel?.id || session?.channelId;
@@ -45,6 +57,61 @@ export class ChoiceActionHandler {
       const completionMessageTs = this.resolveChoiceMessageTs(session, messageTs);
 
       this.logger.info('User choice selected', { sessionKey, choiceId, label, userId });
+
+      const branch = this.classifyClick({ sessionKey, payloadTurnId, messageTs });
+
+      if (branch === 'stale') {
+        this.logger.info('User choice click classified as stale — marking and returning', {
+          sessionKey,
+          payloadTurnId,
+          messageTs,
+        });
+        if (channel && messageTs) {
+          await this.markClickAsStale(channel, messageTs, sessionKey);
+        }
+        return;
+      }
+
+      if (branch === 'p3' && session && channel) {
+        const completedText = `✅ *${question}*\n선택: *${choiceId}. ${label}*`;
+        const completedBlocks = [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: completedText },
+          },
+        ];
+        const resolved = await this.ctx.threadPanel
+          ?.resolveChoice(session, sessionKey, channel, completedText, completedBlocks)
+          .catch((err) => {
+            this.logger.warn('resolveChoice threw — falling back to legacy path', {
+              sessionKey,
+              error: (err as Error)?.message ?? String(err),
+            });
+            return false;
+          });
+        if (resolved) {
+          await this.afterP3Resolve(session, sessionKey, channel);
+          try {
+            const say = this.createSayFn(channel);
+            await this.ctx.messageHandler(
+              { user: userId, channel, thread_ts: threadTs, ts: messageTs, text: choiceId },
+              say,
+            );
+          } catch (handlerError) {
+            this.logger.error('Choice handler failed (P3), rolling back to waiting', {
+              sessionKey,
+              error: handlerError,
+            });
+            try {
+              this.ctx.claudeHandler.setActivityStateByKey(sessionKey, 'waiting');
+            } catch (rollbackError) {
+              this.logger.error('Failed to rollback activity state', { sessionKey, rollbackError });
+            }
+          }
+          return;
+        }
+        // resolve returned false (unexpected under PHASE>=3 + matching pc) → fall through to legacy.
+      }
 
       // 선택 메시지 업데이트 (모든 동기화 대상에 대해)
       // Immediately replace buttons to prevent double-click on other options
@@ -86,6 +153,17 @@ export class ChoiceActionHandler {
         // Clear pending question from session (dashboard sync)
         if (session.actionPanel) {
           session.actionPanel.pendingQuestion = undefined;
+        }
+        // P3 parity: pendingQuestion now persists (see stream-executor) so it
+        // must also be broadcast+persisted when cleared — otherwise a dashboard
+        // restart restores a stale pending question.
+        try {
+          this.ctx.claudeHandler.getSessionRegistry?.()?.persistAndBroadcast?.(sessionKey);
+        } catch (err) {
+          this.logger.debug('handleUserChoice: persistAndBroadcast failed', {
+            sessionKey,
+            error: (err as Error)?.message ?? String(err),
+          });
         }
         // Delete tracked completion messages on choice selection (S8)
         if (channel) {
@@ -163,6 +241,26 @@ export class ChoiceActionHandler {
         return;
       }
 
+      // P3 (PHASE>=3) stale-click check. For multi, payload turnId comes from
+      // the PendingFormStore entry (button values don't carry turnId for
+      // multi — turnId lives on the form record).
+      const branch = this.classifyClick({
+        sessionKey,
+        payloadTurnId: pendingForm.turnId,
+        formId,
+      });
+      if (branch === 'stale') {
+        this.logger.info('Multi-choice click classified as stale — marking and returning', {
+          sessionKey,
+          formId,
+          questionId,
+        });
+        if (channel && messageTs) {
+          await this.markClickAsStale(channel, messageTs, sessionKey);
+        }
+        return;
+      }
+
       // 선택 저장
       pendingForm.selections[questionId] = { choiceId, label };
 
@@ -232,6 +330,23 @@ export class ChoiceActionHandler {
           userId,
           '❌ 폼을 찾을 수 없습니다. 시간이 만료되었을 수 있습니다.',
         );
+        return;
+      }
+
+      // P3 (PHASE>=3) stale-click guard for the submit button.
+      const branch = this.classifyClick({
+        sessionKey,
+        payloadTurnId: pendingForm.turnId,
+        formId,
+      });
+      if (branch === 'stale') {
+        this.logger.info('Form submit click classified as stale — marking and returning', {
+          sessionKey,
+          formId,
+        });
+        if (channel && messageTs) {
+          await this.markClickAsStale(channel, messageTs, sessionKey);
+        }
         return;
       }
 
@@ -377,20 +492,85 @@ export class ChoiceActionHandler {
     });
     const combinedMessage = responses.join('\n');
 
-    this.formStore.delete(pendingForm.formId);
-
-    const completionMessageTs = pendingForm.messageTs || messageTs;
-
-    // 완료 UI 업데이트 (모든 동기화 대상에 대해)
+    const completedText = `✅ *모든 선택 완료*\n\n${responses.map((r, i) => `${i + 1}. ${r}`).join('\n')}`;
     const completedBlocks = [
       {
         type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `✅ *모든 선택 완료*\n\n${responses.map((r, i) => `${i + 1}. ${r}`).join('\n')}`,
-        },
+        text: { type: 'mrkdwn', text: completedText },
       },
     ];
+
+    const session = this.ctx.claudeHandler.getSessionByKey(pendingForm.sessionKey);
+    const resolvedThreadTs = this.resolveSessionThreadTs(session, threadTs);
+
+    // P3 (PHASE>=3) — resolve via ThreadPanel.resolveMultiChoice so we update
+    // every chunk in pendingChoice.formIds via their tracked messageTs (not
+    // the ts-union resolver). Only when pendingChoice.kind === 'multi' and
+    // turnId matches this form's turnId (already checked by caller).
+    const pc = session?.actionPanel?.pendingChoice;
+    const canUseP3 =
+      config.ui.fiveBlockPhase >= 3 &&
+      !!session &&
+      !!this.ctx.threadPanel &&
+      !!pc &&
+      pc.kind === 'multi' &&
+      pc.turnId === pendingForm.turnId;
+
+    if (canUseP3 && session && channel) {
+      // Build tsList from pendingChoice.formIds → pendingForm.messageTs via formStore
+      const tsList: string[] = [];
+      for (const fId of pc!.formIds) {
+        const form = this.formStore.get(fId);
+        if (form?.messageTs) tsList.push(form.messageTs);
+      }
+      // Delete the form *after* we've collected the tsList (so chunk lookup works).
+      this.formStore.delete(pendingForm.formId);
+      const resolved = await this.ctx
+        .threadPanel!.resolveMultiChoice(
+          session,
+          pendingForm.sessionKey,
+          channel,
+          tsList,
+          completedText,
+          completedBlocks,
+        )
+        .catch((err) => {
+          this.logger.warn('resolveMultiChoice threw — falling back to legacy UI update', {
+            sessionKey: pendingForm.sessionKey,
+            error: (err as Error)?.message ?? String(err),
+          });
+          return false;
+        });
+      if (resolved) {
+        await this.afterP3Resolve(session, pendingForm.sessionKey, channel);
+        try {
+          const say = this.createSayFn(channel);
+          await this.ctx.messageHandler(
+            { user: userId, channel, thread_ts: resolvedThreadTs, ts: messageTs, text: combinedMessage },
+            say,
+          );
+        } catch (handlerError) {
+          this.logger.error('Multi-choice handler failed (P3), rolling back to waiting', {
+            sessionKey: pendingForm.sessionKey,
+            error: handlerError,
+          });
+          try {
+            this.ctx.claudeHandler.setActivityStateByKey(pendingForm.sessionKey, 'waiting');
+          } catch (rollbackError) {
+            this.logger.error('Failed to rollback activity state', {
+              sessionKey: pendingForm.sessionKey,
+              rollbackError,
+            });
+          }
+        }
+        return;
+      }
+      // resolve returned false — fall through to legacy path.
+    }
+
+    this.formStore.delete(pendingForm.formId);
+
+    const completionMessageTs = pendingForm.messageTs || messageTs;
 
     const targetTimestamps = this.resolveChoiceSyncMessageTs(pendingForm.sessionKey, messageTs, completionMessageTs);
     for (const targetTs of targetTimestamps) {
@@ -408,12 +588,19 @@ export class ChoiceActionHandler {
     }
 
     // Claude에 전송
-    const session = this.ctx.claudeHandler.getSessionByKey(pendingForm.sessionKey);
-    const resolvedThreadTs = this.resolveSessionThreadTs(session, threadTs);
     if (session) {
       // clearChoice already fired in handleFormSubmit; only clear pending question here
       if (session.actionPanel) {
         session.actionPanel.pendingQuestion = undefined;
+      }
+      // P3 parity: also persist+broadcast the cleared pendingQuestion.
+      try {
+        this.ctx.claudeHandler.getSessionRegistry?.()?.persistAndBroadcast?.(pendingForm.sessionKey);
+      } catch (err) {
+        this.logger.debug('completeMultiChoiceForm: persistAndBroadcast failed', {
+          sessionKey: pendingForm.sessionKey,
+          error: (err as Error)?.message ?? String(err),
+        });
       }
       // Delete tracked completion messages on form submission (S8)
       if (channel) {
@@ -549,6 +736,23 @@ export class ChoiceActionHandler {
       if (pendingForm.submitting) {
         if (channel && userId) {
           await this.ctx.slackApi.postEphemeral(channel, userId, '⏳ 이미 제출 처리 중입니다.');
+        }
+        return;
+      }
+
+      // P3 (PHASE>=3) stale-click guard for the hero button.
+      const heroBranch = this.classifyClick({
+        sessionKey,
+        payloadTurnId: pendingForm.turnId,
+        formId,
+      });
+      if (heroBranch === 'stale') {
+        this.logger.info('Hero submit-all click classified as stale — marking and returning', {
+          sessionKey,
+          formId,
+        });
+        if (channel && messageTs) {
+          await this.markClickAsStale(channel, messageTs, sessionKey);
         }
         return;
       }
@@ -702,6 +906,54 @@ export class ChoiceActionHandler {
 
     this.logger.info('Dashboard choice selected', { sessionKey, choiceId, label, userId });
 
+    // P3 (PHASE>=3) — when a pendingChoice exists, route through resolveChoice.
+    // Dashboard payloads don't carry turnId, but pc.turnId always matches itself,
+    // so the classifier returns 'p3' whenever pc exists under PHASE>=3.
+    const pcSingle = session.actionPanel?.pendingChoice;
+    const canUseDashboardP3 =
+      config.ui.fiveBlockPhase >= 3 && !!this.ctx.threadPanel && !!pcSingle && pcSingle.kind === 'single';
+    if (canUseDashboardP3 && channel) {
+      const completedText = `✅ *${question}*\n선택: *${choiceId}. ${label}* _(대시보드)_`;
+      const completedBlocks = [
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: completedText },
+        },
+      ];
+      const resolved = await this.ctx
+        .threadPanel!.resolveChoice(session, sessionKey, channel, completedText, completedBlocks)
+        .catch((err) => {
+          this.logger.warn('resolveChoice (dashboard) threw — falling back to legacy path', {
+            sessionKey,
+            error: (err as Error)?.message ?? String(err),
+          });
+          return false;
+        });
+      if (resolved) {
+        try {
+          await this.afterP3Resolve(session, sessionKey, channel);
+          const say = this.createSayFn(channel);
+          await this.ctx.messageHandler(
+            { user: userId, channel, thread_ts: threadTs, ts: String(Date.now() / 1000), text: choiceId },
+            say,
+          );
+        } catch (error) {
+          this.logger.error('Error processing dashboard choice (P3)', { sessionKey, choiceId, error });
+          try {
+            this.ctx.claudeHandler.setActivityStateByKey(sessionKey, 'waiting');
+          } catch (rollbackError) {
+            this.logger.error('Failed to rollback activity state after dashboard choice (P3)', {
+              sessionKey,
+              rollbackError,
+            });
+          }
+          throw error;
+        }
+        return;
+      }
+      // Fall through to legacy path.
+    }
+
     try {
       // Update Slack choice messages with selection confirmation
       const completedBlocks = [
@@ -732,6 +984,14 @@ export class ChoiceActionHandler {
       await this.ctx.threadPanel?.clearChoice(sessionKey);
       if (session.actionPanel) {
         session.actionPanel.pendingQuestion = undefined;
+      }
+      try {
+        this.ctx.claudeHandler.getSessionRegistry?.()?.persistAndBroadcast?.(sessionKey);
+      } catch (err) {
+        this.logger.debug('handleChoiceFromDashboard: persistAndBroadcast failed', {
+          sessionKey,
+          error: (err as Error)?.message ?? String(err),
+        });
       }
 
       // Delete tracked completion messages
@@ -859,27 +1119,87 @@ export class ChoiceActionHandler {
     // Save pendingQuestion for rollback in case messageHandler fails
     const savedPendingQuestion = session.actionPanel?.pendingQuestion;
 
-    try {
-      // Build combined response text (same format as Slack form submission)
-      const responses = questions.map((q: { id: string; question: string }) => {
-        const sel = selections[q.id];
-        if (sel.choiceId === CUSTOM_INPUT_CHOICE_ID) {
-          return `${q.question}: (직접입력) ${sel.label}`;
-        }
-        return `${q.question}: ${sel.choiceId}. ${sel.label}`;
-      });
-      const combinedMessage = responses.join('\n');
+    // Build combined response text once (shared between P3 + legacy paths)
+    const responses = questions.map((q: { id: string; question: string }) => {
+      const sel = selections[q.id];
+      if (sel.choiceId === CUSTOM_INPUT_CHOICE_ID) {
+        return `${q.question}: (직접입력) ${sel.label}`;
+      }
+      return `${q.question}: ${sel.choiceId}. ${sel.label}`;
+    });
+    const combinedMessage = responses.join('\n');
+    const dashboardCompletedText = `✅ *모든 선택 완료* _(대시보드)_\n${responses.map((r: string, i: number) => `${i + 1}. ${r}`).join('\n')}`;
+    const dashboardCompletedBlocks = [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: dashboardCompletedText },
+      },
+    ];
 
+    // P3 (PHASE>=3) — route through resolveMultiChoice when pendingChoice is
+    // a multi record. Dashboard payloads don't carry turnId, but pc.turnId
+    // always matches itself.
+    const pcMulti = session.actionPanel?.pendingChoice;
+    const canUseDashboardMultiP3 =
+      config.ui.fiveBlockPhase >= 3 && !!this.ctx.threadPanel && !!pcMulti && pcMulti.kind === 'multi';
+    if (canUseDashboardMultiP3 && channel) {
+      const tsList: string[] = [];
+      for (const fId of pcMulti!.formIds) {
+        const form = this.formStore.get(fId);
+        if (form?.messageTs) tsList.push(form.messageTs);
+      }
+      const resolved = await this.ctx
+        .threadPanel!.resolveMultiChoice(
+          session,
+          sessionKey,
+          channel,
+          tsList,
+          dashboardCompletedText,
+          dashboardCompletedBlocks,
+        )
+        .catch((err) => {
+          this.logger.warn('resolveMultiChoice (dashboard) threw — falling back to legacy', {
+            sessionKey,
+            error: (err as Error)?.message ?? String(err),
+          });
+          return false;
+        });
+      if (resolved) {
+        // Invalidate any pending Slack forms for this session
+        const sessionForms = this.formStore.getFormsBySession(sessionKey);
+        for (const [formId] of sessionForms) {
+          this.formStore.delete(formId);
+        }
+        try {
+          await this.afterP3Resolve(session, sessionKey, channel);
+          const say = this.createSayFn(channel);
+          await this.ctx.messageHandler(
+            { user: userId, channel, thread_ts: threadTs, ts: String(Date.now() / 1000), text: combinedMessage },
+            say,
+          );
+        } catch (error) {
+          this.logger.error('Error processing dashboard multi-choice (P3)', { sessionKey, error });
+          try {
+            if (session.actionPanel && savedPendingQuestion) {
+              session.actionPanel.pendingQuestion = savedPendingQuestion;
+            }
+            this.ctx.claudeHandler.setActivityStateByKey(sessionKey, 'waiting');
+          } catch (rollbackError) {
+            this.logger.error('Failed to rollback activity state after dashboard multi-choice (P3)', {
+              sessionKey,
+              rollbackError,
+            });
+          }
+          throw error;
+        }
+        return;
+      }
+      // Fall through to legacy path.
+    }
+
+    try {
       // Update Slack form messages with completion
-      const completedBlocks = [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `✅ *모든 선택 완료* _(대시보드)_\n${responses.map((r: string, i: number) => `${i + 1}. ${r}`).join('\n')}`,
-          },
-        },
-      ];
+      const completedBlocks = dashboardCompletedBlocks;
 
       // Try to update the Slack form message(s)
       const choiceMessageTs = session.actionPanel?.choiceMessageTs;
@@ -909,6 +1229,14 @@ export class ChoiceActionHandler {
       }
       if (session.actionPanel) {
         session.actionPanel.pendingQuestion = undefined;
+      }
+      try {
+        this.ctx.claudeHandler.getSessionRegistry?.()?.persistAndBroadcast?.(sessionKey);
+      } catch (err) {
+        this.logger.debug('handleMultiChoiceFromDashboard: persistAndBroadcast failed', {
+          sessionKey,
+          error: (err as Error)?.message ?? String(err),
+        });
       }
 
       // Delete tracked completion messages
@@ -1016,5 +1344,107 @@ export class ChoiceActionHandler {
     }
 
     return [...targets];
+  }
+
+  /**
+   * P3 (PHASE>=3) click routing.
+   *
+   *   'legacy' — run the pre-P3 code path unchanged.
+   *   'p3'     — use ThreadPanel.resolveChoice / resolveMultiChoice.
+   *   'stale'  — update message to stale marker and drop the dispatch.
+   *
+   * Classification matrix (PHASE>=3 only — PHASE<3 always returns 'legacy'):
+   *
+   *  | payload turnId | pendingChoice | match (turnId+ts) | branch |
+   *  | absent         | absent        | —                 | legacy |
+   *  | present        | absent        | —                 | stale  |
+   *  | absent         | present       | —                 | stale  |
+   *  | present        | present       | yes               | p3     |
+   *  | present        | present       | no                | stale  |
+   */
+  private classifyClick(args: {
+    sessionKey: string;
+    payloadTurnId?: string;
+    messageTs?: string;
+    formId?: string;
+  }): ClickBranch {
+    if (config.ui.fiveBlockPhase < 3) return 'legacy';
+
+    const session = this.ctx.claudeHandler.getSessionByKey(args.sessionKey);
+    const pc = session?.actionPanel?.pendingChoice;
+
+    if (pc) {
+      const turnIdMatches = !!args.payloadTurnId && pc.turnId === args.payloadTurnId;
+      const tsMatches =
+        pc.kind === 'single'
+          ? !!args.messageTs && pc.choiceTs === args.messageTs
+          : !!args.formId && pc.formIds.includes(args.formId);
+      if (turnIdMatches && tsMatches) return 'p3';
+      return 'stale';
+    }
+
+    // No pendingChoice: payload carries P3 identity ⇒ stale (don't resurrect
+    // a click via the ts-union legacy resolver). No P3 identity ⇒ truly
+    // pre-flip legacy message; legacy path is safe.
+    if (args.payloadTurnId) return 'stale';
+    return 'legacy';
+  }
+
+  /** Apply the stale marker to the clicked message. Best-effort (logs on failure). */
+  private async markClickAsStale(channel: string, messageTs: string, sessionKey: string): Promise<void> {
+    if (!channel || !messageTs) return;
+    const staleBlocks = [{ type: 'section', text: { type: 'mrkdwn', text: STALE_CLICK_TEXT } }];
+    try {
+      await this.ctx.slackApi.updateMessage(channel, messageTs, STALE_CLICK_TEXT, staleBlocks, []);
+    } catch (err) {
+      this.logger.warn('markClickAsStale: updateMessage failed', {
+        sessionKey,
+        messageTs,
+        error: (err as Error)?.message ?? String(err),
+      });
+    }
+  }
+
+  /**
+   * Common "click resolved" terminus (P3 single + multi path). Clears the
+   * pendingQuestion, persists+broadcasts, transitions waiting→working, then
+   * deletes tracked completion messages. Caller dispatches to messageHandler
+   * after this returns.
+   */
+  private async afterP3Resolve(session: any, sessionKey: string, channel: string | undefined): Promise<void> {
+    if (session.actionPanel) {
+      session.actionPanel.pendingQuestion = undefined;
+    }
+    try {
+      this.ctx.claudeHandler.getSessionRegistry?.()?.persistAndBroadcast?.(sessionKey);
+    } catch (err) {
+      this.logger.debug('afterP3Resolve: persistAndBroadcast failed', {
+        sessionKey,
+        error: (err as Error)?.message ?? String(err),
+      });
+    }
+    if (channel) {
+      const threadRootTs = session.threadRootTs;
+      this.ctx.completionMessageTracker
+        ?.deleteAll(
+          sessionKey,
+          async (ch, ts) => {
+            if (threadRootTs && ts === threadRootTs) {
+              this.logger.error('BLOCKED: attempted to delete thread root via completion tracker (P3 choice)', {
+                sessionKey,
+                ts,
+                threadRootTs,
+              });
+              return;
+            }
+            try {
+              await this.ctx.slackApi.deleteMessage(ch, ts);
+            } catch {}
+          },
+          channel,
+        )
+        .catch(() => {});
+    }
+    this.ctx.claudeHandler.setActivityStateByKey(sessionKey, 'working');
   }
 }

--- a/src/slack/actions/click-classifier.ts
+++ b/src/slack/actions/click-classifier.ts
@@ -1,0 +1,78 @@
+import type { ClaudeHandler } from '../../claude-handler';
+import { config } from '../../config';
+import type { Logger } from '../../logger';
+import type { SlackApiHelper } from '../slack-api-helper';
+
+/** Stale-click marker shown on a button message after a superseded click. */
+export const STALE_CLICK_TEXT = '⏱️ _이 질문은 더 이상 유효하지 않습니다._';
+
+/** Rollback marker for askUserForm partial-failure. */
+export const FORM_BUILD_FAILED_TEXT = '⏱️ _폼 생성에 실패했습니다._';
+
+/** Supersede marker applied to prior choice messages when a new ask arrives. */
+export const SUPERSEDED_TEXT = '⏱️ _새 질문으로 대체되었습니다._';
+
+export type ClickBranch = 'legacy' | 'p3' | 'stale';
+
+/**
+ * Wrap a marker text in a single-section Slack blocks payload.
+ */
+export function buildMarkerBlocks(text: string): any[] {
+  return [{ type: 'section', text: { type: 'mrkdwn', text } }];
+}
+
+/**
+ * P3 (PHASE>=3) click routing.
+ *
+ *   PHASE<3          → always 'legacy' (ignore any payload turnId)
+ *   PHASE>=3 + pc    → match turnId + ts/formId → 'p3' else 'stale'
+ *   PHASE>=3 + !pc   → payload has turnId → 'stale' (never resurrect via
+ *                      legacy ts-union) else 'legacy' (truly pre-flip)
+ */
+export function classifyClick(
+  claudeHandler: ClaudeHandler,
+  args: {
+    sessionKey: string;
+    payloadTurnId?: string;
+    messageTs?: string;
+    formId?: string;
+  },
+): ClickBranch {
+  if (config.ui.fiveBlockPhase < 3) return 'legacy';
+  const session = claudeHandler.getSessionByKey(args.sessionKey);
+  const pc = session?.actionPanel?.pendingChoice;
+  if (pc) {
+    const turnIdMatches = !!args.payloadTurnId && pc.turnId === args.payloadTurnId;
+    const tsMatches =
+      pc.kind === 'single'
+        ? !!args.messageTs && pc.choiceTs === args.messageTs
+        : !!args.formId && pc.formIds.includes(args.formId);
+    if (turnIdMatches && tsMatches) return 'p3';
+    return 'stale';
+  }
+  if (args.payloadTurnId) return 'stale';
+  return 'legacy';
+}
+
+/**
+ * Apply the stale marker to the clicked message. Best-effort (logs on
+ * failure; never throws).
+ */
+export async function markClickAsStale(
+  slackApi: SlackApiHelper,
+  logger: Logger,
+  channel: string | undefined,
+  messageTs: string | undefined,
+  sessionKey: string,
+): Promise<void> {
+  if (!channel || !messageTs) return;
+  try {
+    await slackApi.updateMessage(channel, messageTs, STALE_CLICK_TEXT, buildMarkerBlocks(STALE_CLICK_TEXT), []);
+  } catch (err) {
+    logger.warn('markClickAsStale: updateMessage failed', {
+      sessionKey,
+      messageTs,
+      error: (err as Error)?.message ?? String(err),
+    });
+  }
+}

--- a/src/slack/actions/form-action-handler.test.ts
+++ b/src/slack/actions/form-action-handler.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config } from '../../config';
 import { FormActionHandler } from './form-action-handler';
 
 describe('FormActionHandler', () => {
@@ -199,5 +200,184 @@ describe('FormActionHandler', () => {
       undefined,
       expect.any(Array),
     );
+  });
+});
+
+describe('FormActionHandler — P3 (PHASE>=3) classifyClick', () => {
+  let slackApi: any;
+  let claudeHandler: any;
+  let messageHandler: any;
+  let threadPanel: any;
+  let formStore: any;
+  let choiceHandler: any;
+  let sessionRegistry: any;
+  let handler: FormActionHandler;
+  const sessionKey = 'C1:thread-root';
+
+  beforeEach(() => {
+    slackApi = {
+      updateMessage: vi.fn().mockResolvedValue(undefined),
+      postMessage: vi.fn().mockResolvedValue({ ts: 'posted' }),
+    };
+    sessionRegistry = { persistAndBroadcast: vi.fn() };
+    claudeHandler = {
+      getSessionByKey: vi.fn(),
+      setActivityStateByKey: vi.fn(),
+      getSessionRegistry: vi.fn(() => sessionRegistry),
+    };
+    messageHandler = vi.fn().mockResolvedValue(undefined);
+    threadPanel = {
+      clearChoice: vi.fn().mockResolvedValue(undefined),
+      attachChoice: vi.fn().mockResolvedValue(undefined),
+      resolveChoice: vi.fn().mockResolvedValue(true),
+      resolveMultiChoice: vi.fn().mockResolvedValue(true),
+    };
+    formStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+    choiceHandler = { completeMultiChoiceForm: vi.fn().mockResolvedValue(undefined) };
+    handler = new FormActionHandler(
+      { slackApi, claudeHandler, messageHandler, threadPanel } as any,
+      formStore,
+      choiceHandler as any,
+    );
+  });
+
+  afterEach(() => {
+    config.ui.fiveBlockPhase = 0;
+  });
+
+  it('handleCustomInputSingle inherits turnId into private_metadata', async () => {
+    config.ui.fiveBlockPhase = 3;
+    claudeHandler.getSessionByKey.mockReturnValue({ threadRootTs: 'tr', threadTs: 'tr' });
+    const views = { open: vi.fn().mockResolvedValue(undefined) };
+    const client = { views };
+    const body = {
+      trigger_id: 'trig',
+      actions: [
+        {
+          value: JSON.stringify({ sessionKey, question: 'Q', type: 'single', turnId: 't1' }),
+        },
+      ],
+      channel: { id: 'C1' },
+      message: { ts: 'msg-1' },
+    };
+    await handler.handleCustomInputSingle(body, client);
+    const view = views.open.mock.calls[0][0].view;
+    const pm = JSON.parse(view.private_metadata);
+    expect(pm.turnId).toBe('t1');
+  });
+
+  it('handleCustomInputSubmit single P3 stale → marks message and no dispatch', async () => {
+    config.ui.fiveBlockPhase = 3;
+    claudeHandler.getSessionByKey.mockReturnValue({
+      channelId: 'C1',
+      threadRootTs: 'tr',
+      threadTs: 'tr',
+      actionPanel: { pendingChoice: { turnId: 'tOTHER', kind: 'single', choiceTs: 'msg-1', formIds: [] } },
+    });
+    const body = { user: { id: 'U1' } };
+    const view = {
+      private_metadata: JSON.stringify({
+        sessionKey,
+        question: 'Q',
+        channel: 'C1',
+        messageTs: 'msg-1',
+        threadTs: 'tr',
+        type: 'single',
+        turnId: 't1',
+      }),
+      state: { values: { custom_input_block: { custom_input_text: { value: 'hello' } } } },
+    };
+    await handler.handleCustomInputSubmit(body, view);
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      'msg-1',
+      expect.stringContaining('더 이상 유효하지 않습니다'),
+      expect.any(Array),
+      [],
+    );
+    expect(messageHandler).not.toHaveBeenCalled();
+    expect(threadPanel.resolveChoice).not.toHaveBeenCalled();
+  });
+
+  it('handleCustomInputSubmit single P3 matching → resolveChoice + dispatch', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = {
+      channelId: 'C1',
+      threadRootTs: 'tr',
+      threadTs: 'tr',
+      actionPanel: {
+        pendingChoice: { turnId: 't1', kind: 'single', choiceTs: 'msg-1', formIds: [] },
+        pendingQuestion: { type: 'user_choice' },
+      },
+    };
+    claudeHandler.getSessionByKey.mockReturnValue(session);
+    const body = { user: { id: 'U1' } };
+    const view = {
+      private_metadata: JSON.stringify({
+        sessionKey,
+        question: 'Q',
+        channel: 'C1',
+        messageTs: 'msg-1',
+        threadTs: 'tr',
+        type: 'single',
+        turnId: 't1',
+      }),
+      state: { values: { custom_input_block: { custom_input_text: { value: 'hello' } } } },
+    };
+    await handler.handleCustomInputSubmit(body, view);
+    expect(threadPanel.resolveChoice).toHaveBeenCalledWith(
+      session,
+      sessionKey,
+      'C1',
+      expect.any(String),
+      expect.any(Array),
+    );
+    expect(messageHandler).toHaveBeenCalled();
+    expect(session.actionPanel.pendingQuestion).toBeUndefined();
+  });
+
+  it('multi custom-input P3 stale → marks message and no dispatch', async () => {
+    config.ui.fiveBlockPhase = 3;
+    formStore.get.mockReturnValue({
+      formId: 'f1',
+      sessionKey,
+      questions: [{ id: 'q1', question: 'Q1', choices: [] }],
+      selections: {},
+      messageTs: 'msg-f',
+      turnId: 'tOTHER',
+      createdAt: Date.now(),
+      channel: 'C1',
+      threadTs: 'tr',
+    });
+    claudeHandler.getSessionByKey.mockReturnValue({
+      channelId: 'C1',
+      threadRootTs: 'tr',
+      threadTs: 'tr',
+      actionPanel: { pendingChoice: { turnId: 't1', kind: 'multi', choiceTs: 'msg-f', formIds: ['f1'] } },
+    });
+    const body = { user: { id: 'U1' } };
+    const view = {
+      private_metadata: JSON.stringify({
+        sessionKey,
+        question: 'Q1',
+        channel: 'C1',
+        messageTs: 'msg-1',
+        threadTs: 'tr',
+        type: 'multi',
+        formId: 'f1',
+        questionId: 'q1',
+      }),
+      state: { values: { custom_input_block: { custom_input_text: { value: 'custom-answer' } } } },
+    };
+    await handler.handleCustomInputSubmit(body, view);
+    // stale branch: marks msg-1 stale; no selection stored on form; no completion call
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      'msg-1',
+      expect.stringContaining('더 이상 유효하지 않습니다'),
+      expect.any(Array),
+      [],
+    );
+    expect(choiceHandler.completeMultiChoiceForm).not.toHaveBeenCalled();
   });
 });

--- a/src/slack/actions/form-action-handler.ts
+++ b/src/slack/actions/form-action-handler.ts
@@ -1,4 +1,5 @@
 import type { ClaudeHandler } from '../../claude-handler';
+import { config } from '../../config';
 import { Logger } from '../../logger';
 import type { UserChoices } from '../../types';
 import type { SlackApiHelper } from '../slack-api-helper';
@@ -7,6 +8,9 @@ import { UserChoiceHandler } from '../user-choice-handler';
 import type { ChoiceActionHandler } from './choice-action-handler';
 import type { PendingFormStore } from './pending-form-store';
 import { type MessageHandler, PendingChoiceFormData, type SayFn } from './types';
+
+/** Stale-click marker (must match ChoiceActionHandler). */
+const STALE_CLICK_TEXT = '⏱️ _이 질문은 더 이상 유효하지 않습니다._';
 
 interface FormActionContext {
   slackApi: SlackApiHelper;
@@ -31,7 +35,7 @@ export class FormActionHandler {
     try {
       const action = body.actions[0];
       const valueData = JSON.parse(action.value);
-      const { sessionKey, question } = valueData;
+      const { sessionKey, question, turnId: payloadTurnId } = valueData;
       const triggerId = body.trigger_id;
       const channel = body.channel?.id;
       const messageTs = body.message?.ts;
@@ -40,7 +44,17 @@ export class FormActionHandler {
 
       await client.views.open({
         trigger_id: triggerId,
-        view: this.buildCustomInputModal(sessionKey, question, channel, messageTs, threadTs, 'single'),
+        view: this.buildCustomInputModal(
+          sessionKey,
+          question,
+          channel,
+          messageTs,
+          threadTs,
+          'single',
+          undefined,
+          undefined,
+          payloadTurnId,
+        ),
       });
     } catch (error) {
       this.logger.error('Error opening custom input modal', error);
@@ -58,6 +72,10 @@ export class FormActionHandler {
       const fallbackThreadTs = body.message?.thread_ts || messageTs;
       const threadTs = this.resolveSessionThreadTs(sessionKey, fallbackThreadTs);
 
+      // P3 (PHASE>=3): inherit turnId from the PendingFormStore record so the
+      // modal submission path can classify stale vs live clicks.
+      const pendingForm = this.formStore.get(formId);
+
       await client.views.open({
         trigger_id: triggerId,
         view: this.buildCustomInputModal(
@@ -69,6 +87,7 @@ export class FormActionHandler {
           'multi',
           formId,
           questionId,
+          pendingForm?.turnId,
         ),
       });
     } catch (error) {
@@ -79,7 +98,7 @@ export class FormActionHandler {
   async handleCustomInputSubmit(body: any, view: any): Promise<void> {
     try {
       const metadata = JSON.parse(view.private_metadata);
-      const { sessionKey, question, channel, messageTs, threadTs, type, formId, questionId } = metadata;
+      const { sessionKey, question, channel, messageTs, threadTs, type, formId, questionId, turnId } = metadata;
       const userId = body.user.id;
       const inputValue = view.state.values.custom_input_block.custom_input_text.value || '';
 
@@ -92,7 +111,16 @@ export class FormActionHandler {
       });
 
       if (type === 'single') {
-        await this.handleSingleCustomInput(sessionKey, question, channel, messageTs, threadTs, userId, inputValue);
+        await this.handleSingleCustomInput(
+          sessionKey,
+          question,
+          channel,
+          messageTs,
+          threadTs,
+          userId,
+          inputValue,
+          turnId,
+        );
       } else if (type === 'multi') {
         await this.handleMultiCustomInput(
           formId,
@@ -119,21 +147,69 @@ export class FormActionHandler {
     threadTs: string | undefined,
     userId: string,
     inputValue: string,
+    payloadTurnId?: string,
   ): Promise<void> {
+    const session = this.ctx.claudeHandler.getSessionByKey(sessionKey);
+    const completedText = `✅ *${question}*\n직접 입력: _${inputValue.substring(0, 200)}${inputValue.length > 200 ? '...' : ''}_`;
+    const completedBlocks = [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: completedText },
+      },
+    ];
+
+    // P3 (PHASE>=3) classifier — reuse the same matrix as ChoiceActionHandler.
+    const branch = this.classifyClick({ sessionKey, payloadTurnId, messageTs });
+
+    if (branch === 'stale') {
+      this.logger.info('Custom input (single) click classified as stale — marking and returning', {
+        sessionKey,
+        payloadTurnId,
+      });
+      if (channel && messageTs) {
+        await this.markClickAsStale(channel, messageTs, sessionKey);
+      }
+      return;
+    }
+
+    if (branch === 'p3' && session && channel) {
+      const resolved = await this.ctx.threadPanel
+        ?.resolveChoice(session, sessionKey, channel, completedText, completedBlocks)
+        .catch((err) => {
+          this.logger.warn('resolveChoice (custom input) threw — falling back to legacy', {
+            sessionKey,
+            error: (err as Error)?.message ?? String(err),
+          });
+          return false;
+        });
+      if (resolved) {
+        if (session.actionPanel) {
+          session.actionPanel.pendingQuestion = undefined;
+        }
+        try {
+          this.ctx.claudeHandler.getSessionRegistry?.()?.persistAndBroadcast?.(sessionKey);
+        } catch (err) {
+          this.logger.debug('handleSingleCustomInput: persistAndBroadcast failed', {
+            sessionKey,
+            error: (err as Error)?.message ?? String(err),
+          });
+        }
+        this.ctx.claudeHandler.setActivityStateByKey(sessionKey, 'working');
+        const say = this.createSayFn(channel);
+        const resolvedThreadTs = this.resolveSessionThreadTs(sessionKey, threadTs);
+        await this.ctx.messageHandler(
+          { user: userId, channel, thread_ts: resolvedThreadTs, ts: messageTs, text: inputValue },
+          say,
+        );
+        return;
+      }
+      // Fall through to legacy below.
+    }
+
     const completionMessageTs = this.resolveChoiceMessageTs(sessionKey, messageTs);
 
     // 메시지 업데이트 (모든 동기화 대상에 대해)
     if (channel) {
-      const completedText = `✅ *${question}*\n직접 입력: _${inputValue.substring(0, 200)}${inputValue.length > 200 ? '...' : ''}_`;
-      const completedBlocks = [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: completedText,
-          },
-        },
-      ];
       const targetTimestamps = this.resolveChoiceSyncMessageTs(sessionKey, messageTs, completionMessageTs);
       for (const targetTs of targetTimestamps) {
         try {
@@ -151,7 +227,6 @@ export class FormActionHandler {
     }
 
     // Claude에 전송
-    const session = this.ctx.claudeHandler.getSessionByKey(sessionKey);
     if (session) {
       await this.ctx.threadPanel?.clearChoice(sessionKey);
       // TODO: Delete tracked completion messages on custom input submission
@@ -186,6 +261,25 @@ export class FormActionHandler {
       return;
     }
 
+    // P3 (PHASE>=3) classifier — turnId comes from the pendingForm record
+    // (multi button values don't carry turnId).
+    const branch = this.classifyClick({
+      sessionKey,
+      payloadTurnId: pendingForm.turnId,
+      formId,
+    });
+    if (branch === 'stale') {
+      this.logger.info('Custom input (multi) click classified as stale — marking and returning', {
+        sessionKey,
+        formId,
+        questionId,
+      });
+      if (channel && messageTs) {
+        await this.markClickAsStale(channel, messageTs, sessionKey);
+      }
+      return;
+    }
+
     // 선택 저장
     pendingForm.selections[questionId] = {
       choiceId: '직접입력',
@@ -208,27 +302,49 @@ export class FormActionHandler {
       pendingForm.selections,
     );
 
-    const targetMessageTs = this.resolveChoiceSyncMessageTs(sessionKey, messageTs, pendingForm.messageTs);
-    for (const targetTs of targetMessageTs) {
-      try {
-        await this.ctx.slackApi.updateMessage(
-          channel,
-          targetTs,
-          '📋 선택이 필요합니다',
-          undefined,
-          updatedPayload.attachments,
-        );
-      } catch (error) {
-        this.logger.warn('Failed to update multi-choice form after custom input', {
-          targetTs,
-          error,
-        });
+    if (branch === 'p3') {
+      // P3: single-ts update on the form's own messageTs. Avoid the ts-union
+      // resolver so we don't rewrite thread header / unrelated chunks.
+      if (channel && pendingForm.messageTs) {
+        try {
+          await this.ctx.slackApi.updateMessage(
+            channel,
+            pendingForm.messageTs,
+            '📋 선택이 필요합니다',
+            undefined,
+            updatedPayload.attachments,
+          );
+        } catch (error) {
+          this.logger.warn('Failed to update multi-choice form after custom input (P3)', {
+            formId,
+            error,
+          });
+        }
       }
+    } else {
+      const targetMessageTs = this.resolveChoiceSyncMessageTs(sessionKey, messageTs, pendingForm.messageTs);
+      for (const targetTs of targetMessageTs) {
+        try {
+          await this.ctx.slackApi.updateMessage(
+            channel,
+            targetTs,
+            '📋 선택이 필요합니다',
+            undefined,
+            updatedPayload.attachments,
+          );
+        } catch (error) {
+          this.logger.warn('Failed to update multi-choice form after custom input', {
+            targetTs,
+            error,
+          });
+        }
+      }
+
+      await this.ctx.threadPanel?.attachChoice(sessionKey, updatedPayload, pendingForm.messageTs);
     }
 
-    await this.ctx.threadPanel?.attachChoice(sessionKey, updatedPayload, pendingForm.messageTs);
-
-    // 모든 질문 완료 시
+    // 모든 질문 완료 시 — delegate to ChoiceActionHandler.completeMultiChoiceForm,
+    // which already routes through ThreadPanel.resolveMultiChoice under P3.
     if (answeredCount === totalQuestions) {
       const resolvedThreadTs = this.resolveSessionThreadTs(sessionKey, threadTs);
       await this.choiceHandler.completeMultiChoiceForm(pendingForm, userId, channel, resolvedThreadTs, messageTs);
@@ -244,6 +360,7 @@ export class FormActionHandler {
     type: 'single' | 'multi',
     formId?: string,
     questionId?: string,
+    turnId?: string,
   ): any {
     return {
       type: 'modal',
@@ -257,6 +374,7 @@ export class FormActionHandler {
         type,
         formId,
         questionId,
+        ...(turnId ? { turnId } : {}),
       }),
       title: {
         type: 'plain_text',
@@ -343,5 +461,49 @@ export class FormActionHandler {
         attachments: msgArgs.attachments,
       });
     };
+  }
+
+  /**
+   * P3 (PHASE>=3) click routing — mirror of ChoiceActionHandler.classifyClick.
+   * Kept local to this handler so FormActionHandler has no direct dependency
+   * on ChoiceActionHandler internals.
+   */
+  private classifyClick(args: {
+    sessionKey: string;
+    payloadTurnId?: string;
+    messageTs?: string;
+    formId?: string;
+  }): 'legacy' | 'p3' | 'stale' {
+    if (config.ui.fiveBlockPhase < 3) return 'legacy';
+
+    const session = this.ctx.claudeHandler.getSessionByKey(args.sessionKey);
+    const pc = session?.actionPanel?.pendingChoice;
+
+    if (pc) {
+      const turnIdMatches = !!args.payloadTurnId && pc.turnId === args.payloadTurnId;
+      const tsMatches =
+        pc.kind === 'single'
+          ? !!args.messageTs && pc.choiceTs === args.messageTs
+          : !!args.formId && pc.formIds.includes(args.formId);
+      if (turnIdMatches && tsMatches) return 'p3';
+      return 'stale';
+    }
+
+    if (args.payloadTurnId) return 'stale';
+    return 'legacy';
+  }
+
+  private async markClickAsStale(channel: string, messageTs: string, sessionKey: string): Promise<void> {
+    if (!channel || !messageTs) return;
+    const staleBlocks = [{ type: 'section', text: { type: 'mrkdwn', text: STALE_CLICK_TEXT } }];
+    try {
+      await this.ctx.slackApi.updateMessage(channel, messageTs, STALE_CLICK_TEXT, staleBlocks, []);
+    } catch (err) {
+      this.logger.warn('markClickAsStale: updateMessage failed', {
+        sessionKey,
+        messageTs,
+        error: (err as Error)?.message ?? String(err),
+      });
+    }
   }
 }

--- a/src/slack/actions/form-action-handler.ts
+++ b/src/slack/actions/form-action-handler.ts
@@ -1,16 +1,13 @@
 import type { ClaudeHandler } from '../../claude-handler';
-import { config } from '../../config';
 import { Logger } from '../../logger';
 import type { UserChoices } from '../../types';
 import type { SlackApiHelper } from '../slack-api-helper';
 import type { ThreadPanel } from '../thread-panel';
 import { UserChoiceHandler } from '../user-choice-handler';
 import type { ChoiceActionHandler } from './choice-action-handler';
+import { classifyClick, markClickAsStale } from './click-classifier';
 import type { PendingFormStore } from './pending-form-store';
 import { type MessageHandler, PendingChoiceFormData, type SayFn } from './types';
-
-/** Stale-click marker (must match ChoiceActionHandler). */
-const STALE_CLICK_TEXT = '⏱️ _이 질문은 더 이상 유효하지 않습니다._';
 
 interface FormActionContext {
   slackApi: SlackApiHelper;
@@ -159,7 +156,7 @@ export class FormActionHandler {
     ];
 
     // P3 (PHASE>=3) classifier — reuse the same matrix as ChoiceActionHandler.
-    const branch = this.classifyClick({ sessionKey, payloadTurnId, messageTs });
+    const branch = classifyClick(this.ctx.claudeHandler, { sessionKey, payloadTurnId, messageTs });
 
     if (branch === 'stale') {
       this.logger.info('Custom input (single) click classified as stale — marking and returning', {
@@ -167,7 +164,7 @@ export class FormActionHandler {
         payloadTurnId,
       });
       if (channel && messageTs) {
-        await this.markClickAsStale(channel, messageTs, sessionKey);
+        await markClickAsStale(this.ctx.slackApi, this.logger, channel, messageTs, sessionKey);
       }
       return;
     }
@@ -263,7 +260,7 @@ export class FormActionHandler {
 
     // P3 (PHASE>=3) classifier — turnId comes from the pendingForm record
     // (multi button values don't carry turnId).
-    const branch = this.classifyClick({
+    const branch = classifyClick(this.ctx.claudeHandler, {
       sessionKey,
       payloadTurnId: pendingForm.turnId,
       formId,
@@ -274,9 +271,7 @@ export class FormActionHandler {
         formId,
         questionId,
       });
-      if (channel && messageTs) {
-        await this.markClickAsStale(channel, messageTs, sessionKey);
-      }
+      await markClickAsStale(this.ctx.slackApi, this.logger, channel, messageTs, sessionKey);
       return;
     }
 
@@ -461,49 +456,5 @@ export class FormActionHandler {
         attachments: msgArgs.attachments,
       });
     };
-  }
-
-  /**
-   * P3 (PHASE>=3) click routing — mirror of ChoiceActionHandler.classifyClick.
-   * Kept local to this handler so FormActionHandler has no direct dependency
-   * on ChoiceActionHandler internals.
-   */
-  private classifyClick(args: {
-    sessionKey: string;
-    payloadTurnId?: string;
-    messageTs?: string;
-    formId?: string;
-  }): 'legacy' | 'p3' | 'stale' {
-    if (config.ui.fiveBlockPhase < 3) return 'legacy';
-
-    const session = this.ctx.claudeHandler.getSessionByKey(args.sessionKey);
-    const pc = session?.actionPanel?.pendingChoice;
-
-    if (pc) {
-      const turnIdMatches = !!args.payloadTurnId && pc.turnId === args.payloadTurnId;
-      const tsMatches =
-        pc.kind === 'single'
-          ? !!args.messageTs && pc.choiceTs === args.messageTs
-          : !!args.formId && pc.formIds.includes(args.formId);
-      if (turnIdMatches && tsMatches) return 'p3';
-      return 'stale';
-    }
-
-    if (args.payloadTurnId) return 'stale';
-    return 'legacy';
-  }
-
-  private async markClickAsStale(channel: string, messageTs: string, sessionKey: string): Promise<void> {
-    if (!channel || !messageTs) return;
-    const staleBlocks = [{ type: 'section', text: { type: 'mrkdwn', text: STALE_CLICK_TEXT } }];
-    try {
-      await this.ctx.slackApi.updateMessage(channel, messageTs, STALE_CLICK_TEXT, staleBlocks, []);
-    } catch (err) {
-      this.logger.warn('markClickAsStale: updateMessage failed', {
-        sessionKey,
-        messageTs,
-        error: (err as Error)?.message ?? String(err),
-      });
-    }
   }
 }

--- a/src/slack/actions/types.ts
+++ b/src/slack/actions/types.ts
@@ -29,6 +29,10 @@ export interface PendingChoiceFormData {
   questions: UserChoiceQuestion[];
   selections: Record<string, { choiceId: string; label: string }>;
   createdAt: number;
+  /** P3 (PHASE>=3) — turn id that owns this form. Used by click handlers to
+   * classify stale vs live clicks. Populated under PHASE>=3; undefined for
+   * legacy PHASE<3 forms. */
+  turnId?: string;
   /**
    * Submission lock for hero "Submit All Recommended" — set to true while
    * `completeMultiChoiceForm` is in flight. Cross-surface lock (Slack ↔ dashboard).

--- a/src/slack/choice-message-builder.test.ts
+++ b/src/slack/choice-message-builder.test.ts
@@ -621,3 +621,80 @@ describe('ChoiceMessageBuilder.buildMultiChoiceFormBlocks — hero "Submit All R
     expect(hero.elements[0].text.text).toBe('🔒 추천 부족 (1/7)');
   });
 });
+
+describe('ChoiceMessageBuilder — P3 (PHASE>=3) turnId in button values', () => {
+  it('buildUserChoiceBlocks embeds turnId in every option button value when provided', () => {
+    const choice: UserChoice = {
+      type: 'user_choice',
+      question: 'Q?',
+      choices: [
+        { id: '1', label: 'A' },
+        { id: '2', label: 'B' },
+      ],
+    };
+    const payload = ChoiceMessageBuilder.buildUserChoiceBlocks(choice, 'sk-x', 'default', 'turn-abc');
+    const blocks = (payload.attachments?.[0] as any).blocks;
+    const buttons = blocks
+      .flatMap((b: any) => (b.type === 'actions' ? b.elements : []))
+      .filter((el: any) => el?.action_id?.startsWith('user_choice_'));
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const btn of buttons) {
+      const v = JSON.parse(btn.value);
+      expect(v.turnId).toBe('turn-abc');
+      expect(v.sessionKey).toBe('sk-x');
+    }
+  });
+
+  it('buildUserChoiceBlocks omits turnId key when not provided (legacy byte-identical)', () => {
+    const choice: UserChoice = {
+      type: 'user_choice',
+      question: 'Q?',
+      choices: [{ id: '1', label: 'A' }],
+    };
+    const payload = ChoiceMessageBuilder.buildUserChoiceBlocks(choice, 'sk-x');
+    const blocks = (payload.attachments?.[0] as any).blocks;
+    const btn = blocks
+      .flatMap((b: any) => (b.type === 'actions' ? b.elements : []))
+      .find((el: any) => el?.action_id === 'user_choice_1');
+    const v = JSON.parse(btn.value);
+    expect('turnId' in v).toBe(false);
+    expect(Object.keys(v).sort()).toEqual(['choiceId', 'label', 'question', 'sessionKey']);
+  });
+
+  it('custom-input button embeds turnId when provided, omits when not', () => {
+    const withTurn: UserChoice = {
+      type: 'user_choice',
+      question: 'Q?',
+      choices: [{ id: '1', label: 'A' }],
+    };
+    const p1 = ChoiceMessageBuilder.buildUserChoiceBlocks(withTurn, 'sk-x', 'default', 'turn-z');
+    const p2 = ChoiceMessageBuilder.buildUserChoiceBlocks(withTurn, 'sk-x');
+    const blocksWith = (p1.attachments?.[0] as any).blocks;
+    const blocksNo = (p2.attachments?.[0] as any).blocks;
+    const customWith = blocksWith
+      .flatMap((b: any) => (b.type === 'actions' ? b.elements : []))
+      .find((el: any) => el?.action_id === 'custom_input_single');
+    const customNo = blocksNo
+      .flatMap((b: any) => (b.type === 'actions' ? b.elements : []))
+      .find((el: any) => el?.action_id === 'custom_input_single');
+    expect(customWith).toBeDefined();
+    expect(customNo).toBeDefined();
+    expect(JSON.parse(customWith!.value).turnId).toBe('turn-z');
+    expect('turnId' in JSON.parse(customNo!.value)).toBe(false);
+  });
+
+  it('hero button shape UNCHANGED under P3 (turnId not added)', () => {
+    const choices: UserChoices = {
+      type: 'user_choices',
+      questions: [{ id: 'q1', question: 'Q1?', recommendedChoiceId: '1', choices: [{ id: '1', label: 'A' }] }],
+    };
+    const payload = ChoiceMessageBuilder.buildMultiChoiceFormBlocks(choices, 'F-X', 'sk-X');
+    const blocks = (payload.attachments?.[0] as any).blocks;
+    const hero = blocks.find(
+      (b: any) => b.type === 'actions' && b.elements?.[0]?.action_id?.startsWith('submit_all_recommended'),
+    );
+    expect(hero).toBeDefined();
+    const v = JSON.parse(hero.elements[0].value);
+    expect(Object.keys(v).sort()).toEqual(['formId', 'm', 'n', 'sessionKey']);
+  });
+});

--- a/src/slack/choice-message-builder.ts
+++ b/src/slack/choice-message-builder.ts
@@ -88,7 +88,7 @@ export class ChoiceMessageBuilder {
    *   When ONLY the recommended exists (no others): banner → rec actions → custom_input own row.
    * When no recommended: a single actions block with all buttons + custom_input (legacy behavior).
    */
-  private static buildSingleChoiceActionBlocks(choice: UserChoice, sessionKey: string): any[] {
+  private static buildSingleChoiceActionBlocks(choice: UserChoice, sessionKey: string, turnId?: string): any[] {
     const rawOptions = choice.choices.slice(0, 4);
     const recId = ChoiceMessageBuilder.resolveRecommendedId(choice.recommendedChoiceId, rawOptions);
     const sanitized = rawOptions.map((o) => ChoiceMessageBuilder.sanitizeLabel(o));
@@ -99,9 +99,9 @@ export class ChoiceMessageBuilder {
     if (recommended.length === 0) {
       // Legacy single-row path
       const buttons = sanitized.map((opt, idx) =>
-        ChoiceMessageBuilder.buildChoiceButton(opt, idx, sessionKey, choice.question, false),
+        ChoiceMessageBuilder.buildChoiceButton(opt, idx, sessionKey, choice.question, false, turnId),
       );
-      buttons.push(ChoiceMessageBuilder.buildCustomInputButton(sessionKey, choice.question));
+      buttons.push(ChoiceMessageBuilder.buildCustomInputButton(sessionKey, choice.question, turnId));
       blocks.push({ type: 'actions', elements: buttons });
       return blocks;
     }
@@ -119,7 +119,7 @@ export class ChoiceMessageBuilder {
 
     // Solo rec actions row (primary-styled)
     const recButtons = recommended.map(({ opt, origIndex }) =>
-      ChoiceMessageBuilder.buildChoiceButton(opt, origIndex, sessionKey, choice.question, true),
+      ChoiceMessageBuilder.buildChoiceButton(opt, origIndex, sessionKey, choice.question, true, turnId),
     );
     blocks.push({ type: 'actions', elements: recButtons });
 
@@ -127,16 +127,16 @@ export class ChoiceMessageBuilder {
       // Only recommended — custom input on its own actions row
       blocks.push({
         type: 'actions',
-        elements: [ChoiceMessageBuilder.buildCustomInputButton(sessionKey, choice.question)],
+        elements: [ChoiceMessageBuilder.buildCustomInputButton(sessionKey, choice.question, turnId)],
       });
       return blocks;
     }
 
     blocks.push({ type: 'divider' });
     const otherButtons = others.map(({ opt, origIndex }) =>
-      ChoiceMessageBuilder.buildChoiceButton(opt, origIndex, sessionKey, choice.question, false),
+      ChoiceMessageBuilder.buildChoiceButton(opt, origIndex, sessionKey, choice.question, false, turnId),
     );
-    otherButtons.push(ChoiceMessageBuilder.buildCustomInputButton(sessionKey, choice.question));
+    otherButtons.push(ChoiceMessageBuilder.buildCustomInputButton(sessionKey, choice.question, turnId));
     blocks.push({ type: 'actions', elements: otherButtons });
 
     return blocks;
@@ -149,6 +149,7 @@ export class ChoiceMessageBuilder {
     sessionKey: string,
     question: string,
     isPrimary: boolean,
+    turnId?: string,
   ): any {
     const btn: any = {
       type: 'button',
@@ -162,6 +163,7 @@ export class ChoiceMessageBuilder {
         choiceId: opt.id,
         label: opt.label,
         question,
+        ...(turnId ? { turnId } : {}),
       }),
       action_id: `user_choice_${opt.id}`,
     };
@@ -175,17 +177,22 @@ export class ChoiceMessageBuilder {
    * Build Slack attachment for single user choice (Jira-style card UI)
    * Dispatches to themed layout builders based on theme parameter.
    */
-  static buildUserChoiceBlocks(choice: UserChoice, sessionKey: string, theme?: SessionTheme): SlackMessagePayload {
+  static buildUserChoiceBlocks(
+    choice: UserChoice,
+    sessionKey: string,
+    theme?: SessionTheme,
+    turnId?: string,
+  ): SlackMessagePayload {
     const resolvedTheme = theme ?? 'default';
 
     switch (resolvedTheme) {
       case 'compact':
-        return ChoiceMessageBuilder.buildThemeCompact(choice, sessionKey);
+        return ChoiceMessageBuilder.buildThemeCompact(choice, sessionKey, turnId);
       case 'minimal':
-        return ChoiceMessageBuilder.buildThemeMinimal(choice, sessionKey);
+        return ChoiceMessageBuilder.buildThemeMinimal(choice, sessionKey, turnId);
       case 'default':
       default:
-        return ChoiceMessageBuilder.buildThemeDefault(choice, sessionKey);
+        return ChoiceMessageBuilder.buildThemeDefault(choice, sessionKey, turnId);
     }
   }
 
@@ -193,7 +200,7 @@ export class ChoiceMessageBuilder {
   // Helper: build standard action buttons (shared across themes)
   // ---------------------------------------------------------------------------
 
-  private static buildCustomInputButton(sessionKey: string, question: string): any {
+  private static buildCustomInputButton(sessionKey: string, question: string, turnId?: string): any {
     return {
       type: 'button',
       text: {
@@ -205,6 +212,7 @@ export class ChoiceMessageBuilder {
         sessionKey,
         question,
         type: 'single',
+        ...(turnId ? { turnId } : {}),
       }),
       action_id: 'custom_input_single',
     };
@@ -226,7 +234,7 @@ export class ChoiceMessageBuilder {
   // Based on former Theme D
   // ---------------------------------------------------------------------------
 
-  private static buildThemeDefault(choice: UserChoice, sessionKey: string): SlackMessagePayload {
+  private static buildThemeDefault(choice: UserChoice, sessionKey: string, turnId?: string): SlackMessagePayload {
     const attachmentBlocks: any[] = [];
 
     // Title with emoji
@@ -283,7 +291,7 @@ export class ChoiceMessageBuilder {
       }
     }
 
-    attachmentBlocks.push(...ChoiceMessageBuilder.buildSingleChoiceActionBlocks(choice, sessionKey));
+    attachmentBlocks.push(...ChoiceMessageBuilder.buildSingleChoiceActionBlocks(choice, sessionKey, turnId));
 
     return {
       attachments: [
@@ -300,7 +308,7 @@ export class ChoiceMessageBuilder {
   // Based on former Theme C
   // ---------------------------------------------------------------------------
 
-  private static buildThemeCompact(choice: UserChoice, sessionKey: string): SlackMessagePayload {
+  private static buildThemeCompact(choice: UserChoice, sessionKey: string, turnId?: string): SlackMessagePayload {
     const blocks: any[] = [];
 
     blocks.push({
@@ -325,7 +333,7 @@ export class ChoiceMessageBuilder {
       });
     }
 
-    blocks.push(...ChoiceMessageBuilder.buildSingleChoiceActionBlocks(choice, sessionKey));
+    blocks.push(...ChoiceMessageBuilder.buildSingleChoiceActionBlocks(choice, sessionKey, turnId));
 
     return ChoiceMessageBuilder.wrapAttachment(blocks);
   }
@@ -335,7 +343,7 @@ export class ChoiceMessageBuilder {
   // Based on former Theme A
   // ---------------------------------------------------------------------------
 
-  private static buildThemeMinimal(choice: UserChoice, sessionKey: string): SlackMessagePayload {
+  private static buildThemeMinimal(choice: UserChoice, sessionKey: string, turnId?: string): SlackMessagePayload {
     const blocks: any[] = [];
 
     blocks.push({
@@ -362,7 +370,7 @@ export class ChoiceMessageBuilder {
       });
     }
 
-    blocks.push(...ChoiceMessageBuilder.buildSingleChoiceActionBlocks(choice, sessionKey));
+    blocks.push(...ChoiceMessageBuilder.buildSingleChoiceActionBlocks(choice, sessionKey, turnId));
 
     return ChoiceMessageBuilder.wrapAttachment(blocks);
   }

--- a/src/slack/pipeline/stream-executor.test.ts
+++ b/src/slack/pipeline/stream-executor.test.ts
@@ -82,6 +82,7 @@ vi.mock('../../token-manager', () => ({
   parseCooldownTime: vi.fn(),
 }));
 
+import { config } from '../../config';
 import type { Continuation } from '../../types';
 import { userSettingsStore } from '../../user-settings-store';
 import { type ExecuteResult, StreamExecutor } from './stream-executor';
@@ -2915,5 +2916,347 @@ describe('turnId propagation into ToolEventContext (#664)', () => {
     // turnId from the outer scope. Independently-minted ids would still
     // pass assertions 1 and 2 while silently decoupling the sink.
     expect(toolUseCtx.turnId).toBe(toolResultCtx.turnId);
+  });
+});
+
+describe('stream-executor — P3 (PHASE>=3) B3 choice wiring', () => {
+  function createP3Deps() {
+    const sessionRegistry = { persistAndBroadcast: vi.fn() };
+    return {
+      deps: {
+        claudeHandler: {
+          setActivityState: vi.fn(),
+          updateSessionResources: vi.fn(),
+          getSessionByKey: vi.fn().mockReturnValue({ ownerId: 'U1', channelId: 'C1' }),
+          getSessionRegistry: vi.fn(() => sessionRegistry),
+        },
+        fileHandler: { cleanupTempFiles: vi.fn().mockResolvedValue(undefined) },
+        toolEventProcessor: {},
+        statusReporter: {
+          updateStatusDirect: vi.fn().mockResolvedValue(undefined),
+          getStatusEmoji: vi.fn().mockReturnValue('stop_button'),
+        },
+        reactionManager: { updateReaction: vi.fn().mockResolvedValue(undefined) },
+        contextWindowManager: { handlePromptTooLong: vi.fn().mockResolvedValue(undefined) },
+        toolTracker: { scheduleCleanup: vi.fn() },
+        todoDisplayManager: { cleanup: vi.fn(), cleanupSession: vi.fn() },
+        actionHandlers: {
+          setPendingForm: vi.fn(),
+          getPendingForm: vi.fn(),
+          deletePendingForm: vi.fn(),
+          invalidateOldForms: vi.fn().mockResolvedValue(undefined),
+        },
+        requestCoordinator: { removeController: vi.fn() },
+        slackApi: { updateMessage: vi.fn().mockResolvedValue(undefined) },
+        assistantStatusManager: { clearStatus: vi.fn().mockResolvedValue(undefined) },
+        threadPanel: {
+          attachChoice: vi.fn().mockResolvedValue(undefined),
+          updatePanel: vi.fn().mockResolvedValue(undefined),
+          setStatus: vi.fn().mockResolvedValue(undefined),
+          askUser: vi.fn().mockResolvedValue({ ok: true, primaryTs: 'posted-ts' }),
+          askUserForm: vi
+            .fn()
+            .mockResolvedValue({ ok: true, primaryTs: 'posted-ts-0', allTs: ['posted-ts-0'], formIds: ['f-0'] }),
+        },
+      } as any,
+      sessionRegistry,
+    };
+  }
+
+  function createSession(): any {
+    return {
+      ownerId: 'U1',
+      channelId: 'C1',
+      threadTs: '171.100',
+      isActive: true,
+      renewState: null,
+      activityState: 'idle',
+      actionPanel: {},
+    };
+  }
+
+  afterEach(() => {
+    config.ui.fiveBlockPhase = 0;
+  });
+
+  it('PHASE=3 single-choice routes through ThreadPanel.askUser (with turnId)', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const { deps, sessionRegistry } = createP3Deps();
+    const session = createSession();
+    // Make getSessionByKey return the same session the executor passes through.
+    deps.claudeHandler.getSessionByKey = vi.fn().mockReturnValue(session);
+    const executor = new StreamExecutor(deps);
+    const say = vi.fn().mockResolvedValue({ ts: 'legacy-ts' });
+
+    await (executor as any).handleModelCommandToolResults(
+      [
+        {
+          toolUseId: 'tool-1',
+          toolName: 'mcp__model-command__run',
+          result: JSON.stringify({
+            type: 'model_command_result',
+            commandId: 'ASK_USER_QUESTION',
+            ok: true,
+            payload: {
+              question: {
+                type: 'user_choice',
+                question: '선택?',
+                choices: [
+                  { id: '1', label: 'A' },
+                  { id: '2', label: 'B' },
+                ],
+              },
+            },
+          }),
+        },
+      ],
+      session,
+      {
+        channel: 'C1',
+        threadTs: '171.100',
+        sessionKey: 'C1-171.100',
+        say,
+        turnId: 'TID-1',
+      },
+    );
+
+    expect(deps.threadPanel.askUser).toHaveBeenCalledWith(
+      'TID-1',
+      expect.objectContaining({ type: 'user_choice' }),
+      expect.any(Object),
+      expect.any(String),
+      expect.objectContaining({ channelId: 'C1', threadTs: '171.100', sessionKey: 'C1-171.100' }),
+      session,
+      'C1-171.100',
+    );
+    // legacy context.say should NOT have been used for the posted message
+    expect(say).not.toHaveBeenCalled();
+    // persist+broadcast after pendingQuestion write
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledWith('C1-171.100');
+  });
+
+  it('PHASE=3 multi-choice pre-allocates formIds with turnId and calls askUserForm', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const { deps } = createP3Deps();
+    deps.threadPanel.askUserForm = vi
+      .fn()
+      .mockResolvedValue({ ok: true, primaryTs: 'ts-0', allTs: ['ts-0'], formIds: ['any'] });
+    // back-fill lookup needs to return something
+    deps.actionHandlers.getPendingForm = vi.fn().mockImplementation((id: string) => ({
+      formId: id,
+      sessionKey: 'C1-171.100',
+      channel: 'C1',
+      threadTs: '171.100',
+      messageTs: '',
+      questions: [],
+      selections: {},
+      createdAt: Date.now(),
+    }));
+    const session = createSession();
+    deps.claudeHandler.getSessionByKey = vi.fn().mockReturnValue(session);
+    const executor = new StreamExecutor(deps);
+    const say = vi.fn();
+
+    await (executor as any).handleModelCommandToolResults(
+      [
+        {
+          toolUseId: 'tool-2',
+          toolName: 'mcp__model-command__run',
+          result: JSON.stringify({
+            type: 'model_command_result',
+            commandId: 'ASK_USER_QUESTION',
+            ok: true,
+            payload: {
+              question: {
+                type: 'user_choices',
+                title: 'Multi',
+                questions: [{ id: 'q1', question: 'Q1?', choices: [{ id: '1', label: 'A' }] }],
+              },
+            },
+          }),
+        },
+      ],
+      session,
+      {
+        channel: 'C1',
+        threadTs: '171.100',
+        sessionKey: 'C1-171.100',
+        say,
+        turnId: 'TID-MULTI',
+      },
+    );
+
+    const setPendingCall = deps.actionHandlers.setPendingForm.mock.calls[0];
+    expect(setPendingCall[1]).toMatchObject({ turnId: 'TID-MULTI' });
+    expect(deps.threadPanel.askUserForm).toHaveBeenCalledWith(
+      'TID-MULTI',
+      expect.any(Array),
+      expect.any(Array),
+      expect.objectContaining({ type: 'user_choices' }),
+      expect.objectContaining({ channelId: 'C1' }),
+      session,
+      'C1-171.100',
+    );
+  });
+
+  it('PHASE=3 defensive prelude clears prior pendingChoice before a new ask', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const { deps, sessionRegistry } = createP3Deps();
+    const session = createSession();
+    deps.claudeHandler.getSessionByKey = vi.fn().mockReturnValue(session);
+    const executor = new StreamExecutor(deps);
+    session.actionPanel = {
+      pendingChoice: { turnId: 'OLD', kind: 'single', choiceTs: 'oldTs', formIds: [] },
+      choiceMessageTs: 'oldTs',
+      waitingForChoice: true,
+    };
+    const say = vi.fn();
+    await (executor as any).handleModelCommandToolResults(
+      [
+        {
+          toolUseId: 'tool-3',
+          toolName: 'mcp__model-command__run',
+          result: JSON.stringify({
+            type: 'model_command_result',
+            commandId: 'ASK_USER_QUESTION',
+            ok: true,
+            payload: {
+              question: { type: 'user_choice', question: 'Q', choices: [{ id: '1', label: 'A' }] },
+            },
+          }),
+        },
+      ],
+      session,
+      {
+        channel: 'C1',
+        threadTs: '171.100',
+        sessionKey: 'C1-171.100',
+        say,
+        turnId: 'NEW',
+      },
+    );
+    // prior pendingChoice is cleared before askUser writes the new record
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledWith('C1-171.100');
+    // askUser was invoked so the new record gets written inside the facade
+    expect(deps.threadPanel.askUser).toHaveBeenCalled();
+  });
+
+  it('PHASE=3 single post-failed → sendCommandChoiceFallback (legacy say)', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const { deps } = createP3Deps();
+    deps.threadPanel.askUser = vi
+      .fn()
+      .mockResolvedValue({ ok: false, reason: 'post-failed', error: new Error('slack') });
+    const session = createSession();
+    deps.claudeHandler.getSessionByKey = vi.fn().mockReturnValue(session);
+    const executor = new StreamExecutor(deps);
+    const say = vi.fn().mockResolvedValue({ ts: 'x' });
+    await (executor as any).handleModelCommandToolResults(
+      [
+        {
+          toolUseId: 'tool-4',
+          toolName: 'mcp__model-command__run',
+          result: JSON.stringify({
+            type: 'model_command_result',
+            commandId: 'ASK_USER_QUESTION',
+            ok: true,
+            payload: {
+              question: { type: 'user_choice', question: 'Q', choices: [{ id: '1', label: 'A' }] },
+            },
+          }),
+        },
+      ],
+      session,
+      {
+        channel: 'C1',
+        threadTs: '171.100',
+        sessionKey: 'C1-171.100',
+        say,
+        turnId: 'TID',
+      },
+    );
+    // sendCommandChoiceFallback uses context.say to post text fallback
+    expect(say).toHaveBeenCalled();
+  });
+
+  it('unconditional pendingQuestion write + persistAndBroadcast fires under PHASE<3', async () => {
+    config.ui.fiveBlockPhase = 0;
+    const { deps, sessionRegistry } = createP3Deps();
+    const session = createSession();
+    deps.claudeHandler.getSessionByKey = vi.fn().mockReturnValue(session);
+    const executor = new StreamExecutor(deps);
+    const say = vi.fn().mockResolvedValue({ ts: 'x' });
+    await (executor as any).handleModelCommandToolResults(
+      [
+        {
+          toolUseId: 'tool-5',
+          toolName: 'mcp__model-command__run',
+          result: JSON.stringify({
+            type: 'model_command_result',
+            commandId: 'ASK_USER_QUESTION',
+            ok: true,
+            payload: {
+              question: { type: 'user_choice', question: 'Q', choices: [{ id: '1', label: 'A' }] },
+            },
+          }),
+        },
+      ],
+      session,
+      {
+        channel: 'C1',
+        threadTs: '171.100',
+        sessionKey: 'C1-171.100',
+        say,
+        turnId: 'TID',
+      },
+    );
+    expect(session.actionPanel?.pendingQuestion).toBeDefined();
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledWith('C1-171.100');
+  });
+
+  it('PHASE<3 multi uses setPendingForm to persist messageTs (v7 fix)', async () => {
+    config.ui.fiveBlockPhase = 0;
+    const { deps } = createP3Deps();
+    const pendingCache: Record<string, any> = {};
+    deps.actionHandlers.setPendingForm = vi.fn((id: string, data: any) => {
+      pendingCache[id] = data;
+    });
+    deps.actionHandlers.getPendingForm = vi.fn((id: string) => pendingCache[id]);
+    const session = createSession();
+    deps.claudeHandler.getSessionByKey = vi.fn().mockReturnValue(session);
+    const executor = new StreamExecutor(deps);
+    const say = vi.fn().mockResolvedValue({ ts: 'multi-ts' });
+    await (executor as any).handleModelCommandToolResults(
+      [
+        {
+          toolUseId: 'tool-6',
+          toolName: 'mcp__model-command__run',
+          result: JSON.stringify({
+            type: 'model_command_result',
+            commandId: 'ASK_USER_QUESTION',
+            ok: true,
+            payload: {
+              question: {
+                type: 'user_choices',
+                title: 'T',
+                questions: [{ id: 'q1', question: 'Q', choices: [{ id: '1', label: 'A' }] }],
+              },
+            },
+          }),
+        },
+      ],
+      session,
+      {
+        channel: 'C1',
+        threadTs: '171.100',
+        sessionKey: 'C1-171.100',
+        say,
+        turnId: 'TID',
+      },
+    );
+    // Two setPendingForm calls: initial set (empty ts) + back-fill with posted ts.
+    expect(deps.actionHandlers.setPendingForm).toHaveBeenCalledTimes(2);
+    const backfillCall = deps.actionHandlers.setPendingForm.mock.calls[1][1];
+    expect(backfillCall.messageTs).toBe('multi-ts');
   });
 });

--- a/src/slack/pipeline/stream-executor.ts
+++ b/src/slack/pipeline/stream-executor.ts
@@ -12,6 +12,7 @@ import {
   isApiLikeError,
   shouldShowStatusBlock,
 } from '../../claude-status-fetcher';
+import { config } from '../../config';
 import { createConversation, recordAssistantTurn, recordUserTurn } from '../../conversation';
 import type { FileHandler, ProcessedFile } from '../../file-handler';
 import { Logger, redactAnthropicSecrets } from '../../logger';
@@ -65,7 +66,7 @@ import { LOG_DETAIL, OutputFlag, shouldOutput, verboseTag } from '../output-flag
 import type { RequestCoordinator } from '../request-coordinator';
 import type { SummaryService } from '../summary-service';
 import type { SummaryTimer } from '../summary-timer.js';
-import type { ThreadPanel, TurnContext } from '../thread-panel';
+import type { ThreadPanel, TurnAddress, TurnContext } from '../thread-panel';
 import { isLocalSlashCommand } from './local-slash-command';
 import { MessageEvent, type SayFn } from './types';
 
@@ -2649,22 +2650,27 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
         });
       }
       const lastQuestion = pendingQuestions[pendingQuestions.length - 1];
-      await this.renderAskUserQuestionFromCommand(lastQuestion, session, context);
+      // P3 (PHASE>=3): stream-executor threads its per-turn `turnId` into the
+      // ASK render so button payloads + PendingFormStore entries carry the
+      // same identity as `pendingChoice.turnId`. `context.turnId` is populated
+      // by stream-executor's `execute()` for every turn.
+      await this.renderAskUserQuestionFromCommand(context.turnId, lastQuestion, session, context);
     }
 
     return { hasPendingChoice, continuation, modelCommandResults };
   }
 
   private async renderAskUserQuestionFromCommand(
+    turnId: string | undefined,
     question: UserChoice | UserChoices,
     session: ConversationSession,
     context: StreamContext,
   ): Promise<void> {
     try {
       if (question.type === 'user_choices') {
-        await this.renderMultiChoiceFromCommand(question, context);
+        await this.renderMultiChoiceFromCommand(turnId, question, context);
       } else {
-        await this.renderSingleChoiceFromCommand(question, context);
+        await this.renderSingleChoiceFromCommand(turnId, question, context);
       }
     } catch (error) {
       // If both primary render AND fallback fail (e.g. Slack rate limit),
@@ -2688,10 +2694,130 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
       activeTool: undefined,
       waitingForChoice: true,
     });
+
+    // P3 (parity fix) — pendingQuestion was historically in-memory only. With
+    // P3's pendingChoice living on the session + broadcast to the dashboard,
+    // we must also persist pendingQuestion so a dashboard restart restores
+    // the question context. setActivityState persists on idle only; force a
+    // broadcast+save here regardless of PHASE so dashboard subscribers see
+    // the new pendingQuestion immediately.
+    try {
+      this.deps.claudeHandler.getSessionRegistry?.().persistAndBroadcast?.(context.sessionKey);
+    } catch (err) {
+      this.logger.debug('renderAskUserQuestionFromCommand: persistAndBroadcast failed', {
+        sessionKey: context.sessionKey,
+        error: (err as Error)?.message ?? String(err),
+      });
+    }
   }
 
-  private async renderSingleChoiceFromCommand(question: UserChoice, context: StreamContext): Promise<void> {
+  /**
+   * P3 (PHASE>=3) defensive prelude — clear any prior pendingChoice on the
+   * session before opening a new ask. Prevents split-brain between Slack UI
+   * and `pendingChoice` when a prior post succeeded but the resolve signal
+   * was lost (e.g. process restart, Slack click dropped).
+   *
+   * For `multi` priors: best-effort rewrite each prior chunk message to
+   * "⏱️ 새 질문으로 대체되었습니다." and delete PendingFormStore entries.
+   * For `single` priors: only clears session state (no Slack rewrite — the
+   * new ask replaces the visible message itself).
+   *
+   * No-op under PHASE<3 or when no prior `pendingChoice` exists.
+   */
+  private async supersedePriorPendingChoice(
+    session: ConversationSession,
+    sessionKey: string,
+    channel: string,
+  ): Promise<void> {
+    if (config.ui.fiveBlockPhase < 3) return;
+    const prior = session.actionPanel?.pendingChoice;
+    if (!prior) return;
+
+    if (prior.kind === 'multi' && prior.formIds.length > 0) {
+      for (const formId of prior.formIds) {
+        const pendingForm = this.deps.actionHandlers.getPendingForm(formId);
+        if (pendingForm?.messageTs) {
+          await this.deps.slackApi
+            .updateMessage(
+              channel,
+              pendingForm.messageTs,
+              '⏱️ _새 질문으로 대체되었습니다._',
+              [{ type: 'section', text: { type: 'mrkdwn', text: '⏱️ _새 질문으로 대체되었습니다._' } }],
+              [],
+            )
+            .catch((err) =>
+              this.logger.warn('supersedePriorPendingChoice: rewrite failed', {
+                sessionKey,
+                formId,
+                error: (err as Error)?.message ?? String(err),
+              }),
+            );
+        }
+        this.deps.actionHandlers.deletePendingForm(formId);
+      }
+    }
+
+    if (session.actionPanel) {
+      session.actionPanel.pendingChoice = undefined;
+      session.actionPanel.choiceMessageTs = undefined;
+      session.actionPanel.choiceMessageLink = undefined;
+      session.actionPanel.waitingForChoice = false;
+    }
+    try {
+      this.deps.claudeHandler.getSessionRegistry?.().persistAndBroadcast?.(sessionKey);
+    } catch (err) {
+      this.logger.debug('supersedePriorPendingChoice: persistAndBroadcast failed', {
+        sessionKey,
+        error: (err as Error)?.message ?? String(err),
+      });
+    }
+  }
+
+  private async renderSingleChoiceFromCommand(
+    turnId: string | undefined,
+    question: UserChoice,
+    context: StreamContext,
+  ): Promise<void> {
     const session = this.deps.claudeHandler.getSessionByKey(context.sessionKey);
+
+    // P3 (PHASE>=3) — route through ThreadPanel.askUser so pendingChoice state
+    // is written synchronously with the posted ts. Falls through to the legacy
+    // context.say path when PHASE<3, threadPanel is missing, or askUser reports
+    // phase-disabled (e.g. test harness mock).
+    if (config.ui.fiveBlockPhase >= 3 && session && this.deps.threadPanel && turnId) {
+      await this.supersedePriorPendingChoice(session, context.sessionKey, context.channel);
+
+      const theme = userSettingsStore.getUserSessionTheme(session.ownerId);
+      const payload = UserChoiceHandler.buildUserChoiceBlocks(question, context.sessionKey, theme, turnId);
+
+      const address: TurnAddress = {
+        channelId: context.channel,
+        threadTs: context.threadTs,
+        sessionKey: context.sessionKey,
+      };
+      const result = await this.deps.threadPanel.askUser(
+        turnId,
+        question,
+        payload,
+        question.question ?? '선택이 필요합니다',
+        address,
+        session,
+        context.sessionKey,
+      );
+
+      if (result.ok) {
+        // ThreadPanel.askUser synchronously wrote pendingChoice + persistAndBroadcast.
+        return;
+      }
+      if (result.reason === 'post-failed') {
+        await this.sendCommandChoiceFallback(question, context);
+        return;
+      }
+      // phase-disabled → fall through to legacy path below.
+    }
+
+    // Legacy path (PHASE<3 or P3 fell through). Byte-identical pre-flip
+    // output: no `turnId` threaded through `buildUserChoiceBlocks`.
     const theme = session ? userSettingsStore.getUserSessionTheme(session.ownerId) : undefined;
     const payload = UserChoiceHandler.buildUserChoiceBlocks(question, context.sessionKey, theme);
     try {
@@ -2711,7 +2837,11 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
     }
   }
 
-  private async renderMultiChoiceFromCommand(question: UserChoices, context: StreamContext): Promise<void> {
+  private async renderMultiChoiceFromCommand(
+    turnId: string | undefined,
+    question: UserChoices,
+    context: StreamContext,
+  ): Promise<void> {
     const maxQuestionsPerForm = 6;
     const chunks: UserChoices[] = [];
     for (let index = 0; index < question.questions.length; index += maxQuestionsPerForm) {
@@ -2728,6 +2858,79 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
       });
     }
 
+    const session = this.deps.claudeHandler.getSessionByKey(context.sessionKey);
+
+    // P3 (PHASE>=3): pre-allocate formIds + persist (with turnId) before any
+    // Slack round-trip so a mid-flight click finds the live form entry.
+    if (config.ui.fiveBlockPhase >= 3 && session && this.deps.threadPanel && turnId) {
+      await this.supersedePriorPendingChoice(session, context.sessionKey, context.channel);
+
+      const formIds: string[] = [];
+      for (const chunk of chunks) {
+        const formId = `form_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+        formIds.push(formId);
+        this.deps.actionHandlers.setPendingForm(formId, {
+          formId,
+          sessionKey: context.sessionKey,
+          channel: context.channel,
+          threadTs: context.threadTs,
+          messageTs: '',
+          questions: chunk.questions,
+          selections: {},
+          createdAt: Date.now(),
+          turnId,
+        });
+      }
+      if (formIds.length > 0) {
+        await this.deps.actionHandlers.invalidateOldForms(context.sessionKey, formIds[0], this.deps.slackApi);
+      }
+
+      const chunkPayloads = chunks.map((chunk, i) => ({
+        builtPayload: UserChoiceHandler.buildMultiChoiceFormBlocks(chunk, formIds[i], context.sessionKey),
+        text: chunk.title || '📋 선택이 필요합니다',
+      }));
+
+      const address: TurnAddress = {
+        channelId: context.channel,
+        threadTs: context.threadTs,
+        sessionKey: context.sessionKey,
+      };
+      const result = await this.deps.threadPanel.askUserForm(
+        turnId,
+        chunkPayloads,
+        formIds,
+        question,
+        address,
+        session,
+        context.sessionKey,
+      );
+
+      if (result.ok) {
+        // Back-fill messageTs on each pending form. Use setPendingForm (not
+        // in-place mutation) so a concurrent save-to-disk sees the new ts.
+        for (let i = 0; i < result.allTs.length; i++) {
+          const fId = formIds[i];
+          const pending = this.deps.actionHandlers.getPendingForm(fId);
+          if (pending) {
+            this.deps.actionHandlers.setPendingForm(fId, { ...pending, messageTs: result.allTs[i] });
+          }
+        }
+        return;
+      }
+      if (result.reason === 'post-failed') {
+        for (const fId of formIds) {
+          this.deps.actionHandlers.deletePendingForm(fId);
+        }
+        await this.sendCommandChoiceFallback(question, context);
+        return;
+      }
+      // phase-disabled → fall through to legacy path (cleanup pre-allocated forms).
+      for (const fId of formIds) {
+        this.deps.actionHandlers.deletePendingForm(fId);
+      }
+    }
+
+    // Legacy path (PHASE<3 or P3 fell through).
     for (let index = 0; index < chunks.length; index += 1) {
       const chunk = chunks[index];
       const formId = `form_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
@@ -2756,9 +2959,12 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
         });
 
         if (result?.ts) {
+          // v7 fix: persist messageTs via setPendingForm so a concurrent
+          // save-to-disk captures the new ts. Previously mutated in place,
+          // which meant the ts was lost across restarts.
           const pending = this.deps.actionHandlers.getPendingForm(formId);
           if (pending) {
-            pending.messageTs = result.ts;
+            this.deps.actionHandlers.setPendingForm(formId, { ...pending, messageTs: result.ts });
           }
         }
 

--- a/src/slack/pipeline/stream-executor.ts
+++ b/src/slack/pipeline/stream-executor.ts
@@ -45,6 +45,7 @@ import type {
 } from '../../types';
 import { coerceToAvailableModel, userSettingsStore } from '../../user-settings-store';
 import type { ActionHandlers } from '../actions';
+import { buildMarkerBlocks, SUPERSEDED_TEXT } from '../actions/click-classifier';
 import type { CompletionMessageTracker } from '../completion-message-tracker.js';
 import { postCompactCompleteIfNeeded, postCompactStartingIfNeeded } from '../hooks/compact-hooks';
 import {
@@ -2734,27 +2735,24 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
     if (!prior) return;
 
     if (prior.kind === 'multi' && prior.formIds.length > 0) {
-      for (const formId of prior.formIds) {
-        const pendingForm = this.deps.actionHandlers.getPendingForm(formId);
-        if (pendingForm?.messageTs) {
-          await this.deps.slackApi
-            .updateMessage(
-              channel,
-              pendingForm.messageTs,
-              '⏱️ _새 질문으로 대체되었습니다._',
-              [{ type: 'section', text: { type: 'mrkdwn', text: '⏱️ _새 질문으로 대체되었습니다._' } }],
-              [],
-            )
-            .catch((err) =>
-              this.logger.warn('supersedePriorPendingChoice: rewrite failed', {
-                sessionKey,
-                formId,
-                error: (err as Error)?.message ?? String(err),
-              }),
-            );
-        }
-        this.deps.actionHandlers.deletePendingForm(formId);
-      }
+      // Prior chunks are independent Slack messages — rewrite in parallel.
+      await Promise.allSettled(
+        prior.formIds.map(async (formId) => {
+          const pendingForm = this.deps.actionHandlers.getPendingForm(formId);
+          if (pendingForm?.messageTs) {
+            await this.deps.slackApi
+              .updateMessage(channel, pendingForm.messageTs, SUPERSEDED_TEXT, buildMarkerBlocks(SUPERSEDED_TEXT), [])
+              .catch((err) =>
+                this.logger.warn('supersedePriorPendingChoice: rewrite failed', {
+                  sessionKey,
+                  formId,
+                  error: (err as Error)?.message ?? String(err),
+                }),
+              );
+          }
+          this.deps.actionHandlers.deletePendingForm(formId);
+        }),
+      );
     }
 
     if (session.actionPanel) {
@@ -2959,9 +2957,7 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
         });
 
         if (result?.ts) {
-          // v7 fix: persist messageTs via setPendingForm so a concurrent
-          // save-to-disk captures the new ts. Previously mutated in place,
-          // which meant the ts was lost across restarts.
+          // Persist messageTs via setPendingForm so restart can resolve the form.
           const pending = this.deps.actionHandlers.getPendingForm(formId);
           if (pending) {
             this.deps.actionHandlers.setPendingForm(formId, { ...pending, messageTs: result.ts });

--- a/src/slack/thread-panel.test.ts
+++ b/src/slack/thread-panel.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
-import type { ConversationSession } from '../types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { config } from '../config';
+import type { ConversationSession, UserChoice, UserChoices } from '../types';
 import { ThreadPanel } from './thread-panel';
 
 function getPostedBlocks(slackApi: { postMessage: ReturnType<typeof vi.fn> }): any[] {
@@ -385,5 +386,345 @@ describe('ThreadPanel', () => {
     // Combined surface: single updateMessage call containing header + panel blocks
     expect(slackApi.updateMessage).toHaveBeenCalledTimes(1);
     expect(slackApi.updateMessage.mock.calls[0][1]).toBe('100.200');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P3 (PHASE>=3) — askUser / askUserForm / resolveChoice / resolveMultiChoice
+// ---------------------------------------------------------------------------
+
+describe('ThreadPanel — P3 (PHASE>=3) B3 choice facade', () => {
+  const originalPhase = config.ui.fiveBlockPhase;
+
+  afterEach(() => {
+    config.ui.fiveBlockPhase = originalPhase;
+    vi.clearAllMocks();
+  });
+
+  function makeSession(): ConversationSession {
+    return {
+      ownerId: 'U1',
+      userId: 'U1',
+      channelId: 'C1',
+      threadTs: 't1',
+      threadRootTs: 't1',
+      isActive: true,
+      lastActivity: new Date(),
+      activityState: 'idle',
+      workflow: 'default',
+    } as unknown as ConversationSession;
+  }
+
+  function makePanelWithMocks(session: ConversationSession, options?: { postMessage?: any }) {
+    const postMessageMock = options?.postMessage ?? vi.fn().mockResolvedValue({ ts: 'posted-ts-1' });
+    const fakeClient = {
+      chat: {
+        startStream: vi.fn(),
+        appendStream: vi.fn(),
+        stopStream: vi.fn(),
+        postMessage: postMessageMock,
+        update: vi.fn(),
+      },
+    };
+    const slackApi = {
+      getClient: vi.fn().mockReturnValue(fakeClient),
+      postMessage: vi.fn().mockResolvedValue({ ts: 'surface-ts' }),
+      updateMessage: vi.fn().mockResolvedValue(undefined),
+      getPermalink: vi.fn().mockResolvedValue(null),
+    };
+    const claudeHandler = {
+      getSessionByKey: vi.fn().mockReturnValue(session),
+      getSessionKey: vi.fn().mockReturnValue('C1:t1'),
+    };
+    const requestCoordinator = { isRequestActive: vi.fn().mockReturnValue(false) };
+    const todoManager = { getTodos: vi.fn().mockReturnValue([]) };
+    const sessionRegistry = {
+      persistAndBroadcast: vi.fn(),
+      getSessionByKey: vi.fn().mockReturnValue(session),
+    };
+    const panel = new ThreadPanel({
+      slackApi: slackApi as any,
+      claudeHandler: claudeHandler as any,
+      requestCoordinator: requestCoordinator as any,
+      todoManager: todoManager as any,
+      sessionRegistry: sessionRegistry as any,
+    });
+    return { panel, slackApi, fakeClient, sessionRegistry };
+  }
+
+  const sampleQuestion: UserChoice = {
+    question: '진행?',
+    choices: [
+      { id: 'yes', label: 'Yes' },
+      { id: 'no', label: 'No' },
+    ],
+  } as unknown as UserChoice;
+
+  const sampleMultiQuestion: UserChoices = {
+    questions: [
+      {
+        id: 'q1',
+        question: 'A?',
+        choices: [{ id: 'a1', label: 'A1' }],
+      },
+      {
+        id: 'q2',
+        question: 'B?',
+        choices: [{ id: 'b1', label: 'B1' }],
+      },
+    ],
+  } as unknown as UserChoices;
+
+  const address = { channelId: 'C1', threadTs: 't1', sessionKey: 'C1:t1' };
+
+  it('askUser success: posts, writes pendingChoice synchronously, calls persistAndBroadcast', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    const { panel, fakeClient, sessionRegistry } = makePanelWithMocks(session, {
+      postMessage: vi.fn().mockResolvedValue({ ts: 'ts-choice-1' }),
+    });
+
+    const result = await panel.askUser(
+      'turn-1',
+      sampleQuestion,
+      { blocks: [{ type: 'section' }] },
+      'Please choose',
+      address,
+      session,
+      'C1:t1',
+    );
+
+    expect(result).toEqual({ ok: true, primaryTs: 'ts-choice-1' });
+    expect(fakeClient.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(session.actionPanel?.pendingChoice).toEqual({
+      turnId: 'turn-1',
+      kind: 'single',
+      choiceTs: 'ts-choice-1',
+      formIds: [],
+      question: sampleQuestion,
+      createdAt: expect.any(Number),
+    });
+    expect(session.actionPanel?.choiceMessageTs).toBe('ts-choice-1');
+    expect(session.actionPanel?.waitingForChoice).toBe(true);
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledTimes(1);
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledWith('C1:t1');
+  });
+
+  it('askUser PHASE<3 returns phase-disabled without mutating state', async () => {
+    config.ui.fiveBlockPhase = 2;
+    const session = makeSession();
+    const { panel, fakeClient, sessionRegistry } = makePanelWithMocks(session);
+
+    const result = await panel.askUser('turn-1', sampleQuestion, { blocks: [] }, 'Q', address, session, 'C1:t1');
+
+    expect(result).toEqual({ ok: false, reason: 'phase-disabled' });
+    expect(fakeClient.chat.postMessage).not.toHaveBeenCalled();
+    expect(session.actionPanel?.pendingChoice).toBeUndefined();
+    expect(sessionRegistry.persistAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('askUser postMessage throws → post-failed + no pendingChoice written', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    const { panel, sessionRegistry } = makePanelWithMocks(session, {
+      postMessage: vi.fn().mockRejectedValue(new Error('slack 500')),
+    });
+
+    const result = await panel.askUser('turn-1', sampleQuestion, { blocks: [] }, 'Q', address, session, 'C1:t1');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('post-failed');
+      expect(result.error?.message).toBe('slack 500');
+    }
+    expect(session.actionPanel?.pendingChoice).toBeUndefined();
+    expect(sessionRegistry.persistAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('askUserForm happy path (2 chunks): both posted, pendingChoice set after chunk 0', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    const postMessage = vi.fn().mockResolvedValueOnce({ ts: 'chunk-0' }).mockResolvedValueOnce({ ts: 'chunk-1' });
+    const { panel, sessionRegistry } = makePanelWithMocks(session, { postMessage });
+
+    const chunks = [
+      { builtPayload: { blocks: [{ type: 'section' }] }, text: 'chunk-0 text' },
+      { builtPayload: { blocks: [{ type: 'section' }] }, text: 'chunk-1 text' },
+    ];
+    const formIds = ['form-0', 'form-1'];
+
+    const result = await panel.askUserForm(
+      'turn-multi',
+      chunks,
+      formIds,
+      sampleMultiQuestion,
+      address,
+      session,
+      'C1:t1',
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.primaryTs).toBe('chunk-0');
+      expect(result.allTs).toEqual(['chunk-0', 'chunk-1']);
+      expect(result.formIds).toEqual(['form-0', 'form-1']);
+    }
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(session.actionPanel?.pendingChoice).toEqual({
+      turnId: 'turn-multi',
+      kind: 'multi',
+      choiceTs: 'chunk-0',
+      formIds: ['form-0', 'form-1'],
+      question: sampleMultiQuestion,
+      createdAt: expect.any(Number),
+    });
+    expect(session.actionPanel?.choiceMessageTs).toBe('chunk-0');
+    expect(session.actionPanel?.waitingForChoice).toBe(true);
+    // persistAndBroadcast called once (after chunk 0 write).
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledTimes(1);
+  });
+
+  it('askUserForm partial failure: rolls back posted chunks and defensively clears pendingChoice', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    const postMessage = vi.fn().mockResolvedValueOnce({ ts: 'chunk-0' }).mockRejectedValueOnce(new Error('slack down'));
+    const { panel, slackApi, sessionRegistry } = makePanelWithMocks(session, { postMessage });
+
+    const chunks = [
+      { builtPayload: { blocks: [] }, text: 'c0' },
+      { builtPayload: { blocks: [] }, text: 'c1' },
+    ];
+
+    const result = await panel.askUserForm(
+      'turn-multi',
+      chunks,
+      ['f0', 'f1'],
+      sampleMultiQuestion,
+      address,
+      session,
+      'C1:t1',
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'post-failed') {
+      expect(result.postedTs).toEqual(['chunk-0']);
+      expect(result.failedIndex).toBe(1);
+    }
+    // Rollback: updateMessage called for chunk-0 with the failure marker.
+    expect(slackApi.updateMessage).toHaveBeenCalledWith(
+      'C1',
+      'chunk-0',
+      expect.stringContaining('폼 생성에 실패'),
+      expect.any(Array),
+      [],
+    );
+    // Defensive clear of pendingChoice after rollback.
+    expect(session.actionPanel?.pendingChoice).toBeUndefined();
+    expect(session.actionPanel?.choiceMessageTs).toBeUndefined();
+    expect(session.actionPanel?.waitingForChoice).toBe(false);
+    // persistAndBroadcast was called twice: once after chunk-0 set, once after clear.
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolveChoice happy path: updates message, clears pendingChoice, persistAndBroadcast', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    session.actionPanel = {
+      pendingChoice: {
+        turnId: 'turn-1',
+        kind: 'single',
+        choiceTs: 'ts-1',
+        formIds: [],
+        question: sampleQuestion,
+        createdAt: 1,
+      },
+      choiceMessageTs: 'ts-1',
+      waitingForChoice: true,
+    };
+    const { panel, slackApi, sessionRegistry } = makePanelWithMocks(session);
+
+    const result = await panel.resolveChoice(session, 'C1:t1', 'C1', 'done text', [{ type: 'section' }] as any);
+    expect(result).toBe(true);
+    expect(slackApi.updateMessage).toHaveBeenCalledWith('C1', 'ts-1', 'done text', [{ type: 'section' }], []);
+    expect(session.actionPanel?.pendingChoice).toBeUndefined();
+    expect(session.actionPanel?.choiceMessageTs).toBeUndefined();
+    expect(session.actionPanel?.waitingForChoice).toBe(false);
+    expect(session.actionPanel?.choiceBlocks).toBeUndefined();
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledWith('C1:t1');
+  });
+
+  it('resolveChoice no pendingChoice present → returns false', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    const { panel, slackApi, sessionRegistry } = makePanelWithMocks(session);
+    const result = await panel.resolveChoice(session, 'C1:t1', 'C1', 'x', []);
+    expect(result).toBe(false);
+    expect(slackApi.updateMessage).not.toHaveBeenCalled();
+    expect(sessionRegistry.persistAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('resolveChoice PHASE<3 returns false', async () => {
+    config.ui.fiveBlockPhase = 2;
+    const session = makeSession();
+    session.actionPanel = {
+      pendingChoice: {
+        turnId: 'turn-1',
+        kind: 'single',
+        choiceTs: 'ts-1',
+        formIds: [],
+        question: sampleQuestion,
+        createdAt: 1,
+      },
+    };
+    const { panel, slackApi } = makePanelWithMocks(session);
+    const result = await panel.resolveChoice(session, 'C1:t1', 'C1', 'x', []);
+    expect(result).toBe(false);
+    expect(slackApi.updateMessage).not.toHaveBeenCalled();
+  });
+
+  it('resolveMultiChoice happy path: iterates tsList and clears', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    session.actionPanel = {
+      pendingChoice: {
+        turnId: 'turn-multi',
+        kind: 'multi',
+        choiceTs: 'ts-0',
+        formIds: ['f0', 'f1'],
+        question: sampleMultiQuestion,
+        createdAt: 1,
+      },
+      choiceMessageTs: 'ts-0',
+      waitingForChoice: true,
+    };
+    const { panel, slackApi, sessionRegistry } = makePanelWithMocks(session);
+
+    const result = await panel.resolveMultiChoice(session, 'C1:t1', 'C1', ['ts-0', 'ts-1'], 'done', [
+      { type: 'section' },
+    ] as any);
+    expect(result).toBe(true);
+    expect(slackApi.updateMessage).toHaveBeenCalledTimes(2);
+    expect(session.actionPanel?.pendingChoice).toBeUndefined();
+    expect(session.actionPanel?.waitingForChoice).toBe(false);
+    expect(sessionRegistry.persistAndBroadcast).toHaveBeenCalledWith('C1:t1');
+  });
+
+  it('resolveMultiChoice returns false when pendingChoice is single-kind', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    session.actionPanel = {
+      pendingChoice: {
+        turnId: 't',
+        kind: 'single',
+        choiceTs: 'ts-x',
+        formIds: [],
+        question: sampleQuestion,
+        createdAt: 1,
+      },
+    };
+    const { panel, slackApi } = makePanelWithMocks(session);
+    const result = await panel.resolveMultiChoice(session, 'C1:t1', 'C1', ['ts-x'], 'done', []);
+    expect(result).toBe(false);
+    expect(slackApi.updateMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/slack/thread-panel.ts
+++ b/src/slack/thread-panel.ts
@@ -5,6 +5,7 @@ import { Logger } from '../logger';
 import type { SessionRegistry } from '../session-registry';
 import type { Todo, TodoManager } from '../todo-manager';
 import type { ConversationSession, UserChoice, UserChoices } from '../types';
+import { buildMarkerBlocks, FORM_BUILD_FAILED_TEXT } from './actions/click-classifier';
 import type { CompletionMessageTracker } from './completion-message-tracker';
 import type { RequestCoordinator } from './request-coordinator';
 import type { SlackApiHelper } from './slack-api-helper';
@@ -312,30 +313,29 @@ export class ThreadPanel {
       }
     } catch (err) {
       // Partial failure: rollback Slack-side + defensive state clear.
-      for (const postedTs of allTs) {
-        await this.deps.slackApi
-          .updateMessage(
-            address.channelId,
-            postedTs,
-            '⏱️ _폼 생성에 실패했습니다._',
-            [{ type: 'section', text: { type: 'mrkdwn', text: '⏱️ _폼 생성에 실패했습니다._' } }],
-            [],
-          )
-          .catch((rollbackErr) => {
-            this.logger.warn('askUserForm: rollback updateMessage failed', {
-              sessionKey,
+      // Posted chunks are independent messages — roll back in parallel.
+      await Promise.allSettled(
+        allTs.map((postedTs) =>
+          this.deps.slackApi
+            .updateMessage(
+              address.channelId,
               postedTs,
-              error: (rollbackErr as Error)?.message ?? String(rollbackErr),
-            });
-          });
-      }
+              FORM_BUILD_FAILED_TEXT,
+              buildMarkerBlocks(FORM_BUILD_FAILED_TEXT),
+              [],
+            )
+            .catch((rollbackErr) => {
+              this.logger.warn('askUserForm: rollback updateMessage failed', {
+                sessionKey,
+                postedTs,
+                error: (rollbackErr as Error)?.message ?? String(rollbackErr),
+              });
+            }),
+        ),
+      );
       // If state was written after chunk 0, clear it.
       if (session.actionPanel?.pendingChoice?.turnId === turnId) {
-        session.actionPanel.pendingChoice = undefined;
-        session.actionPanel.choiceMessageTs = undefined;
-        session.actionPanel.choiceMessageLink = undefined;
-        session.actionPanel.waitingForChoice = false;
-        this.deps.sessionRegistry?.persistAndBroadcast(sessionKey);
+        this.clearPendingChoiceState(session, sessionKey);
       }
       return {
         ok: false,
@@ -377,18 +377,7 @@ export class ThreadPanel {
     const pc = session.actionPanel?.pendingChoice;
     if (!pc || pc.kind !== 'single' || !pc.choiceTs) return false;
     await this.turnSurface.resolveChoice(channelId, pc.choiceTs, completedText, completedBlocks);
-    if (!session.actionPanel) {
-      session.actionPanel = {
-        channelId: session.channelId,
-        userId: session.ownerId,
-      };
-    }
-    session.actionPanel.pendingChoice = undefined;
-    session.actionPanel.choiceMessageTs = undefined;
-    session.actionPanel.choiceMessageLink = undefined;
-    session.actionPanel.waitingForChoice = false;
-    session.actionPanel.choiceBlocks = undefined;
-    this.deps.sessionRegistry?.persistAndBroadcast(sessionKey);
+    this.clearPendingChoiceState(session, sessionKey);
     return true;
   }
 
@@ -408,6 +397,18 @@ export class ThreadPanel {
     const pc = session.actionPanel?.pendingChoice;
     if (!pc || pc.kind !== 'multi') return false;
     await this.turnSurface.resolveMultiChoice(channelId, tsList, completedText, completedBlocks);
+    this.clearPendingChoiceState(session, sessionKey);
+    return true;
+  }
+
+  // ---- internal helpers ----
+
+  /**
+   * P3 pendingChoice lifecycle clear — used by resolveChoice, resolveMultiChoice,
+   * and the askUserForm partial-failure defensive path. Ensures the whole P3
+   * co-field set clears atomically with a single persistAndBroadcast.
+   */
+  private clearPendingChoiceState(session: ConversationSession, sessionKey: string): void {
     if (!session.actionPanel) {
       session.actionPanel = {
         channelId: session.channelId,
@@ -420,10 +421,7 @@ export class ThreadPanel {
     session.actionPanel.waitingForChoice = false;
     session.actionPanel.choiceBlocks = undefined;
     this.deps.sessionRegistry?.persistAndBroadcast(sessionKey);
-    return true;
   }
-
-  // ---- internal helpers ----
 
   private findSessionKey(session: ConversationSession): string | undefined {
     const threadTs = session.threadRootTs || session.threadTs;

--- a/src/slack/thread-panel.ts
+++ b/src/slack/thread-panel.ts
@@ -2,8 +2,9 @@ import type { EndTurnInfo } from '../agent-session/agent-session-types';
 import type { ClaudeHandler } from '../claude-handler';
 import { config } from '../config';
 import { Logger } from '../logger';
+import type { SessionRegistry } from '../session-registry';
 import type { Todo, TodoManager } from '../todo-manager';
-import type { ConversationSession } from '../types';
+import type { ConversationSession, UserChoice, UserChoices } from '../types';
 import type { CompletionMessageTracker } from './completion-message-tracker';
 import type { RequestCoordinator } from './request-coordinator';
 import type { SlackApiHelper } from './slack-api-helper';
@@ -17,6 +18,13 @@ interface ThreadPanelDeps {
   requestCoordinator: RequestCoordinator;
   todoManager: TodoManager;
   completionMessageTracker?: CompletionMessageTracker;
+  /**
+   * P3 (PHASE>=3) dep — SessionRegistry for persistAndBroadcast() after
+   * pendingChoice mutations. Optional for backward compatibility with
+   * legacy tests that construct ThreadPanel without it; persist calls
+   * degrade to no-ops when absent.
+   */
+  sessionRegistry?: SessionRegistry;
 }
 
 // Keeps TurnSurface `@internal` while exposing the public type contract.
@@ -169,6 +177,250 @@ export class ThreadPanel {
   async renderTasks(turnId: string, todos: Todo[], ctx?: TurnAddress): Promise<boolean> {
     if (config.ui.fiveBlockPhase < 2) return false;
     return this.turnSurface.renderTasks(turnId, todos, ctx);
+  }
+
+  // =========================================================================
+  // 5-block per-turn façade — P3 B3 choice (Issue #665)
+  //
+  // PHASE<3 → returns a sentinel (`{ok:false, reason:'phase-disabled'}` or
+  //           `false`) so callers take the legacy `context.say` +
+  //           `attachChoice` / `sendCommandChoiceFallback` path.
+  // PHASE>=3 → posts the question via TurnSurface, synchronously writes
+  //           `session.actionPanel.pendingChoice` + co-fields, and fires
+  //           permalink warm-up via `ThreadSurface.setChoiceMeta`.
+  //
+  // Write-order invariant: after postMessage returns a ts, the session state
+  // write (pendingChoice + choiceMessageTs + waitingForChoice) runs
+  // SYNCHRONOUSLY before any further await — otherwise a live click during
+  // the permalink await hits a stale "no pendingChoice" branch.
+  // =========================================================================
+
+  /**
+   * P3 (PHASE>=3) — single-choice ask. Posts the question via TurnSurface,
+   * synchronously writes session state, then fires permalink warm-up.
+   *
+   * Returns `{ok:true, primaryTs}` on success.
+   * Returns `{ok:false, reason:'phase-disabled'}` if PHASE<3 — caller
+   *   falls back to the legacy path.
+   * Returns `{ok:false, reason:'post-failed', error}` if the Slack post
+   *   itself raised — caller falls back to `sendCommandChoiceFallback`.
+   *
+   * `session` is mutated in place with the new pending record. Caller is
+   * responsible for having cleared any prior pendingChoice BEFORE calling
+   * (defensive prelude in stream-executor).
+   */
+  async askUser(
+    turnId: string,
+    question: UserChoice,
+    builtPayload: { blocks?: any[]; attachments?: any[] },
+    text: string,
+    address: TurnAddress,
+    session: ConversationSession,
+    sessionKey: string,
+  ): Promise<{ ok: true; primaryTs: string } | { ok: false; reason: 'phase-disabled' | 'post-failed'; error?: Error }> {
+    if (config.ui.fiveBlockPhase < 3) return { ok: false, reason: 'phase-disabled' };
+    let ts: string;
+    try {
+      ts = await this.turnSurface.askUser(turnId, builtPayload, text, address);
+    } catch (err) {
+      return { ok: false, reason: 'post-failed', error: err as Error };
+    }
+    if (!ts) return { ok: false, reason: 'phase-disabled' };
+
+    // SYNCHRONOUS state write — no await between postMessage and here.
+    if (!session.actionPanel) {
+      session.actionPanel = {
+        channelId: session.channelId,
+        userId: session.ownerId,
+      };
+    }
+    session.actionPanel.pendingChoice = {
+      turnId,
+      kind: 'single',
+      choiceTs: ts,
+      formIds: [],
+      question,
+      createdAt: Date.now(),
+    };
+    session.actionPanel.choiceMessageTs = ts;
+    session.actionPanel.waitingForChoice = true;
+
+    // Persist + broadcast immediately so the dashboard sees the new pending
+    // question and a concurrent restart can restore state.
+    this.deps.sessionRegistry?.persistAndBroadcast(sessionKey);
+
+    // Fire-and-forget permalink warm + render.
+    this.surface.setChoiceMeta(sessionKey, ts).catch((err) => {
+      this.logger.warn('askUser: setChoiceMeta failed', {
+        sessionKey,
+        turnId,
+        error: (err as Error)?.message ?? String(err),
+      });
+    });
+
+    return { ok: true, primaryTs: ts };
+  }
+
+  /**
+   * P3 (PHASE>=3) — multi-choice ask. Caller (stream-executor) provides
+   * pre-chunked payloads + pre-allocated formIds (already registered in
+   * PendingFormStore with turnId). ThreadPanel posts all chunks, writes
+   * state after the FIRST chunk succeeds, and rolls back Slack-side on
+   * partial failure.
+   */
+  async askUserForm(
+    turnId: string,
+    chunks: Array<{ builtPayload: { blocks?: any[]; attachments?: any[] }; text: string }>,
+    formIds: string[],
+    originalQuestion: UserChoices,
+    address: TurnAddress,
+    session: ConversationSession,
+    sessionKey: string,
+  ): Promise<
+    | { ok: true; primaryTs: string; allTs: string[]; formIds: string[] }
+    | { ok: false; reason: 'phase-disabled' }
+    | { ok: false; reason: 'post-failed'; postedTs: string[]; failedIndex: number; error: Error }
+  > {
+    if (config.ui.fiveBlockPhase < 3) return { ok: false, reason: 'phase-disabled' };
+
+    const allTs: string[] = [];
+    let i = 0;
+    try {
+      for (i = 0; i < chunks.length; i++) {
+        const ts = await this.turnSurface.askUserForm(turnId, chunks[i].builtPayload, chunks[i].text, address);
+        allTs.push(ts);
+        if (i === 0) {
+          // SYNCHRONOUS state write after FIRST successful chunk.
+          if (!session.actionPanel) {
+            session.actionPanel = {
+              channelId: session.channelId,
+              userId: session.ownerId,
+            };
+          }
+          session.actionPanel.pendingChoice = {
+            turnId,
+            kind: 'multi',
+            choiceTs: ts,
+            formIds: [...formIds],
+            question: originalQuestion,
+            createdAt: Date.now(),
+          };
+          session.actionPanel.choiceMessageTs = ts;
+          session.actionPanel.waitingForChoice = true;
+          this.deps.sessionRegistry?.persistAndBroadcast(sessionKey);
+        }
+      }
+    } catch (err) {
+      // Partial failure: rollback Slack-side + defensive state clear.
+      for (const postedTs of allTs) {
+        await this.deps.slackApi
+          .updateMessage(
+            address.channelId,
+            postedTs,
+            '⏱️ _폼 생성에 실패했습니다._',
+            [{ type: 'section', text: { type: 'mrkdwn', text: '⏱️ _폼 생성에 실패했습니다._' } }],
+            [],
+          )
+          .catch((rollbackErr) => {
+            this.logger.warn('askUserForm: rollback updateMessage failed', {
+              sessionKey,
+              postedTs,
+              error: (rollbackErr as Error)?.message ?? String(rollbackErr),
+            });
+          });
+      }
+      // If state was written after chunk 0, clear it.
+      if (session.actionPanel?.pendingChoice?.turnId === turnId) {
+        session.actionPanel.pendingChoice = undefined;
+        session.actionPanel.choiceMessageTs = undefined;
+        session.actionPanel.choiceMessageLink = undefined;
+        session.actionPanel.waitingForChoice = false;
+        this.deps.sessionRegistry?.persistAndBroadcast(sessionKey);
+      }
+      return {
+        ok: false,
+        reason: 'post-failed',
+        postedTs: allTs,
+        failedIndex: i,
+        error: err as Error,
+      };
+    }
+
+    // All chunks posted: fire-and-forget permalink warm for primary.
+    this.surface.setChoiceMeta(sessionKey, allTs[0]).catch((err) => {
+      this.logger.warn('askUserForm: setChoiceMeta failed', {
+        sessionKey,
+        turnId,
+        error: (err as Error)?.message ?? String(err),
+      });
+    });
+
+    return { ok: true, primaryTs: allTs[0], allTs, formIds };
+  }
+
+  /**
+   * P3 (PHASE>=3) — resolve the current single-choice pending record.
+   * Reads choiceTs from session state, updates the message in place,
+   * then clears pendingChoice and related fields.
+   *
+   * Returns true on P3 handled; false when PHASE<3 or no pendingChoice
+   * present (caller takes legacy path).
+   */
+  async resolveChoice(
+    session: ConversationSession,
+    sessionKey: string,
+    channelId: string,
+    completedText: string,
+    completedBlocks: any[],
+  ): Promise<boolean> {
+    if (config.ui.fiveBlockPhase < 3) return false;
+    const pc = session.actionPanel?.pendingChoice;
+    if (!pc || pc.kind !== 'single' || !pc.choiceTs) return false;
+    await this.turnSurface.resolveChoice(channelId, pc.choiceTs, completedText, completedBlocks);
+    if (!session.actionPanel) {
+      session.actionPanel = {
+        channelId: session.channelId,
+        userId: session.ownerId,
+      };
+    }
+    session.actionPanel.pendingChoice = undefined;
+    session.actionPanel.choiceMessageTs = undefined;
+    session.actionPanel.choiceMessageLink = undefined;
+    session.actionPanel.waitingForChoice = false;
+    session.actionPanel.choiceBlocks = undefined;
+    this.deps.sessionRegistry?.persistAndBroadcast(sessionKey);
+    return true;
+  }
+
+  /**
+   * P3 (PHASE>=3) — resolve the current multi-choice pending record.
+   * Caller passes the ts list (ThreadPanel does NOT own PendingFormStore).
+   */
+  async resolveMultiChoice(
+    session: ConversationSession,
+    sessionKey: string,
+    channelId: string,
+    tsList: string[],
+    completedText: string,
+    completedBlocks: any[],
+  ): Promise<boolean> {
+    if (config.ui.fiveBlockPhase < 3) return false;
+    const pc = session.actionPanel?.pendingChoice;
+    if (!pc || pc.kind !== 'multi') return false;
+    await this.turnSurface.resolveMultiChoice(channelId, tsList, completedText, completedBlocks);
+    if (!session.actionPanel) {
+      session.actionPanel = {
+        channelId: session.channelId,
+        userId: session.ownerId,
+      };
+    }
+    session.actionPanel.pendingChoice = undefined;
+    session.actionPanel.choiceMessageTs = undefined;
+    session.actionPanel.choiceMessageLink = undefined;
+    session.actionPanel.waitingForChoice = false;
+    session.actionPanel.choiceBlocks = undefined;
+    this.deps.sessionRegistry?.persistAndBroadcast(sessionKey);
+    return true;
   }
 
   // ---- internal helpers ----

--- a/src/slack/thread-surface.test.ts
+++ b/src/slack/thread-surface.test.ts
@@ -143,3 +143,109 @@ describe('ThreadSurface.buildCombinedBlocks — P2 B2 guard', () => {
     expect(hasTaskListEmbed(blocks)).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// P3 (PHASE>=3) — setChoiceMeta + clearChoice (extended pendingChoice clear)
+// ---------------------------------------------------------------------------
+
+describe('ThreadSurface — P3 setChoiceMeta / clearChoice', () => {
+  const originalPhase = config.ui.fiveBlockPhase;
+
+  afterEach(() => {
+    config.ui.fiveBlockPhase = originalPhase;
+    vi.clearAllMocks();
+  });
+
+  function makeP3Deps(session: ConversationSession) {
+    const slackApi = {
+      getClient: vi.fn().mockReturnValue({}),
+      getPermalink: vi.fn().mockResolvedValue('https://slack.example/p1'),
+      postMessage: vi.fn().mockResolvedValue({ ts: 'panel-ts' }),
+      updateMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const claudeHandler = {
+      getSessionByKey: vi.fn().mockReturnValue(session),
+      getSessionKey: vi.fn().mockReturnValue('C1:t1.0'),
+    };
+    const requestCoordinator = { isRequestActive: vi.fn().mockReturnValue(false) };
+    const todoManager = { getTodos: vi.fn().mockReturnValue([]), getEffectiveStatus: vi.fn() };
+    return {
+      slackApi: slackApi as any,
+      claudeHandler: claudeHandler as any,
+      requestCoordinator: requestCoordinator as any,
+      todoManager: todoManager as any,
+    };
+  }
+
+  it('setChoiceMeta writes choiceMessageTs + waitingForChoice and attempts permalink', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    const deps = makeP3Deps(session);
+    const surface = new ThreadSurface(deps);
+
+    await surface.setChoiceMeta('C1:t1.0', 'choice-ts-1');
+
+    expect(session.actionPanel?.choiceMessageTs).toBe('choice-ts-1');
+    expect(session.actionPanel?.waitingForChoice).toBe(true);
+    // Permalink fetch fires (fire-and-forget) — allow pending microtasks to run
+    await new Promise((r) => setImmediate(r));
+    expect(deps.slackApi.getPermalink).toHaveBeenCalledWith('C1', 'choice-ts-1');
+  });
+
+  it('setChoiceMeta does NOT write choiceBlocks (the B3 message owns its own buttons)', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    const deps = makeP3Deps(session);
+    const surface = new ThreadSurface(deps);
+
+    await surface.setChoiceMeta('C1:t1.0', 'choice-ts-2');
+    expect(session.actionPanel?.choiceBlocks).toBeUndefined();
+  });
+
+  it('setChoiceMeta is a no-op below PHASE=3', async () => {
+    config.ui.fiveBlockPhase = 2;
+    const session = makeSession();
+    const deps = makeP3Deps(session);
+    const surface = new ThreadSurface(deps);
+
+    await surface.setChoiceMeta('C1:t1.0', 'never-written');
+    expect(session.actionPanel?.choiceMessageTs).toBeUndefined();
+    expect(deps.slackApi.getPermalink).not.toHaveBeenCalled();
+  });
+
+  it('setChoiceMeta is a no-op when session is missing', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const deps = makeP3Deps({} as any);
+    (deps.claudeHandler.getSessionByKey as any) = vi.fn().mockReturnValue(undefined);
+    const surface = new ThreadSurface(deps);
+    await expect(surface.setChoiceMeta('missing', 'ts')).resolves.toBeUndefined();
+    expect(deps.slackApi.getPermalink).not.toHaveBeenCalled();
+  });
+
+  it('clearChoice also clears pendingChoice (P3)', async () => {
+    config.ui.fiveBlockPhase = 3;
+    const session = makeSession();
+    session.actionPanel = {
+      choiceMessageTs: 'ts-xyz',
+      choiceMessageLink: 'link',
+      waitingForChoice: true,
+      choiceBlocks: [{ type: 'section' } as any],
+      pendingChoice: {
+        turnId: 'turn-1',
+        kind: 'single',
+        choiceTs: 'ts-xyz',
+        formIds: [],
+        question: {} as any,
+        createdAt: 1,
+      },
+    };
+    const deps = makeP3Deps(session);
+    const surface = new ThreadSurface(deps);
+    await surface.clearChoice('C1:t1.0');
+    expect(session.actionPanel?.pendingChoice).toBeUndefined();
+    expect(session.actionPanel?.choiceBlocks).toBeUndefined();
+    expect(session.actionPanel?.waitingForChoice).toBe(false);
+    expect(session.actionPanel?.choiceMessageTs).toBeUndefined();
+    expect(session.actionPanel?.choiceMessageLink).toBeUndefined();
+  });
+});

--- a/src/slack/thread-surface.ts
+++ b/src/slack/thread-surface.ts
@@ -253,6 +253,53 @@ export class ThreadSurface {
   }
 
   /**
+   * P3 (PHASE>=3) — lightweight metadata update for a posted B3 choice
+   * message. Writes `choiceMessageTs`, `waitingForChoice=true`, and resolves
+   * `choiceMessageLink` via permalink lookup. Does NOT write `choiceBlocks`
+   * (the B3 single-writer owns the buttons in its own message).
+   *
+   * Equivalent to attachChoice() minus the choiceBlocks write. Used by
+   * ThreadPanel.askUser / askUserForm P3 path AFTER session state has been
+   * written synchronously — this method is fire-and-forget for the
+   * permalink warm-up.
+   *
+   * Safe to call with `config.ui.fiveBlockPhase < 3`: it degrades to a
+   * no-op (legacy code should use attachChoice instead).
+   */
+  async setChoiceMeta(sessionKey: string, ts: string): Promise<void> {
+    if (config.ui.fiveBlockPhase < 3) return;
+    const session = this.deps.claudeHandler.getSessionByKey(sessionKey);
+    if (!session) return;
+    if (!session.actionPanel) {
+      session.actionPanel = {
+        channelId: session.channelId,
+        userId: session.ownerId,
+      };
+    }
+    session.actionPanel.choiceMessageTs = ts;
+    session.actionPanel.waitingForChoice = true;
+
+    // Trigger render with current state (best-effort).
+    try {
+      await this.renderViaFlush(session, sessionKey, true);
+    } catch (err) {
+      this.logger.warn('setChoiceMeta: render failed', {
+        sessionKey,
+        error: (err as Error)?.message ?? String(err),
+      });
+    }
+
+    // Permalink lookup (fire-and-forget, same pattern as attachChoice).
+    this.resolveChoicePermalink(session, ts).catch((err) => {
+      this.logger.warn('setChoiceMeta: permalink resolve failed', {
+        sessionKey,
+        ts,
+        error: (err as Error)?.message ?? String(err),
+      });
+    });
+  }
+
+  /**
    * Clear pending choice and force-render.
    */
   async clearChoice(sessionKey: string): Promise<void> {
@@ -263,6 +310,8 @@ export class ThreadSurface {
     session.actionPanel.waitingForChoice = false;
     session.actionPanel.choiceMessageTs = undefined;
     session.actionPanel.choiceMessageLink = undefined;
+    // P3: also clear the authoritative pending record (if present).
+    session.actionPanel.pendingChoice = undefined;
 
     await this.renderViaFlush(session, sessionKey, true);
   }

--- a/src/slack/turn-surface.test.ts
+++ b/src/slack/turn-surface.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { config } from '../config';
-import { TurnSurface } from './turn-surface';
+import { type TurnAddress, TurnSurface } from './turn-surface';
 
 /**
  * TurnSurface unit tests (Issue #525, P1).
@@ -500,7 +500,8 @@ describe('TurnSurface', () => {
       config.ui.fiveBlockPhase = 2;
       const client = makeClient();
       const surface = new TurnSurface({ slackApi: makeSlackApi(client) });
-      await expect(surface.askUser('any-turn', { x: 1 })).resolves.toBe('');
+      const addr = { channelId: 'C1', threadTs: 't1', sessionKey: 'C1:t1' };
+      await expect(surface.askUser('any-turn', { blocks: [] }, 'Q', addr)).resolves.toBe('');
     });
   });
 
@@ -698,6 +699,187 @@ describe('TurnSurface', () => {
         surface.renderTasks('t', todos as any, { channelId: 'C', threadTs: 't', sessionKey: 'C:t' }),
       ).resolves.toBe(false);
       expect(client.chat.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // B3 choice (P3) — askUser / askUserForm / resolveChoice / resolveMultiChoice
+  // -------------------------------------------------------------------------
+
+  describe('TurnSurface — P3 (PHASE>=3) B3 choice', () => {
+    beforeEach(() => {
+      config.ui.fiveBlockPhase = 3;
+    });
+
+    function makeSurfaceWithApi(overrides?: Partial<MockClient['chat']>) {
+      const client = makeClient(overrides);
+      const slackApi = {
+        getClient: vi.fn().mockReturnValue(client),
+        updateMessage: vi.fn().mockResolvedValue(undefined),
+      } as any;
+      const surface = new TurnSurface({ slackApi });
+      return { surface, client, slackApi };
+    }
+
+    it('askUser posts message and returns ts', async () => {
+      const { surface, client } = makeSurfaceWithApi({
+        postMessage: vi.fn().mockResolvedValue({ ts: 'msg-1' }),
+      });
+      const addr: TurnAddress = { channelId: 'C1', threadTs: 'thr-1', sessionKey: 'C1:thr-1' };
+      const ts = await surface.askUser('turn-1', { blocks: [{ type: 'section' }] }, 'Q?', addr);
+      expect(ts).toBe('msg-1');
+      expect(client.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C1',
+          thread_ts: 'thr-1',
+          text: 'Q?',
+          blocks: [{ type: 'section' }],
+        }),
+      );
+    });
+
+    it('askUser stamps choiceTs on turn state when turn exists', async () => {
+      const { surface } = makeSurfaceWithApi({
+        postMessage: vi.fn().mockResolvedValue({ ts: 'msg-stamped' }),
+      });
+      await surface.begin({ channelId: 'C', threadTs: 'thr', sessionKey: 'C:thr', turnId: 'turn-1' });
+      const addr: TurnAddress = { channelId: 'C', threadTs: 'thr', sessionKey: 'C:thr' };
+      await surface.askUser('turn-1', { blocks: [] }, 'Q?', addr);
+      expect(surface._getChoiceTs('turn-1')).toBe('msg-stamped');
+      await surface.end('turn-1', 'completed');
+    });
+
+    it('askUser tolerates missing turn state (turn may have ended)', async () => {
+      const { surface } = makeSurfaceWithApi({
+        postMessage: vi.fn().mockResolvedValue({ ts: 'msg-orphan' }),
+      });
+      const addr: TurnAddress = { channelId: 'C', sessionKey: 'C:t' };
+      // No begin() — askUser should still work.
+      await expect(surface.askUser('orphan-turn', { blocks: [] }, 'Q', addr)).resolves.toBe('msg-orphan');
+    });
+
+    it('askUser returns empty string below PHASE=3', async () => {
+      config.ui.fiveBlockPhase = 2;
+      const { surface, client } = makeSurfaceWithApi();
+      const addr: TurnAddress = { channelId: 'C', sessionKey: 'C:t' };
+      const ts = await surface.askUser('turn-1', { blocks: [] }, 'Q?', addr);
+      expect(ts).toBe('');
+      expect(client.chat.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('askUser throws when postMessage returns no ts', async () => {
+      const { surface } = makeSurfaceWithApi({
+        postMessage: vi.fn().mockResolvedValue({}),
+      });
+      const addr: TurnAddress = { channelId: 'C', sessionKey: 'C:t' };
+      await expect(surface.askUser('turn-1', { blocks: [] }, 'Q', addr)).rejects.toThrow();
+    });
+
+    it('askUser omits thread_ts when address has none (DM root)', async () => {
+      const { surface, client } = makeSurfaceWithApi({
+        postMessage: vi.fn().mockResolvedValue({ ts: 'msg-dm' }),
+      });
+      const addr: TurnAddress = { channelId: 'D1', sessionKey: 'D1:root' };
+      await surface.askUser('turn-1', { blocks: [] }, 'Q', addr);
+      const postArgs = client.chat.postMessage.mock.calls[0][0];
+      expect(postArgs.thread_ts).toBeUndefined();
+      expect(postArgs.channel).toBe('D1');
+    });
+
+    it('askUserForm posts per chunk and accumulates formTsList', async () => {
+      const { surface, client } = makeSurfaceWithApi({
+        postMessage: vi.fn().mockResolvedValueOnce({ ts: 'msg-1' }).mockResolvedValueOnce({ ts: 'msg-2' }),
+      });
+      await surface.begin({ channelId: 'C', threadTs: 'thr', sessionKey: 'C:thr', turnId: 'turn-1' });
+      const addr: TurnAddress = { channelId: 'C', threadTs: 'thr', sessionKey: 'C:thr' };
+      const ts1 = await surface.askUserForm('turn-1', { blocks: [] }, 'Q1', addr);
+      const ts2 = await surface.askUserForm('turn-1', { blocks: [] }, 'Q2', addr);
+      expect(ts1).toBe('msg-1');
+      expect(ts2).toBe('msg-2');
+      expect(surface._getFormTsList('turn-1')).toEqual(['msg-1', 'msg-2']);
+      expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it('askUserForm returns empty string below PHASE=3', async () => {
+      config.ui.fiveBlockPhase = 2;
+      const { surface } = makeSurfaceWithApi();
+      const addr: TurnAddress = { channelId: 'C', sessionKey: 'C:t' };
+      await expect(surface.askUserForm('t', { blocks: [] }, 'Q', addr)).resolves.toBe('');
+    });
+
+    it('askUserForm throws when postMessage returns no ts', async () => {
+      const { surface } = makeSurfaceWithApi({
+        postMessage: vi.fn().mockResolvedValue({}),
+      });
+      const addr: TurnAddress = { channelId: 'C', sessionKey: 'C:t' };
+      await expect(surface.askUserForm('turn-1', { blocks: [] }, 'Q', addr)).rejects.toThrow();
+    });
+
+    it('resolveChoice updates the message via slackApi.updateMessage', async () => {
+      const { surface, slackApi } = makeSurfaceWithApi();
+      await surface.resolveChoice('C', 'msg-1', 'done', [{ type: 'section' }]);
+      expect(slackApi.updateMessage).toHaveBeenCalledWith('C', 'msg-1', 'done', [{ type: 'section' }], []);
+    });
+
+    it('resolveChoice is a no-op below PHASE=3', async () => {
+      config.ui.fiveBlockPhase = 2;
+      const { surface, slackApi } = makeSurfaceWithApi();
+      await surface.resolveChoice('C', 'msg-1', 'done', []);
+      expect(slackApi.updateMessage).not.toHaveBeenCalled();
+    });
+
+    it('resolveChoice swallows message_not_found (idempotent)', async () => {
+      const { surface, slackApi } = makeSurfaceWithApi();
+      slackApi.updateMessage = vi.fn().mockRejectedValue({ data: { error: 'message_not_found' }, message: 'gone' });
+      await expect(surface.resolveChoice('C', 'gone-ts', 'x', [])).resolves.toBeUndefined();
+    });
+
+    it('resolveChoice rethrows non-message_not_found errors', async () => {
+      const { surface, slackApi } = makeSurfaceWithApi();
+      slackApi.updateMessage = vi.fn().mockRejectedValue({ data: { error: 'rate_limited' }, message: 'rl' });
+      await expect(surface.resolveChoice('C', 'ts', 'x', [])).rejects.toBeTruthy();
+    });
+
+    it('resolveMultiChoice iterates best-effort per ts', async () => {
+      const { surface, slackApi } = makeSurfaceWithApi();
+      slackApi.updateMessage = vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce({ data: { error: 'message_not_found' } })
+        .mockResolvedValueOnce(undefined);
+      await surface.resolveMultiChoice('C', ['t1', 't2', 't3'], 'done', []);
+      expect(slackApi.updateMessage).toHaveBeenCalledTimes(3);
+    });
+
+    it('resolveMultiChoice continues past non-message_not_found errors (best-effort)', async () => {
+      const { surface, slackApi } = makeSurfaceWithApi();
+      slackApi.updateMessage = vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce({ data: { error: 'rate_limited' } })
+        .mockResolvedValueOnce(undefined);
+      await surface.resolveMultiChoice('C', ['t1', 't2', 't3'], 'done', []);
+      expect(slackApi.updateMessage).toHaveBeenCalledTimes(3);
+    });
+
+    it('resolveMultiChoice is a no-op below PHASE=3', async () => {
+      config.ui.fiveBlockPhase = 2;
+      const { surface, slackApi } = makeSurfaceWithApi();
+      await surface.resolveMultiChoice('C', ['t1', 't2'], 'done', []);
+      expect(slackApi.updateMessage).not.toHaveBeenCalled();
+    });
+
+    it('end() does NOT force-resolve a pending choice (outlives turn)', async () => {
+      // Verify no calls to updateMessage from end() path
+      const { surface, slackApi } = makeSurfaceWithApi({
+        postMessage: vi.fn().mockResolvedValue({ ts: 'msg-1' }),
+      });
+      slackApi.updateMessage = vi.fn();
+      await surface.begin({ channelId: 'C', threadTs: 'thr', sessionKey: 'C:thr', turnId: 'turn-1' });
+      const addr: TurnAddress = { channelId: 'C', threadTs: 'thr', sessionKey: 'C:thr' };
+      await surface.askUser('turn-1', { blocks: [] }, 'Q', addr);
+      await surface.end('turn-1', 'completed');
+      expect(slackApi.updateMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/slack/turn-surface.ts
+++ b/src/slack/turn-surface.ts
@@ -90,6 +90,17 @@ interface TurnState {
    * renderTasks without a prior begin()) also use this field.
    */
   planTs?: string;
+  /**
+   * P3 single-choice ts. Set by askUser() on successful post. NON-AUTHORITATIVE
+   * (the source of truth is session.actionPanel.pendingChoice.choiceTs, written
+   * by ThreadPanel). Here purely for per-turn debug/observability.
+   */
+  choiceTs?: string;
+  /**
+   * P3 multi-choice form ts list. Populated by askUserForm() per chunk.
+   * Same observability-only semantics as choiceTs.
+   */
+  formTsList: string[];
   startedAt: number;
   /** Monotonic counter of appended chunks (debug/observability). */
   appendedChunks: number;
@@ -189,6 +200,7 @@ export class TurnSurface {
       startedAt: Date.now(),
       appendedChunks: 0,
       closing: false,
+      formTsList: [],
     });
     this.activeTurn.set(ctx.sessionKey, ctx.turnId);
 
@@ -323,6 +335,7 @@ export class TurnSurface {
         startedAt: Date.now(),
         appendedChunks: 0,
         closing: false,
+        formTsList: [],
       };
       this.turns.set(turnId, state);
     }
@@ -402,16 +415,143 @@ export class TurnSurface {
   }
 
   /**
-   * B3 (choice block) entry point — activated in P3.
+   * B3 (single choice) post — PHASE>=3. Posts a pre-built single-choice
+   * payload as a fresh `chat.postMessage`. Returns the message ts so the
+   * caller (ThreadPanel) can synchronously write it into session state.
    *
-   * In P1 (PHASE<3) this returns immediately; the legacy user-choice-handler
-   * flow continues to own B3. Returning an empty string is a deliberate
-   * sentinel — P3 will return a selection id.
+   * TurnSurface stays writer-only: it does NOT touch session state,
+   * pending-choice records, or permalinks. Those are ThreadPanel's job.
+   *
+   * PHASE<3: returns empty string (sentinel, caller falls back to legacy).
+   * Failure: throws (caller's try/catch handles rollback).
+   *
+   * `address` is required because the turn may have already ended by post
+   * time; `turnId` is observability-only (looked up in `this.turns` to
+   * stamp `state.choiceTs` on success; missing turnState is tolerated).
    */
-  async askUser(turnId: string, _payload: unknown): Promise<string> {
+  async askUser(
+    turnId: string,
+    builtPayload: { blocks?: any[]; attachments?: any[] },
+    text: string,
+    address: TurnAddress,
+  ): Promise<string> {
     if (this.phase() < 3) return '';
-    this.logger.debug('askUser invoked before P3 wiring', { turnId });
-    return '';
+    const client = this.deps.slackApi.getClient();
+    const postArgs: Record<string, unknown> = {
+      channel: address.channelId,
+      text,
+      ...builtPayload,
+    };
+    if (address.threadTs) postArgs.thread_ts = address.threadTs;
+    const result: { ts?: string } = await (client.chat as any).postMessage(postArgs);
+    if (!result?.ts) {
+      throw new Error('chat.postMessage returned no ts');
+    }
+    const state = this.turns.get(turnId);
+    if (state) state.choiceTs = result.ts;
+    this.logger.debug('B3 single-choice message posted', {
+      turnId,
+      choiceTs: result.ts,
+    });
+    return result.ts;
+  }
+
+  /**
+   * B3 (multi-choice chunk) post — PHASE>=3. Posts ONE chunk of a multi-
+   * choice form. Caller (ThreadPanel) loops this per chunk.
+   *
+   * Returns the chunk's message ts. Throws on failure — caller rolls back
+   * posted chunks.
+   */
+  async askUserForm(
+    turnId: string,
+    builtPayload: { blocks?: any[]; attachments?: any[] },
+    text: string,
+    address: TurnAddress,
+  ): Promise<string> {
+    if (this.phase() < 3) return '';
+    const client = this.deps.slackApi.getClient();
+    const postArgs: Record<string, unknown> = {
+      channel: address.channelId,
+      text,
+      ...builtPayload,
+    };
+    if (address.threadTs) postArgs.thread_ts = address.threadTs;
+    const result: { ts?: string } = await (client.chat as any).postMessage(postArgs);
+    if (!result?.ts) {
+      throw new Error('chat.postMessage returned no ts');
+    }
+    const state = this.turns.get(turnId);
+    if (state) state.formTsList.push(result.ts);
+    this.logger.debug('B3 multi-choice chunk posted', {
+      turnId,
+      formTs: result.ts,
+      chunkCount: state?.formTsList.length,
+    });
+    return result.ts;
+  }
+
+  /**
+   * B3 in-place resolve — PHASE>=3. Updates the single choice message with
+   * the "✅ 선택: …" completed blocks. Idempotent — swallow
+   * `message_not_found` (user or cleanup may have deleted the message).
+   */
+  async resolveChoice(
+    channelId: string,
+    choiceTs: string,
+    completedText: string,
+    completedBlocks: any[],
+  ): Promise<void> {
+    if (this.phase() < 3) return;
+    try {
+      await this.deps.slackApi.updateMessage(channelId, choiceTs, completedText, completedBlocks, []);
+      this.logger.debug('B3 single-choice resolved', { channelId, choiceTs });
+    } catch (err) {
+      const described = describeSlackError(err);
+      if (described.code === 'message_not_found') {
+        this.logger.debug('B3 resolveChoice: message already gone (idempotent)', {
+          channelId,
+          choiceTs,
+        });
+        return;
+      }
+      this.logger.warn('B3 resolveChoice: updateMessage failed', {
+        channelId,
+        choiceTs,
+        error: described,
+      });
+      throw err;
+    }
+  }
+
+  /**
+   * B3 multi-choice in-place resolve — iterates per-chunk ts update.
+   * Best-effort per chunk: a single chunk failure logs but does not abort
+   * the remaining updates (user already saw the click feedback; best to
+   * finish as many chunks as possible).
+   */
+  async resolveMultiChoice(
+    channelId: string,
+    tsList: string[],
+    completedText: string,
+    completedBlocks: any[],
+  ): Promise<void> {
+    if (this.phase() < 3) return;
+    for (const ts of tsList) {
+      try {
+        await this.deps.slackApi.updateMessage(channelId, ts, completedText, completedBlocks, []);
+        this.logger.debug('B3 multi-choice chunk resolved', { channelId, ts });
+      } catch (err) {
+        const described = describeSlackError(err);
+        if (described.code === 'message_not_found') continue;
+        this.logger.warn('B3 resolveMultiChoice: updateMessage failed', {
+          channelId,
+          ts,
+          error: described,
+        });
+        // continue rest of tsList
+      }
+    }
   }
 
   /**
@@ -603,5 +743,15 @@ export class TurnSurface {
       appendedChunks: state.appendedChunks,
       closing: state.closing,
     };
+  }
+
+  /** @internal — visibility for unit tests; do not call from production code. */
+  _getChoiceTs(turnId: string): string | undefined {
+    return this.turns.get(turnId)?.choiceTs;
+  }
+
+  /** @internal — visibility for unit tests; do not call from production code. */
+  _getFormTsList(turnId: string): string[] {
+    return this.turns.get(turnId)?.formTsList ?? [];
   }
 }

--- a/src/slack/turn-surface.ts
+++ b/src/slack/turn-surface.ts
@@ -537,21 +537,25 @@ export class TurnSurface {
     completedBlocks: any[],
   ): Promise<void> {
     if (this.phase() < 3) return;
-    for (const ts of tsList) {
-      try {
-        await this.deps.slackApi.updateMessage(channelId, ts, completedText, completedBlocks, []);
-        this.logger.debug('B3 multi-choice chunk resolved', { channelId, ts });
-      } catch (err) {
-        const described = describeSlackError(err);
-        if (described.code === 'message_not_found') continue;
-        this.logger.warn('B3 resolveMultiChoice: updateMessage failed', {
-          channelId,
-          ts,
-          error: described,
-        });
-        // continue rest of tsList
-      }
-    }
+    // Chunks are independent Slack messages — update in parallel so the user
+    // sees all resolves at roughly the same wall clock. Individual failures
+    // are logged but don't fail siblings.
+    await Promise.allSettled(
+      tsList.map(async (ts) => {
+        try {
+          await this.deps.slackApi.updateMessage(channelId, ts, completedText, completedBlocks, []);
+          this.logger.debug('B3 multi-choice chunk resolved', { channelId, ts });
+        } catch (err) {
+          const described = describeSlackError(err);
+          if (described.code === 'message_not_found') return;
+          this.logger.warn('B3 resolveMultiChoice: updateMessage failed', {
+            channelId,
+            ts,
+            error: described,
+          });
+        }
+      }),
+    );
   }
 
   /**

--- a/src/slack/user-choice-handler.ts
+++ b/src/slack/user-choice-handler.ts
@@ -23,10 +23,19 @@ export class UserChoiceHandler {
   }
 
   /**
-   * Build Slack attachment for single user choice
+   * Build Slack attachment for single user choice.
+   *
+   * Optional `turnId` threads through to per-button JSON `value` so P3
+   * (PHASE>=3) click handlers can classify stale vs live clicks. PHASE<3
+   * callers omit `turnId` to preserve byte-identical legacy output.
    */
-  static buildUserChoiceBlocks(choice: UserChoice, sessionKey: string, theme?: SessionTheme): SlackMessagePayload {
-    return ChoiceMessageBuilder.buildUserChoiceBlocks(choice, sessionKey, theme);
+  static buildUserChoiceBlocks(
+    choice: UserChoice,
+    sessionKey: string,
+    theme?: SessionTheme,
+    turnId?: string,
+  ): SlackMessagePayload {
+    return ChoiceMessageBuilder.buildUserChoiceBlocks(choice, sessionKey, theme, turnId);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,21 @@ export interface ActionPanelState {
   disabled?: boolean;
   waitingForChoice?: boolean;
   choiceBlocks?: any[];
+  /**
+   * P3 (PHASE>=3) — pending B3 choice lifecycle record. Authoritative session
+   * state for an outstanding user-choice question. Survives turn end and
+   * restart (persisted via session-registry). See docs/slack-ui-phase3.md.
+   */
+  pendingChoice?: {
+    turnId: string;
+    kind: 'single' | 'multi';
+    /** Single: message ts. Multi: primary (first form) ts. */
+    choiceTs?: string;
+    /** Multi only: form ids for all chunks. Empty for single. */
+    formIds: string[];
+    question: UserChoice | UserChoices;
+    createdAt: number;
+  };
   /** Raw question data for dashboard rendering (set when ASK_USER_QUESTION fires, cleared on answer) */
   pendingQuestion?: UserChoice | UserChoices;
   renderKey?: string;


### PR DESCRIPTION
## Summary

- Collapses B3 (question/choice block) from legacy two-path (inline message + header embed) into a **single-writer Slack message owned by `TurnSurface`**, gated on `SOMA_UI_5BLOCK_PHASE>=3`.
- `PHASE<3` byte-identical.
- **Closes #665** (epic #669 P3).

## Architecture

- **Session state SSOT**: new `session.actionPanel.pendingChoice` persisted via session-registry + broadcast to dashboard websocket on every transition. No new store.
- **Payload identity**: `turnId` embedded in single-choice + custom-input button `value` JSON + modal `private_metadata` (additive). Hero multi-choice button shape UNCHANGED (exact-shape test). Multi identity via `formId` → `pendingForm.turnId`.
- **Writer**: `TurnSurface.askUser` / `askUserForm` / `resolveChoice` / `resolveMultiChoice` (raw Slack writes only).
- **Facade**: `ThreadPanel.askUser*/resolveChoice*` — synchronous state write after post (live-click race protection), `persistAndBroadcast` on every set/clear.
- **Click classifier**: 3-way gate (legacy / p3 / stale). Stale clicks show the stale marker and never fall through to legacy.
- **Defensive supersede prelude**: clears prior `pendingChoice` before new ask; for multi also rewrites prior chunks + deletes formStore entries.
- **Partial failure rollback**: `askUserForm` chunk-N fail rolls back posted chunks + defensive clear.

## Bundled pre-existing bug fixes

- `pending.messageTs` in-place mutation → `setPendingForm` (persisted via `formStore.set()`). Restart-safe messageTs back-fill.
- `session.actionPanel.pendingQuestion` now persists + broadcasts on every write/clear across all PHASEs (dashboard restart parity).

## Rollback

- PHASE 3→2: legacy handler ignores extra `turnId` → legacy resolver. Deterministic.
- PHASE 2→3 with pre-flip message: no `turnId` + no `pendingChoice` → legacy resolver. Deterministic.
- Both directions covered by tests.

## Review history

8 iterations of codex review: 62 → 79 → 88 → 91 → 94 → 93 → 94 → **96/100 Go**. Every P0/P1 closed (turn-scoped lifetime, memory-only store, stale-click legacy fallback, form-store ownership, choiceBlocks ambiguity, matrix gaps, live-click ordering, partial-failure clear, persistence, dashboard parity).

## Files changed (21)

- Types: `src/types.ts`, `src/slack/actions/types.ts`
- Persistence: `src/session-registry.ts`
- Builders: `src/slack/choice-message-builder.ts`, `src/slack/user-choice-handler.ts`
- Surfaces: `src/slack/turn-surface.ts`, `thread-surface.ts`, `thread-panel.ts`
- Wiring: `src/slack/pipeline/stream-executor.ts`, `src/slack-handler.ts`
- Handlers: `src/slack/actions/choice-action-handler.ts`, `form-action-handler.ts`
- Tests: 8 test files (53 new tests; 0 pre-existing regressions)
- Docs: `docs/slack-ui-phase3.md` (new)

## Test plan

- [x] 7 unit test files, 53 new tests all passing
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/` 0 errors
- [ ] `ui-test choice` + `ui-test choice multi` smoke on iOS / Android / desktop before PHASE=3 dev flip (deploy gate)
- [ ] 1-week dev soak at `SOMA_UI_5BLOCK_PHASE=3` before prod flip

See `docs/slack-ui-phase3.md` for full design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <z@2lab.ai>
