### PR TITLE
[#756] 현재 지시 프롬프트 블록 — compact/reset 생존

### DIFF
--- a/src/__tests__/claude-handler.system-prompt-cache-freshness.test.ts
+++ b/src/__tests__/claude-handler.system-prompt-cache-freshness.test.ts
@@ -1,0 +1,207 @@
+/**
+ * ClaudeHandler × system prompt cache freshness (#756 PR3a fix loop #1, P1-B).
+ *
+ * Codex review: the previous flow cached the FULL system prompt on
+ * `session.systemPrompt` once per reset point and then reused it
+ * verbatim on every subsequent turn. The `<current-user-instruction>`
+ * block (active id, age, candidates, pending) became stale across
+ * normal turns until the next reset / SSOT invalidation.
+ *
+ * Fix: bypass the cache for the current-instruction block. The cached
+ * prefix is reused, but the block is re-derived from the user-scope
+ * master + pending-confirm store on every turn — guaranteeing the
+ * model sees fresh user-instruction state even between resets.
+ *
+ * This test pins the contract: pre-populate the cache, mutate the
+ * user-scope master and pending store, call `assembleSystemPromptForTurn`
+ * a SECOND time without clearing `session.systemPrompt`, and assert
+ * the returned prompt reflects the mutated state.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => {
+  const fsh = require('node:fs') as typeof import('node:fs');
+  const osh = require('node:os') as typeof import('node:os');
+  const pathh = require('node:path') as typeof import('node:path');
+  const dir = fsh.mkdtempSync(pathh.join(osh.tmpdir(), 'soma-claude-handler-cache-freshness-boot-'));
+  return { dir };
+});
+
+vi.mock('../env-paths', () => ({
+  get DATA_DIR() {
+    return state.dir;
+  },
+  get SYSTEM_PROMPT_FILE() {
+    return path.join(state.dir, '.system.prompt');
+  },
+  get MCP_CONFIG_FILE() {
+    return path.join(state.dir, 'mcp-servers.json');
+  },
+}));
+
+vi.mock('../user-settings-store', () => ({
+  userSettingsStore: {
+    getUserPersona: vi.fn().mockReturnValue('default'),
+    getUserSettings: vi.fn().mockReturnValue(undefined),
+    getUserNetworkDisabled: vi.fn().mockReturnValue(false),
+    getUserSandboxDisabled: vi.fn().mockReturnValue(false),
+  },
+  DEFAULT_SHOW_THINKING: true,
+  DEFAULT_THINKING_ENABLED: true,
+}));
+
+vi.mock('../user-memory-store', () => ({
+  formatMemoryForPrompt: vi.fn().mockReturnValue(''),
+}));
+
+import { ClaudeHandler } from '../claude-handler';
+import { McpManager } from '../mcp-manager';
+import { PendingInstructionConfirmStore } from '../slack/actions/pending-instruction-confirm-store';
+import type { ConversationSession } from '../types';
+import { getUserSessionStore, initUserSessionStore, type UserInstruction } from '../user-session-store';
+
+let TEST_DIR: string;
+const USER_ID = 'U_CACHE_FRESH_756';
+
+function mkInstr(partial: Partial<UserInstruction> & Pick<UserInstruction, 'id' | 'text'>): UserInstruction {
+  return {
+    id: partial.id,
+    text: partial.text,
+    status: partial.status ?? 'active',
+    source: partial.source ?? 'model',
+    createdAt: partial.createdAt ?? new Date(0).toISOString(),
+    completedAt: partial.completedAt,
+    cancelledAt: partial.cancelledAt,
+    linkedSessionIds: partial.linkedSessionIds ?? [],
+    sourceRawInputIds: partial.sourceRawInputIds ?? [],
+  };
+}
+
+function mkSession(partial: Partial<ConversationSession> = {}): ConversationSession {
+  return {
+    ownerId: USER_ID,
+    userId: USER_ID,
+    channelId: 'C1',
+    threadTs: 'T1',
+    isActive: true,
+    lastActivity: new Date(),
+    workflow: 'default',
+    currentInstructionId: 'inst_alpha',
+    instructions: [],
+    sessionId: 'sdk-session-already-initialized',
+    ...partial,
+  } as ConversationSession;
+}
+
+function writeMaster(instructions: UserInstruction[]): void {
+  const userDir = path.join(TEST_DIR, 'users', USER_ID);
+  fs.mkdirSync(userDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDir, 'user-session.json'),
+    JSON.stringify({ schemaVersion: 1, instructions, lifecycleEvents: [] }, null, 2),
+  );
+}
+
+beforeEach(() => {
+  TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'soma-claude-handler-cache-freshness-'));
+  state.dir = TEST_DIR;
+  initUserSessionStore(TEST_DIR);
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('ClaudeHandler.assembleSystemPromptForTurn — P1-B cache freshness', () => {
+  it('re-derives <current-user-instruction> per turn even when session.systemPrompt cache is hot', () => {
+    writeMaster([
+      mkInstr({
+        id: 'inst_alpha',
+        text: 'first instruction',
+        createdAt: new Date(Date.now() - 4 * 3600 * 1000).toISOString(),
+        linkedSessionIds: ['C1-T1'],
+      }),
+    ]);
+
+    const handler = new ClaudeHandler(new McpManager());
+    const session = mkSession();
+
+    // Turn 1 — populates `session.systemPrompt` (the cached prefix).
+    const turn1 = (handler as any).assembleSystemPromptForTurn(session) as string | undefined;
+    expect(turn1).toBeDefined();
+    expect(turn1!).toContain('active: inst_alpha · first instruction');
+    expect(typeof session.systemPrompt).toBe('string');
+    expect(session.systemPrompt!.length).toBeGreaterThan(0);
+
+    // Mutate the user-scope master AND switch the session pointer.
+    // Invalidate the store's per-userId cache so the next `load()` reads
+    // the freshly-written master from disk (mirrors what an SSOT mutator
+    // does on commit).
+    writeMaster([
+      mkInstr({
+        id: 'inst_beta',
+        text: 'second instruction (after rename)',
+        createdAt: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+        linkedSessionIds: ['C1-T1'],
+      }),
+    ]);
+    getUserSessionStore().invalidateCache(USER_ID);
+    session.currentInstructionId = 'inst_beta';
+
+    // Turn 2 — must NOT clear `session.systemPrompt`. Cached prefix stays
+    // hot (cheap rebuild gate is still satisfied), but the block must
+    // reflect the mutated state.
+    const turn2 = (handler as any).assembleSystemPromptForTurn(session) as string | undefined;
+    expect(turn2).toBeDefined();
+    expect(turn2!).toContain('active: inst_beta · second instruction (after rename)');
+    expect(turn2!).not.toContain('active: inst_alpha · first instruction');
+  });
+
+  it('renders pending: line freshness — entry added after the cache is hot still surfaces on the next turn', () => {
+    writeMaster([
+      mkInstr({
+        id: 'inst_p',
+        text: 'with pending op',
+        createdAt: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+        linkedSessionIds: ['C1-T1'],
+      }),
+    ]);
+
+    const handler = new ClaudeHandler(new McpManager());
+    const session = mkSession({ currentInstructionId: 'inst_p' });
+
+    // Wire the pending store BEFORE building. Empty for the first turn.
+    const pendingStore = new PendingInstructionConfirmStore();
+    handler.setPendingInstructionConfirmStore(pendingStore);
+
+    const turn1 = (handler as any).assembleSystemPromptForTurn(session) as string | undefined;
+    expect(turn1).toBeDefined();
+    expect(turn1!).not.toMatch(/pending: complete/);
+
+    // Add a pending entry mid-conversation. The cache should NOT mask it.
+    pendingStore.set({
+      requestId: 'req_99',
+      sessionKey: 'C1-T1',
+      channelId: 'C1',
+      threadTs: 'T1',
+      payload: { instructionOperations: [{ action: 'complete', id: 'inst_p' }] } as unknown as Parameters<
+        typeof pendingStore.set
+      >[0]['payload'],
+      createdAt: Date.now() - 60 * 1000,
+      requesterId: 'U_REQ',
+      type: 'complete',
+      by: { type: 'slack-user', id: 'U_REQ' },
+    });
+
+    const turn2 = (handler as any).assembleSystemPromptForTurn(session) as string | undefined;
+    expect(turn2).toBeDefined();
+    expect(turn2!).toMatch(/pending: complete \(requested by slack-user:U_REQ at /);
+  });
+});

--- a/src/__tests__/claude-handler.system-prompt-ordering.test.ts
+++ b/src/__tests__/claude-handler.system-prompt-ordering.test.ts
@@ -1,0 +1,172 @@
+/**
+ * ClaudeHandler × system prompt ordering (#756 PR3a fix loop #1, P1-A).
+ *
+ * Codex review: the `<current-user-instruction>` block must be the LAST
+ * non-whitespace section of the final system prompt the model sees.
+ * `PromptBuilder.buildSystemPrompt` placed it at the end of its own output,
+ * but `ClaudeHandler.streamQuery` then APPENDS `<channel-description>` and
+ * `<channel-repository>` AFTER. Net effect — the block is no longer last.
+ *
+ * Fix: assembly happens in ClaudeHandler. The block is placed AFTER all
+ * other suffixes (channel description / repo context) so it occupies the
+ * tail slot of the final string.
+ *
+ * The assembly is now exposed as a public method
+ * `ClaudeHandler.assembleSystemPromptForTurn` so we can verify ordering
+ * without a live Claude SDK call.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => {
+  const fsh = require('node:fs') as typeof import('node:fs');
+  const osh = require('node:os') as typeof import('node:os');
+  const pathh = require('node:path') as typeof import('node:path');
+  const dir = fsh.mkdtempSync(pathh.join(osh.tmpdir(), 'soma-claude-handler-ordering-boot-'));
+  return { dir };
+});
+
+vi.mock('../env-paths', () => ({
+  get DATA_DIR() {
+    return state.dir;
+  },
+  get SYSTEM_PROMPT_FILE() {
+    return path.join(state.dir, '.system.prompt');
+  },
+  get MCP_CONFIG_FILE() {
+    return path.join(state.dir, 'mcp-servers.json');
+  },
+}));
+
+vi.mock('../user-settings-store', () => ({
+  userSettingsStore: {
+    getUserPersona: vi.fn().mockReturnValue('default'),
+    getUserSettings: vi.fn().mockReturnValue(undefined),
+    getUserNetworkDisabled: vi.fn().mockReturnValue(false),
+    getUserSandboxDisabled: vi.fn().mockReturnValue(false),
+  },
+  DEFAULT_SHOW_THINKING: true,
+  DEFAULT_THINKING_ENABLED: true,
+}));
+
+vi.mock('../user-memory-store', () => ({
+  formatMemoryForPrompt: vi.fn().mockReturnValue(''),
+}));
+
+import { ClaudeHandler } from '../claude-handler';
+import { McpManager } from '../mcp-manager';
+import { CURRENT_INSTRUCTION_BLOCK_CLOSE, CURRENT_INSTRUCTION_BLOCK_OPEN } from '../prompt/current-instruction-block';
+import type { ConversationSession } from '../types';
+import { initUserSessionStore, type UserInstruction } from '../user-session-store';
+
+let TEST_DIR: string;
+const USER_ID = 'U_ORDERING_756';
+
+function mkInstr(partial: Partial<UserInstruction> & Pick<UserInstruction, 'id' | 'text'>): UserInstruction {
+  return {
+    id: partial.id,
+    text: partial.text,
+    status: partial.status ?? 'active',
+    source: partial.source ?? 'model',
+    createdAt: partial.createdAt ?? new Date(0).toISOString(),
+    completedAt: partial.completedAt,
+    cancelledAt: partial.cancelledAt,
+    linkedSessionIds: partial.linkedSessionIds ?? [],
+    sourceRawInputIds: partial.sourceRawInputIds ?? [],
+  };
+}
+
+function mkSession(partial: Partial<ConversationSession> = {}): ConversationSession {
+  return {
+    ownerId: USER_ID,
+    userId: USER_ID,
+    channelId: 'C1',
+    threadTs: 'T1',
+    isActive: true,
+    lastActivity: new Date(),
+    workflow: 'default',
+    currentInstructionId: 'inst_alpha',
+    instructions: [],
+    ...partial,
+  } as ConversationSession;
+}
+
+beforeEach(() => {
+  TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'soma-claude-handler-ordering-'));
+  state.dir = TEST_DIR;
+  initUserSessionStore(TEST_DIR);
+
+  const userDir = path.join(TEST_DIR, 'users', USER_ID);
+  fs.mkdirSync(userDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDir, 'user-session.json'),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        instructions: [
+          mkInstr({
+            id: 'inst_alpha',
+            text: 'ship the dashboard',
+            createdAt: new Date(Date.now() - 4 * 3600 * 1000).toISOString(),
+            linkedSessionIds: ['C1-T1'],
+          }),
+        ],
+        lifecycleEvents: [],
+      },
+      null,
+      2,
+    ),
+  );
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('ClaudeHandler.assembleSystemPromptForTurn — ordering', () => {
+  it('places <current-user-instruction> as the LAST non-whitespace section even when channel-description + repo context are appended', () => {
+    const handler = new ClaudeHandler(new McpManager());
+    const session = mkSession();
+
+    const slackContext = {
+      user: USER_ID,
+      channel: 'C1',
+      threadTs: 'T1',
+      channelDescription: 'engineering channel — ship code',
+      repos: ['2lab-ai/soma-work'],
+      confluenceUrl: undefined,
+    };
+
+    const prompt = (handler as any).assembleSystemPromptForTurn(session, slackContext) as string;
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(0);
+
+    // Confirm both upstream suffixes are still present so the regression
+    // surfaces if someone deletes them by accident.
+    expect(prompt).toContain('<channel-description');
+    expect(prompt).toContain('<channel-repository>');
+    expect(prompt).toContain(CURRENT_INSTRUCTION_BLOCK_OPEN);
+    expect(prompt).toContain(CURRENT_INSTRUCTION_BLOCK_CLOSE);
+
+    // Strip trailing whitespace, then assert the LAST non-whitespace
+    // section is the closing tag of the current-user-instruction block.
+    const trimmed = prompt.replace(/\s+$/, '');
+    expect(trimmed.endsWith(CURRENT_INSTRUCTION_BLOCK_CLOSE)).toBe(true);
+
+    // And the LAST occurrence of `<channel-description` and
+    // `<channel-repository>` must come BEFORE the block open tag.
+    const blockOpen = prompt.lastIndexOf(CURRENT_INSTRUCTION_BLOCK_OPEN);
+    const lastChanDesc = prompt.lastIndexOf('<channel-description');
+    const lastRepo = prompt.lastIndexOf('<channel-repository>');
+    expect(lastChanDesc).toBeGreaterThanOrEqual(0);
+    expect(lastRepo).toBeGreaterThanOrEqual(0);
+    expect(lastChanDesc).toBeLessThan(blockOpen);
+    expect(lastRepo).toBeLessThan(blockOpen);
+  });
+});

--- a/src/__tests__/prompt-builder.current-instruction.test.ts
+++ b/src/__tests__/prompt-builder.current-instruction.test.ts
@@ -1,0 +1,274 @@
+/**
+ * PromptBuilder × `<current-user-instruction>` block (#756 PR3a).
+ *
+ * The block must:
+ *   1. Live at a fixed position in the system prompt every request.
+ *   2. Be re-derived from the user-scope master (UserSessionStore) on
+ *      every call to `buildSystemPrompt(userId, workflow, session)` —
+ *      surviving compact / reset since the host re-runs the builder
+ *      against the unchanged master.
+ *   3. Surface the active instruction details when the session has a
+ *      live pointer.
+ *   4. Surface candidates + `active: null` for fresh sessions.
+ *   5. Surface a `pending: <op>` line when a confirm entry exists for
+ *      the session.
+ *
+ * The test wires the singletons via the standard `initUserSessionStore`
+ * + per-test temp dir pattern used elsewhere in the suite (#754/#755),
+ * so the prompt-builder consumes a real on-disk master.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => {
+  const fsh = require('node:fs') as typeof import('node:fs');
+  const osh = require('node:os') as typeof import('node:os');
+  const pathh = require('node:path') as typeof import('node:path');
+  const dir = fsh.mkdtempSync(pathh.join(osh.tmpdir(), 'soma-prompt-builder-current-instr-boot-'));
+  return { dir };
+});
+
+vi.mock('../env-paths', () => ({
+  get DATA_DIR() {
+    return state.dir;
+  },
+  get SYSTEM_PROMPT_FILE() {
+    return path.join(state.dir, '.system.prompt');
+  },
+}));
+
+vi.mock('../user-settings-store', () => ({
+  userSettingsStore: {
+    getUserPersona: vi.fn().mockReturnValue('default'),
+    getUserSettings: vi.fn().mockReturnValue(undefined),
+    getUserNetworkDisabled: vi.fn().mockReturnValue(false),
+  },
+}));
+
+vi.mock('../user-memory-store', () => ({
+  formatMemoryForPrompt: vi.fn().mockReturnValue(''),
+}));
+
+import { PromptBuilder } from '../prompt-builder';
+import { initUserSessionStore, type UserInstruction } from '../user-session-store';
+import {
+  CURRENT_INSTRUCTION_BLOCK_CLOSE,
+  CURRENT_INSTRUCTION_BLOCK_OPEN,
+} from '../prompt/current-instruction-block';
+import { PendingInstructionConfirmStore } from '../slack/actions/pending-instruction-confirm-store';
+import type { ConversationSession } from '../types';
+
+let TEST_DIR: string;
+const USER_ID = 'U_PROMPT_BUILDER_756';
+
+function mkInstr(partial: Partial<UserInstruction> & Pick<UserInstruction, 'id' | 'text'>): UserInstruction {
+  return {
+    id: partial.id,
+    text: partial.text,
+    status: partial.status ?? 'active',
+    source: partial.source ?? 'model',
+    createdAt: partial.createdAt ?? new Date(0).toISOString(),
+    completedAt: partial.completedAt,
+    cancelledAt: partial.cancelledAt,
+    linkedSessionIds: partial.linkedSessionIds ?? [],
+    sourceRawInputIds: partial.sourceRawInputIds ?? [],
+  };
+}
+
+function mkSession(currentInstructionId: string | null): ConversationSession {
+  return {
+    ownerId: USER_ID,
+    userId: USER_ID,
+    channelId: 'C1',
+    threadTs: 'T1',
+    isActive: true,
+    lastActivity: new Date(),
+    currentInstructionId,
+    instructions: [], // legacy field, untouched by #756
+  } as ConversationSession;
+}
+
+beforeEach(() => {
+  TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'soma-prompt-builder-current-instr-'));
+  state.dir = TEST_DIR;
+  initUserSessionStore(TEST_DIR);
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('PromptBuilder.buildSystemPrompt — <current-user-instruction>', () => {
+  it('always emits the block when a session is supplied', () => {
+    const builder = new PromptBuilder();
+    const prompt = builder.buildSystemPrompt(USER_ID, 'default', mkSession(null));
+    expect(prompt).toBeDefined();
+    expect(prompt!).toContain(CURRENT_INSTRUCTION_BLOCK_OPEN);
+    expect(prompt!).toContain(CURRENT_INSTRUCTION_BLOCK_CLOSE);
+    // Empty master + null pointer → just `active: null`, no candidates list.
+    expect(prompt!).toContain('active: null');
+  });
+
+  it('renders the active instruction line when the master + pointer line up', () => {
+    const userDir = path.join(TEST_DIR, 'users', USER_ID);
+    fs.mkdirSync(userDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(userDir, 'user-session.json'),
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          instructions: [
+            mkInstr({
+              id: 'inst_alpha',
+              text: 'ship the dashboard',
+              createdAt: new Date(Date.now() - 4 * 3600 * 1000).toISOString(),
+              linkedSessionIds: ['C1-T1'],
+            }),
+          ],
+          lifecycleEvents: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const builder = new PromptBuilder();
+    const prompt = builder.buildSystemPrompt(USER_ID, 'default', mkSession('inst_alpha'));
+    expect(prompt!).toContain('active: inst_alpha · ship the dashboard');
+    expect(prompt!).toContain('linked sessions: [C1-T1]');
+  });
+
+  it('surfaces candidate instructions when the pointer is null and the user has active rows', () => {
+    const userDir = path.join(TEST_DIR, 'users', USER_ID);
+    fs.mkdirSync(userDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(userDir, 'user-session.json'),
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          instructions: [
+            mkInstr({
+              id: 'cand_1',
+              text: 'candidate one',
+              createdAt: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
+            }),
+            mkInstr({
+              id: 'cand_2',
+              text: 'candidate two',
+              createdAt: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+            }),
+          ],
+          lifecycleEvents: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const builder = new PromptBuilder();
+    const prompt = builder.buildSystemPrompt(USER_ID, 'default', mkSession(null));
+    expect(prompt!).toContain('active: null');
+    expect(prompt!).toContain('candidates');
+    expect(prompt!).toContain('cand_1 · candidate one');
+    expect(prompt!).toContain('cand_2 · candidate two');
+  });
+
+  it('survives compact/reset — re-deriving against the unchanged master yields the same block content', () => {
+    const userDir = path.join(TEST_DIR, 'users', USER_ID);
+    fs.mkdirSync(userDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(userDir, 'user-session.json'),
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          instructions: [
+            mkInstr({
+              id: 'inst_persistent',
+              text: 'survive compact',
+              createdAt: new Date(Date.now() - 6 * 3600 * 1000).toISOString(),
+              linkedSessionIds: ['C1-T1'],
+            }),
+          ],
+          lifecycleEvents: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const builder = new PromptBuilder();
+    const session = mkSession('inst_persistent');
+
+    const before = builder.buildSystemPrompt(USER_ID, 'default', session);
+    // Simulate compact/reset: the host reruns buildSystemPrompt with the
+    // same session + same master. The block must reappear identically.
+    const after = builder.buildSystemPrompt(USER_ID, 'default', session);
+
+    const extract = (s: string | undefined): string => {
+      if (!s) return '';
+      const i = s.indexOf(CURRENT_INSTRUCTION_BLOCK_OPEN);
+      const j = s.indexOf(CURRENT_INSTRUCTION_BLOCK_CLOSE);
+      return i >= 0 && j >= 0 ? s.slice(i, j + CURRENT_INSTRUCTION_BLOCK_CLOSE.length) : '';
+    };
+    expect(extract(before)).not.toBe('');
+    expect(extract(after)).toBe(extract(before));
+  });
+
+  it('surfaces a pending: line when the pending-confirm store has an entry for this session', () => {
+    const userDir = path.join(TEST_DIR, 'users', USER_ID);
+    fs.mkdirSync(userDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(userDir, 'user-session.json'),
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          instructions: [
+            mkInstr({
+              id: 'inst_p',
+              text: 'with pending op',
+              createdAt: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+              linkedSessionIds: ['C1-T1'],
+            }),
+          ],
+          lifecycleEvents: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const pendingStore = new PendingInstructionConfirmStore();
+    pendingStore.set({
+      requestId: 'req_42',
+      sessionKey: 'C1-T1',
+      channelId: 'C1',
+      threadTs: 'T1',
+      payload: { instructionOperations: [{ action: 'complete', id: 'inst_p' }] } as unknown as Parameters<
+        typeof pendingStore.set
+      >[0]['payload'],
+      createdAt: Date.now() - 60 * 1000,
+      requesterId: 'U_REQ',
+      type: 'complete',
+      by: { type: 'slack-user', id: 'U_REQ' },
+    });
+
+    const builder = new PromptBuilder({ pendingInstructionConfirmStore: pendingStore });
+    const prompt = builder.buildSystemPrompt(USER_ID, 'default', mkSession('inst_p'));
+    expect(prompt!).toMatch(/pending: complete \(requested by slack-user:U_REQ at /);
+  });
+
+  it('does not emit the block when no session is supplied (e.g. dispatch one-shot prompt build)', () => {
+    const builder = new PromptBuilder();
+    const prompt = builder.buildSystemPrompt(USER_ID, 'default');
+    // Dispatch / classifier prompts are session-less and should not be
+    // burdened with the per-session current-instruction block.
+    expect(prompt!).not.toContain(CURRENT_INSTRUCTION_BLOCK_OPEN);
+  });
+});

--- a/src/__tests__/prompt-builder.current-instruction.test.ts
+++ b/src/__tests__/prompt-builder.current-instruction.test.ts
@@ -52,14 +52,11 @@ vi.mock('../user-memory-store', () => ({
   formatMemoryForPrompt: vi.fn().mockReturnValue(''),
 }));
 
+import { CURRENT_INSTRUCTION_BLOCK_CLOSE, CURRENT_INSTRUCTION_BLOCK_OPEN } from '../prompt/current-instruction-block';
 import { PromptBuilder } from '../prompt-builder';
-import { initUserSessionStore, type UserInstruction } from '../user-session-store';
-import {
-  CURRENT_INSTRUCTION_BLOCK_CLOSE,
-  CURRENT_INSTRUCTION_BLOCK_OPEN,
-} from '../prompt/current-instruction-block';
 import { PendingInstructionConfirmStore } from '../slack/actions/pending-instruction-confirm-store';
 import type { ConversationSession } from '../types';
+import { initUserSessionStore, type UserInstruction } from '../user-session-store';
 
 let TEST_DIR: string;
 const USER_ID = 'U_PROMPT_BUILDER_756';

--- a/src/__tests__/slack-handler.prompt-builder-pending-wiring.test.ts
+++ b/src/__tests__/slack-handler.prompt-builder-pending-wiring.test.ts
@@ -1,0 +1,184 @@
+/**
+ * SlackHandler × PromptBuilder pending-store wiring (#756 PR3a fix loop #1, P1-C).
+ *
+ * Codex review: `SlackHandler` constructs the singleton
+ * `PendingInstructionConfirmStore` and threads it into `ActionHandlers`
+ * (button click reader) and `StreamExecutor` (write producer), but
+ * never into the production `PromptBuilder` owned by `ClaudeHandler`.
+ * Net effect — the `<current-user-instruction>` block's
+ * `pending: <op>` line never renders in prod despite the
+ * `prompt-builder.current-instruction.test.ts` suite covering the
+ * happy path (those tests inject the store directly into the builder
+ * constructor).
+ *
+ * Fix: SlackHandler must call
+ * `claudeHandler.setPendingInstructionConfirmStore(store)` during
+ * bootstrap so the production `PromptBuilder` sees the same singleton
+ * that `ActionHandlers` / `StreamExecutor` reference.
+ *
+ * This test exercises the production wiring end-to-end:
+ *   1. Construct `SlackHandler(app, ClaudeHandler(...), McpManager())`.
+ *   2. Use the `claudeHandler` reference to call
+ *      `assembleSystemPromptForTurn` for a session that has a pending
+ *      entry in the SlackHandler-owned store.
+ *   3. Assert the assembled prompt contains the `pending: <op>` line.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => {
+  const fsh = require('node:fs') as typeof import('node:fs');
+  const osh = require('node:os') as typeof import('node:os');
+  const pathh = require('node:path') as typeof import('node:path');
+  const dir = fsh.mkdtempSync(pathh.join(osh.tmpdir(), 'soma-slack-handler-pending-wire-boot-'));
+  return { dir };
+});
+
+vi.mock('../env-paths', () => ({
+  get DATA_DIR() {
+    return state.dir;
+  },
+  get SYSTEM_PROMPT_FILE() {
+    return path.join(state.dir, '.system.prompt');
+  },
+  get MCP_CONFIG_FILE() {
+    return path.join(state.dir, 'mcp-servers.json');
+  },
+}));
+
+vi.mock('../user-settings-store', () => ({
+  userSettingsStore: {
+    getUserPersona: vi.fn().mockReturnValue('default'),
+    getUserSettings: vi.fn().mockReturnValue(undefined),
+    getUserNetworkDisabled: vi.fn().mockReturnValue(false),
+    getUserSandboxDisabled: vi.fn().mockReturnValue(false),
+  },
+  DEFAULT_SHOW_THINKING: true,
+  DEFAULT_THINKING_ENABLED: true,
+}));
+
+vi.mock('../user-memory-store', () => ({
+  formatMemoryForPrompt: vi.fn().mockReturnValue(''),
+}));
+
+import { ClaudeHandler } from '../claude-handler';
+import { McpManager } from '../mcp-manager';
+import { SlackHandler } from '../slack-handler';
+import type { ConversationSession } from '../types';
+import { initUserSessionStore, type UserInstruction } from '../user-session-store';
+
+let TEST_DIR: string;
+const USER_ID = 'U_PROD_WIRE_756';
+
+function mkInstr(partial: Partial<UserInstruction> & Pick<UserInstruction, 'id' | 'text'>): UserInstruction {
+  return {
+    id: partial.id,
+    text: partial.text,
+    status: partial.status ?? 'active',
+    source: partial.source ?? 'model',
+    createdAt: partial.createdAt ?? new Date(0).toISOString(),
+    completedAt: partial.completedAt,
+    cancelledAt: partial.cancelledAt,
+    linkedSessionIds: partial.linkedSessionIds ?? [],
+    sourceRawInputIds: partial.sourceRawInputIds ?? [],
+  };
+}
+
+beforeEach(() => {
+  TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'soma-slack-handler-pending-wire-'));
+  state.dir = TEST_DIR;
+  initUserSessionStore(TEST_DIR);
+
+  // Master with one active instruction the session points at.
+  const userDir = path.join(TEST_DIR, 'users', USER_ID);
+  fs.mkdirSync(userDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDir, 'user-session.json'),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        instructions: [
+          mkInstr({
+            id: 'inst_prod',
+            text: 'production wiring fixture',
+            createdAt: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
+            linkedSessionIds: ['C1-T1'],
+          }),
+        ],
+        lifecycleEvents: [],
+      },
+      null,
+      2,
+    ),
+  );
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('SlackHandler × PromptBuilder pending-store wiring (P1-C)', () => {
+  it('threads the SlackHandler-owned PendingInstructionConfirmStore into the production PromptBuilder so `pending:` lines render', () => {
+    const app = { client: {}, assistant: vi.fn() } as any;
+    const mcpManager = new McpManager();
+    const claudeHandler = new ClaudeHandler(mcpManager);
+
+    // Construct SlackHandler — this is where the wiring must happen.
+    const handler = new SlackHandler(app as any, claudeHandler as any, mcpManager as any);
+
+    // Recover the SlackHandler-owned pending store via the handler's
+    // ActionHandlers context (it shares the same singleton ActionHandlers
+    // and StreamExecutor see — production invariant from PLAN §7).
+    const handlerAny = handler as any;
+    const pendingStore =
+      handlerAny.actionHandlers?.context?.pendingInstructionConfirmStore ??
+      handlerAny.actionHandlers?.deps?.pendingInstructionConfirmStore ??
+      handlerAny.actionHandlers?.pendingInstructionConfirmStore ??
+      handlerAny.streamExecutor?.deps?.pendingInstructionConfirmStore ??
+      handlerAny.streamExecutor?.pendingInstructionConfirmStore;
+
+    expect(pendingStore, 'SlackHandler must own a PendingInstructionConfirmStore singleton').toBeDefined();
+
+    // Stage a pending entry for the session.
+    pendingStore.set({
+      requestId: 'req_prod',
+      sessionKey: 'C1-T1',
+      channelId: 'C1',
+      threadTs: 'T1',
+      payload: { instructionOperations: [{ action: 'complete', id: 'inst_prod' }] },
+      createdAt: Date.now() - 30 * 1000,
+      requesterId: 'U_REQ',
+      type: 'complete',
+      by: { type: 'slack-user', id: 'U_REQ' },
+    });
+
+    // Drive a turn through the production seam.
+    const session: ConversationSession = {
+      ownerId: USER_ID,
+      userId: USER_ID,
+      channelId: 'C1',
+      threadTs: 'T1',
+      isActive: true,
+      lastActivity: new Date(),
+      workflow: 'default',
+      currentInstructionId: 'inst_prod',
+      instructions: [],
+    } as ConversationSession;
+
+    const prompt = (claudeHandler as any).assembleSystemPromptForTurn(session, {
+      user: USER_ID,
+      channel: 'C1',
+      threadTs: 'T1',
+    }) as string | undefined;
+
+    expect(prompt, 'production system prompt should not be empty').toBeDefined();
+    expect(prompt!).toMatch(/pending: complete \(requested by slack-user:U_REQ at /);
+  });
+});

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -220,7 +220,9 @@ export class ClaudeHandler {
    * `<current-user-instruction>` block never renders the
    * `pending: <op>` line in prod even though tests cover the path.
    */
-  setPendingInstructionConfirmStore(store: import('./slack/actions/pending-instruction-confirm-store').PendingInstructionConfirmStore): void {
+  setPendingInstructionConfirmStore(
+    store: import('./slack/actions/pending-instruction-confirm-store').PendingInstructionConfirmStore,
+  ): void {
     this.promptBuilder.setPendingInstructionConfirmStore(store);
   }
 

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -212,6 +212,102 @@ export class ClaudeHandler {
   }
 
   /**
+   * Inject the SlackHandler-owned `PendingInstructionConfirmStore` into
+   * the underlying `PromptBuilder` (#756 PR3a fix loop #1, P1-C).
+   *
+   * Called by `SlackHandler` during bootstrap AFTER it constructs the
+   * shared store. Production wiring requirement: without this call, the
+   * `<current-user-instruction>` block never renders the
+   * `pending: <op>` line in prod even though tests cover the path.
+   */
+  setPendingInstructionConfirmStore(store: import('./slack/actions/pending-instruction-confirm-store').PendingInstructionConfirmStore): void {
+    this.promptBuilder.setPendingInstructionConfirmStore(store);
+  }
+
+  /**
+   * Assemble the final system prompt the model will see this turn
+   * (#756 PR3a fix loop #1, P1-A/P1-B).
+   *
+   * Layout (top → bottom):
+   *   <workflow prompt> + <persona> + <memory> + <skills>
+   *   + <user-instructions-ssot>
+   *   + <channel-description>            (if slackContext.channelDescription)
+   *   + <channel-repository>             (if repos / confluenceUrl)
+   *   + <current-user-instruction>       (LAST — re-derived per turn)
+   *
+   * Caching contract:
+   *   - The PREFIX (everything up to and including channel-repository)
+   *     is built once per reset point and cached on
+   *     `session.systemPrompt`.
+   *   - The `<current-user-instruction>` block is re-derived from the
+   *     user-scope master + pending-confirm store on EVERY turn so the
+   *     model never sees a stale snapshot, even when the prefix is
+   *     served from cache. P1-B fix.
+   *   - The block is appended AFTER channel-description / repo context
+   *     so it lands in the very last slot of the prompt — receiving the
+   *     highest recency weight in the model's attention. P1-A fix.
+   *
+   * Public so the assembly is unit-testable without spinning up the SDK
+   * (see `claude-handler.system-prompt-ordering.test.ts`).
+   */
+  assembleSystemPromptForTurn(
+    session: ConversationSession | undefined,
+    slackContext?: SlackContext,
+  ): string | undefined {
+    const workflow = session?.workflow || 'default';
+    const promptUserId = session?.ownerId || slackContext?.user;
+
+    // Rebuild gate (PLAN.md §2). The PREFIX is what we cache — channel /
+    // repo context don't change across turns within a session.
+    const shouldRebuild =
+      !session || !session.systemPrompt || session.compactionOccurred === true || !session.sessionId;
+
+    let prefix: string | undefined;
+    if (shouldRebuild) {
+      // Build the prefix WITHOUT the `<current-user-instruction>` block —
+      // we'll append a fresh one below.
+      prefix = this.promptBuilder.buildSystemPrompt(promptUserId, workflow, session, {
+        omitCurrentInstructionBlock: true,
+      });
+
+      // Inject channel description as additional context.
+      if (prefix && slackContext?.channelDescription) {
+        prefix = `${prefix}\n\n<channel-description source="slack">\n${slackContext.channelDescription}\n</channel-description>`;
+      }
+
+      // Inject structured repository context from channel registry.
+      const hasRepos = !!slackContext?.repos && slackContext.repos.length > 0;
+      const hasConfluence = !!slackContext?.confluenceUrl;
+      if (prefix && (hasRepos || hasConfluence)) {
+        prefix = `${prefix}\n\n${buildRepoContextBlock(slackContext!.repos || [], slackContext!.confluenceUrl)}`;
+      }
+
+      // Cache the prefix on the session so subsequent turns skip the
+      // rebuild until the next reset / SSOT change.
+      if (session) {
+        session.systemPrompt = prefix || undefined;
+      }
+    } else {
+      // Reuse the cached prefix.
+      prefix = session!.systemPrompt;
+    }
+
+    // Re-derive the `<current-user-instruction>` block FRESH every turn.
+    let block: string | undefined;
+    if (session && (session.ownerId || promptUserId)) {
+      const masterUserId = session.ownerId || promptUserId;
+      if (masterUserId) {
+        block = this.promptBuilder.buildCurrentInstructionBlockForSession(masterUserId, session);
+      }
+    }
+
+    if (prefix && block) return `${prefix}\n\n${block}`;
+    if (prefix) return prefix;
+    if (block) return block;
+    return undefined;
+  }
+
+  /**
    * Resolve effective plugin paths dynamically from PluginManager.
    * Called each time a new session is created so that forceRefresh/rollback
    * changes are immediately reflected without service restart.
@@ -1127,40 +1223,15 @@ export class ClaudeHandler {
       // SSOT mutators (InstructionConfirmActionHandler.handleYes,
       // regenerateInstructionsSummaryIfStale) clear `session.systemPrompt`
       // on change so the next turn lands on branch (c) and rebuilds.
+      //
+      // PR3a fix loop #1 (#756 P1-A/P1-B): the cached snapshot is the
+      // *prefix* only — `<current-user-instruction>` is re-derived per
+      // turn and appended AFTER channel-description / repo context so it
+      // (1) sits at the very tail of the prompt and (2) reflects fresh
+      // user-instruction state on every turn even when the prefix is
+      // cached. See `assembleSystemPromptForTurn` for the assembly seam.
       const workflow = session?.workflow || 'default';
-      const promptUserId = session?.ownerId || slackContext?.user;
-      const shouldRebuild =
-        !session || !session.systemPrompt || session.compactionOccurred === true || !session.sessionId;
-
-      let builtSystemPrompt: string | undefined;
-      if (shouldRebuild) {
-        builtSystemPrompt = this.promptBuilder.buildSystemPrompt(promptUserId, workflow, session);
-
-        // Inject channel description as additional context
-        if (builtSystemPrompt && slackContext?.channelDescription) {
-          builtSystemPrompt = `${builtSystemPrompt}\n\n<channel-description source="slack">\n${slackContext.channelDescription}\n</channel-description>`;
-        }
-
-        // Inject structured repository context from channel registry.
-        // This provides explicit repo identification so the model doesn't
-        // have to guess from raw description.
-        const hasRepos = slackContext?.repos && slackContext.repos.length > 0;
-        const hasConfluence = !!slackContext?.confluenceUrl;
-        if (builtSystemPrompt && (hasRepos || hasConfluence)) {
-          builtSystemPrompt = `${builtSystemPrompt}\n\n${buildRepoContextBlock(slackContext!.repos || [], slackContext!.confluenceUrl)}`;
-        }
-
-        // Cache the freshly-built prompt on the session so subsequent turns
-        // skip the rebuild until the next reset / SSOT change.
-        if (session) {
-          session.systemPrompt = builtSystemPrompt || undefined;
-        }
-      } else {
-        // Reuse the cached snapshot. Skip channel / repo injection —
-        // they were baked in at build time and don't change across turns
-        // within the same logical session.
-        builtSystemPrompt = session!.systemPrompt;
-      }
+      const builtSystemPrompt = this.assembleSystemPromptForTurn(session, slackContext);
       if (builtSystemPrompt) {
         options.systemPrompt = builtSystemPrompt;
         this.logger.info(`\uD83D\uDE80 STARTING QUERY with workflow: [${workflow}]`, {

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -91,6 +91,22 @@ export class PromptBuilder {
   }
 
   /**
+   * Inject the pending-instruction confirm store after construction
+   * (#756 PR3a fix loop #1, P1-C).
+   *
+   * The singleton `PromptBuilder` is created by `ClaudeHandler` before
+   * `SlackHandler` constructs the shared `PendingInstructionConfirmStore`,
+   * so production wiring is a setter — `SlackHandler` calls
+   * `claudeHandler.setPendingInstructionConfirmStore(store)` during
+   * bootstrap, which forwards here. Without this, the
+   * `<current-user-instruction>` block never renders the
+   * `pending: <op>` line in production.
+   */
+  setPendingInstructionConfirmStore(store: PendingInstructionConfirmStore): void {
+    this.pendingInstructionConfirmStore = store;
+  }
+
+  /**
    * Get the resolved prompt directory (for testing)
    */
   getPromptDir(): string {
@@ -383,6 +399,17 @@ export class PromptBuilder {
   }
 
   /**
+   * Options for `buildSystemPrompt` (#756 PR3a fix loop #1).
+   *
+   * `omitCurrentInstructionBlock` lets the caller skip the trailing
+   * `<current-user-instruction>` block emission. Used by `ClaudeHandler`
+   * which caches the prefix on `session.systemPrompt` and re-derives the
+   * block freshly on EVERY turn — appended AFTER `<channel-description>`
+   * and `<channel-repository>` so the block lands in the very last slot.
+   * Existing callers that want the legacy (block-included) behavior pass
+   * nothing — defaults to `false`.
+   */
+  /**
    * Build the complete system prompt for a user
    * Includes base prompt (or workflow prompt) and user's persona.
    *
@@ -393,7 +420,12 @@ export class PromptBuilder {
    * reset points (first turn / reset / post-compact) + SSOT change
    * invalidations. See PLAN.md §2 for the cache protocol.
    */
-  buildSystemPrompt(userId?: string, workflow?: WorkflowType, session?: ConversationSession): string | undefined {
+  buildSystemPrompt(
+    userId?: string,
+    workflow?: WorkflowType,
+    session?: ConversationSession,
+    options?: { omitCurrentInstructionBlock?: boolean },
+  ): string | undefined {
     // Load workflow-specific prompt or default
     let systemPrompt = workflow
       ? this.loadWorkflowPrompt(workflow) || this.defaultSystemPrompt || ''
@@ -461,7 +493,14 @@ export class PromptBuilder {
     //
     // Skipped when no session is supplied (dispatch / classifier
     // one-shots are session-less).
-    if (session && (session.ownerId || userId)) {
+    //
+    // PR3a fix loop #1, P1-A: ClaudeHandler appends `<channel-description>`
+    // and `<channel-repository>` AFTER this method returns. To keep the
+    // block at the very tail of the FINAL prompt, ClaudeHandler now passes
+    // `omitCurrentInstructionBlock: true` and re-emits the block itself
+    // post-suffixes. Other callers (existing tests, dispatch) get the
+    // legacy in-line emission.
+    if (!options?.omitCurrentInstructionBlock && session && (session.ownerId || userId)) {
       const masterUserId = session.ownerId || userId;
       if (masterUserId) {
         const currentInstrBlock = this.buildCurrentInstructionBlockForSession(masterUserId, session);
@@ -486,8 +525,14 @@ export class PromptBuilder {
    * pending-confirm entry from the injected store. Failures are logged
    * and degrade to an empty string — a missing/corrupt master must not
    * sink the entire prompt build.
+   *
+   * Public so `ClaudeHandler` can re-derive the block freshly per turn
+   * (PR3a fix loop #1, P1-A/P1-B): ClaudeHandler appends channel /
+   * repo suffixes AFTER `buildSystemPrompt` returns and then appends a
+   * fresh block — keeping the block at the tail of the prompt AND
+   * keeping its content current even when the prefix is cached.
    */
-  private buildCurrentInstructionBlockForSession(userId: string, session: ConversationSession): string | undefined {
+  buildCurrentInstructionBlockForSession(userId: string, session: ConversationSession): string | undefined {
     let doc;
     try {
       doc = getUserSessionStore().load(userId);

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -8,9 +8,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SYSTEM_PROMPT_FILE } from './env-paths';
 import { Logger } from './logger';
+import { buildCurrentInstructionBlock } from './prompt/current-instruction-block';
 import { buildUserInstructionsBlock } from './prompt/user-instructions-block';
+import type { PendingInstructionConfirmStore } from './slack/actions/pending-instruction-confirm-store';
 import type { ConversationSession, WorkflowType } from './types';
 import { formatMemoryForPrompt } from './user-memory-store';
+import { getUserSessionStore, UserSessionStoreCorruptError } from './user-session-store';
 import { userSettingsStore } from './user-settings-store';
 import { listUserSkills } from './user-skill-store';
 
@@ -36,6 +39,16 @@ const VARIABLE_PATTERN = /(?<!\\)\{\{([\w.]+)\}\}/g;
 export interface PromptBuilderOptions {
   agentName?: string;
   promptDir?: string; // explicit override, takes precedence over agentName
+  /**
+   * Optional pending-confirm store (#756). When provided, `buildSystemPrompt`
+   * surfaces the active `pending: <op>` line in the
+   * `<current-user-instruction>` block. Production callers wire the
+   * SlackHandler-owned singleton; tests inject their own.
+   *
+   * Left optional so session-less dispatch / classifier prompt builds (and
+   * existing tests) keep working without touching the pending store.
+   */
+  pendingInstructionConfirmStore?: PendingInstructionConfirmStore;
 }
 
 /**
@@ -53,10 +66,13 @@ export class PromptBuilder {
   private fallbackPromptDir: string;
   /** Agent name (undefined for main bot) */
   private agentName: string | undefined;
+  /** Optional pending-instruction confirm store (#756). */
+  private pendingInstructionConfirmStore: PendingInstructionConfirmStore | undefined;
 
   constructor(options?: PromptBuilderOptions) {
     this.fallbackPromptDir = PROMPT_DIR;
     this.agentName = options?.agentName;
+    this.pendingInstructionConfirmStore = options?.pendingInstructionConfirmStore;
 
     if (options?.promptDir) {
       // Explicit prompt dir override
@@ -433,6 +449,28 @@ export class PromptBuilder {
       }
     }
 
+    // Inject `<current-user-instruction>` dual-protection block (#756).
+    //
+    // FIXED POSITION: rendered AFTER the legacy user-instructions-ssot
+    // block so it occupies the very last slot of the system prompt and
+    // receives the highest recency weight in the model's attention. The
+    // host re-runs `buildSystemPrompt` at every reset point (first turn /
+    // post-compact / SSOT-mutated cache invalidation), so this block is
+    // re-derived from the user-scope master each time — surviving
+    // compact/reset by construction.
+    //
+    // Skipped when no session is supplied (dispatch / classifier
+    // one-shots are session-less).
+    if (session && (session.ownerId || userId)) {
+      const masterUserId = session.ownerId || userId;
+      if (masterUserId) {
+        const currentInstrBlock = this.buildCurrentInstructionBlockForSession(masterUserId, session);
+        if (currentInstrBlock) {
+          systemPrompt = systemPrompt ? `${systemPrompt}\n\n${currentInstrBlock}` : currentInstrBlock;
+        }
+      }
+    }
+
     // Process runtime variables (e.g., {{user.email}})
     // Done last so dynamic values are always current
     if (systemPrompt) {
@@ -440,6 +478,41 @@ export class PromptBuilder {
     }
 
     return systemPrompt || undefined;
+  }
+
+  /**
+   * Render the `<current-user-instruction>` block for a session by reading
+   * the user-scope master via `getUserSessionStore()` and (optionally) the
+   * pending-confirm entry from the injected store. Failures are logged
+   * and degrade to an empty string — a missing/corrupt master must not
+   * sink the entire prompt build.
+   */
+  private buildCurrentInstructionBlockForSession(userId: string, session: ConversationSession): string | undefined {
+    let doc;
+    try {
+      doc = getUserSessionStore().load(userId);
+    } catch (err) {
+      if (err instanceof UserSessionStoreCorruptError) {
+        // Sealed contract: store NEVER overwrites a corrupt file. We
+        // log + skip the block rather than substituting a fake doc that
+        // would silently mis-inform the model about active instructions.
+        this.logger.error('Skipping <current-user-instruction>: user master is corrupt', {
+          userId,
+          file: err.file,
+        });
+      } else {
+        this.logger.error('Skipping <current-user-instruction>: failed to load user master', { userId, error: err });
+      }
+      return undefined;
+    }
+    const sessionKey = `${session.channelId}-${session.threadTs || 'direct'}`;
+    const pending = this.pendingInstructionConfirmStore?.getBySession(sessionKey);
+    return buildCurrentInstructionBlock({
+      doc,
+      sessionKey,
+      currentInstructionId: session.currentInstructionId ?? null,
+      pending,
+    });
   }
 
   /**

--- a/src/prompt/__tests__/current-instruction-block.test.ts
+++ b/src/prompt/__tests__/current-instruction-block.test.ts
@@ -15,13 +15,13 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import type { PendingInstructionConfirm } from '../../slack/actions/pending-instruction-confirm-store';
+import type { UserSessionDoc } from '../../user-session-store';
 import {
   buildCurrentInstructionBlock,
   CURRENT_INSTRUCTION_BLOCK_CLOSE,
   CURRENT_INSTRUCTION_BLOCK_OPEN,
 } from '../current-instruction-block';
-import type { UserSessionDoc } from '../../user-session-store';
-import type { PendingInstructionConfirm } from '../../slack/actions/pending-instruction-confirm-store';
 
 const NOW_MS = Date.UTC(2026, 3, 28, 12, 0, 0); // 2026-04-28 12:00 UTC
 const NOW_ISO = new Date(NOW_MS).toISOString();
@@ -269,7 +269,9 @@ describe('buildCurrentInstructionBlock', () => {
       sessionKey: 'C1-T1',
       channelId: 'C1',
       threadTs: 'T1',
-      payload: { instructionOperations: [{ action: 'complete', id: 'inst_1' }] } as unknown as PendingInstructionConfirm['payload'],
+      payload: {
+        instructionOperations: [{ action: 'complete', id: 'inst_1' }],
+      } as unknown as PendingInstructionConfirm['payload'],
       createdAt: NOW_MS - 30 * 60 * 1000,
       requesterId: 'U_REQ',
       type: 'complete',
@@ -306,7 +308,9 @@ describe('buildCurrentInstructionBlock', () => {
       sessionKey: 'C1-T1',
       channelId: 'C1',
       threadTs: 'T1',
-      payload: { instructionOperations: [{ action: 'rename', id: 'inst_1', text: 'do x prime' }] } as unknown as PendingInstructionConfirm['payload'],
+      payload: {
+        instructionOperations: [{ action: 'rename', id: 'inst_1', text: 'do x prime' }],
+      } as unknown as PendingInstructionConfirm['payload'],
       createdAt: NOW_MS - 5 * 60 * 1000,
       requesterId: 'U_REQ',
       type: 'rename',

--- a/src/prompt/__tests__/current-instruction-block.test.ts
+++ b/src/prompt/__tests__/current-instruction-block.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Tests for `<current-user-instruction>` block builder (#756).
+ *
+ * The block lives at a fixed position in the system prompt every request,
+ * is re-derived from the user-scope master (UserSessionStore) on every
+ * rebuild, and surfaces:
+ *   - the active instruction (id · title, age, linked sessions)
+ *   - explicit `active: null` when the session pointer is null
+ *   - candidate active instructions (max 5, "+ N more" overflow)
+ *   - a `pending: <op> ...` line when a y/n confirm entry exists
+ *
+ * The builder is pure — it consumes a UserSessionDoc, the session pointer,
+ * and an optional pending-confirm entry. Wiring (UserSessionStore +
+ * PendingInstructionConfirmStore lookup) is the prompt-builder's job.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildCurrentInstructionBlock,
+  CURRENT_INSTRUCTION_BLOCK_CLOSE,
+  CURRENT_INSTRUCTION_BLOCK_OPEN,
+} from '../current-instruction-block';
+import type { UserSessionDoc } from '../../user-session-store';
+import type { PendingInstructionConfirm } from '../../slack/actions/pending-instruction-confirm-store';
+
+const NOW_MS = Date.UTC(2026, 3, 28, 12, 0, 0); // 2026-04-28 12:00 UTC
+const NOW_ISO = new Date(NOW_MS).toISOString();
+
+function isoHoursAgo(h: number): string {
+  return new Date(NOW_MS - h * 3600 * 1000).toISOString();
+}
+
+function emptyDoc(): UserSessionDoc {
+  return { schemaVersion: 1, instructions: [], lifecycleEvents: [] };
+}
+
+describe('buildCurrentInstructionBlock', () => {
+  it('always emits the block — fixed position with the canonical tag', () => {
+    const doc = emptyDoc();
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: null,
+      now: () => NOW_ISO,
+    });
+    expect(block.startsWith(CURRENT_INSTRUCTION_BLOCK_OPEN)).toBe(true);
+    expect(block.endsWith(CURRENT_INSTRUCTION_BLOCK_CLOSE)).toBe(true);
+    expect(block).toContain('active: null');
+  });
+
+  it('renders the active instruction with id · title, age, and linked sessions', () => {
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions: [
+        {
+          id: 'inst_1',
+          text: 'ship the dashboard',
+          status: 'active',
+          source: 'model',
+          createdAt: isoHoursAgo(5),
+          linkedSessionIds: ['C1-T1', 'C1-T2'],
+          sourceRawInputIds: [],
+        },
+      ],
+      lifecycleEvents: [],
+    };
+
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'inst_1',
+      now: () => NOW_ISO,
+    });
+
+    expect(block).toContain('active: inst_1 · ship the dashboard');
+    expect(block).toContain('age: 5h');
+    expect(block).toContain('linked sessions: [C1-T1, C1-T2]');
+    // Active line must be the first content row inside the block.
+    const lines = block.split('\n');
+    expect(lines[1]?.trim().startsWith('active: inst_1')).toBe(true);
+  });
+
+  it('renders linked sessions as an empty list when there are no links yet', () => {
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions: [
+        {
+          id: 'inst_1',
+          text: 't',
+          status: 'active',
+          source: 'model',
+          createdAt: isoHoursAgo(0),
+          linkedSessionIds: [],
+          sourceRawInputIds: [],
+        },
+      ],
+      lifecycleEvents: [],
+    };
+
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'inst_1',
+      now: () => NOW_ISO,
+    });
+    expect(block).toContain('linked sessions: []');
+  });
+
+  it('falls back to active: null when currentInstructionId points at a missing instruction', () => {
+    // Defensive: doc.instructions does not contain `gone_id`. The block
+    // should NOT throw; it should render `active: null` so the model gets
+    // a deterministic answer instead of a half-formed line.
+    const doc = emptyDoc();
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'gone_id',
+      now: () => NOW_ISO,
+    });
+    expect(block).toContain('active: null');
+    expect(block).not.toContain('gone_id');
+  });
+
+  it('falls back to active: null when the pointed instruction is completed/cancelled', () => {
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions: [
+        {
+          id: 'done_1',
+          text: 'done',
+          status: 'completed',
+          source: 'model',
+          createdAt: isoHoursAgo(10),
+          completedAt: isoHoursAgo(1),
+          linkedSessionIds: [],
+          sourceRawInputIds: [],
+        },
+      ],
+      lifecycleEvents: [],
+    };
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'done_1',
+      now: () => NOW_ISO,
+    });
+    expect(block).toContain('active: null');
+    expect(block).not.toContain('active: done_1');
+  });
+
+  it('lists candidates from the user master when active is null, sorted by recency, max 5', () => {
+    const instructions: UserSessionDoc['instructions'] = [];
+    for (let i = 1; i <= 7; i++) {
+      instructions.push({
+        id: `c${i}`,
+        text: `candidate ${i}`,
+        status: 'active',
+        source: 'model',
+        createdAt: isoHoursAgo(20 - i), // c1 oldest, c7 newest
+        linkedSessionIds: [],
+        sourceRawInputIds: [],
+      });
+    }
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions,
+      lifecycleEvents: [],
+    };
+
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: null,
+      now: () => NOW_ISO,
+    });
+
+    expect(block).toContain('active: null');
+    expect(block).toContain('candidates');
+    // Newest 5 candidates (c7..c3); c1 and c2 dropped, surfaced as "+ N more".
+    expect(block).toContain('c7 · candidate 7');
+    expect(block).toContain('c3 · candidate 3');
+    expect(block).not.toContain('c2 · candidate 2');
+    expect(block).not.toContain('c1 · candidate 1');
+    expect(block).toContain('+ 2 more (see dashboard)');
+  });
+
+  it('omits completed/cancelled rows from the candidate list', () => {
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions: [
+        {
+          id: 'c_active',
+          text: 'live',
+          status: 'active',
+          source: 'model',
+          createdAt: isoHoursAgo(2),
+          linkedSessionIds: [],
+          sourceRawInputIds: [],
+        },
+        {
+          id: 'c_done',
+          text: 'done',
+          status: 'completed',
+          source: 'model',
+          createdAt: isoHoursAgo(3),
+          completedAt: isoHoursAgo(1),
+          linkedSessionIds: [],
+          sourceRawInputIds: [],
+        },
+        {
+          id: 'c_cancelled',
+          text: 'gone',
+          status: 'cancelled',
+          source: 'model',
+          createdAt: isoHoursAgo(4),
+          cancelledAt: isoHoursAgo(2),
+          linkedSessionIds: [],
+          sourceRawInputIds: [],
+        },
+      ],
+      lifecycleEvents: [],
+    };
+
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: null,
+      now: () => NOW_ISO,
+    });
+
+    expect(block).toContain('c_active · live');
+    expect(block).not.toContain('c_done');
+    expect(block).not.toContain('c_cancelled');
+  });
+
+  it('emits "candidates: none" when active is null and the user has no active instructions', () => {
+    const doc = emptyDoc();
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: null,
+      now: () => NOW_ISO,
+    });
+    expect(block).toContain('active: null');
+    // No candidates list emitted when the master is empty — keeps prompt
+    // noise low. The model just sees `active: null`.
+    expect(block).not.toContain('candidates');
+    expect(block).not.toContain('see dashboard');
+  });
+
+  it('emits a pending: line when a confirm entry is supplied', () => {
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions: [
+        {
+          id: 'inst_1',
+          text: 't',
+          status: 'active',
+          source: 'model',
+          createdAt: isoHoursAgo(2),
+          linkedSessionIds: [],
+          sourceRawInputIds: [],
+        },
+      ],
+      lifecycleEvents: [],
+    };
+    const pending: PendingInstructionConfirm = {
+      requestId: 'req_1',
+      sessionKey: 'C1-T1',
+      channelId: 'C1',
+      threadTs: 'T1',
+      payload: { instructionOperations: [{ action: 'complete', id: 'inst_1' }] } as unknown as PendingInstructionConfirm['payload'],
+      createdAt: NOW_MS - 30 * 60 * 1000,
+      requesterId: 'U_REQ',
+      type: 'complete',
+      by: { type: 'slack-user', id: 'U_REQ' },
+    };
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'inst_1',
+      pending,
+      now: () => NOW_ISO,
+    });
+    expect(block).toMatch(/pending: complete \(requested by slack-user:U_REQ at /);
+  });
+
+  it('still emits the block with active and pending lines together', () => {
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions: [
+        {
+          id: 'inst_1',
+          text: 'do x',
+          status: 'active',
+          source: 'model',
+          createdAt: isoHoursAgo(1),
+          linkedSessionIds: ['C1-T1'],
+          sourceRawInputIds: [],
+        },
+      ],
+      lifecycleEvents: [],
+    };
+    const pending: PendingInstructionConfirm = {
+      requestId: 'req_x',
+      sessionKey: 'C1-T1',
+      channelId: 'C1',
+      threadTs: 'T1',
+      payload: { instructionOperations: [{ action: 'rename', id: 'inst_1', text: 'do x prime' }] } as unknown as PendingInstructionConfirm['payload'],
+      createdAt: NOW_MS - 5 * 60 * 1000,
+      requesterId: 'U_REQ',
+      type: 'rename',
+      by: { type: 'slack-user', id: 'U_REQ' },
+    };
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'inst_1',
+      pending,
+      now: () => NOW_ISO,
+    });
+    expect(block).toContain('active: inst_1 · do x');
+    expect(block).toContain('pending: rename');
+    expect(block.indexOf('active:')).toBeLessThan(block.indexOf('pending:'));
+  });
+
+  it('produces the same block content from the same master across two calls (compact/reset survival)', () => {
+    // The block is re-derivable on demand: same UserSessionDoc + same
+    // session pointer must yield byte-identical output. This is the
+    // dual-protection contract — after compaction or reset the host
+    // re-runs the builder against the unchanged master and the model
+    // sees the same authoritative answer.
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions: [
+        {
+          id: 'inst_1',
+          text: 't',
+          status: 'active',
+          source: 'model',
+          createdAt: isoHoursAgo(3),
+          linkedSessionIds: ['C1-T1'],
+          sourceRawInputIds: [],
+        },
+      ],
+      lifecycleEvents: [],
+    };
+    const a = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'inst_1',
+      now: () => NOW_ISO,
+    });
+    const b = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'inst_1',
+      now: () => NOW_ISO,
+    });
+    expect(a).toBe(b);
+  });
+
+  it('truncates long instruction titles to keep the prompt compact', () => {
+    const longText = 'x'.repeat(500);
+    const doc: UserSessionDoc = {
+      schemaVersion: 1,
+      instructions: [
+        {
+          id: 'inst_1',
+          text: longText,
+          status: 'active',
+          source: 'model',
+          createdAt: isoHoursAgo(0),
+          linkedSessionIds: [],
+          sourceRawInputIds: [],
+        },
+      ],
+      lifecycleEvents: [],
+    };
+    const block = buildCurrentInstructionBlock({
+      doc,
+      sessionKey: 'C1-T1',
+      currentInstructionId: 'inst_1',
+      now: () => NOW_ISO,
+    });
+    // Single active line must not contain the full 500-char text — the
+    // builder enforces a length cap on the rendered title.
+    const activeLine = block.split('\n').find((l) => l.trim().startsWith('active:')) || '';
+    expect(activeLine.length).toBeLessThan(longText.length);
+    expect(activeLine).toContain('…');
+  });
+});

--- a/src/prompt/current-instruction-block.ts
+++ b/src/prompt/current-instruction-block.ts
@@ -1,0 +1,179 @@
+/**
+ * `<current-user-instruction>` block builder (#756, parent epic #727).
+ *
+ * Dual-protection prompt block — lives at a fixed position in the system
+ * prompt every request and is re-derived from the user-scope master
+ * (UserSessionStore) on every rebuild so the model retains a single
+ * authoritative answer to "which instruction is this turn working on?"
+ * even after compaction or reset.
+ *
+ * Pure module: callers feed in the loaded UserSessionDoc, the session's
+ * `currentInstructionId`, and (optionally) the active pending-confirm
+ * entry from `PendingInstructionConfirmStore.getBySession()`. Wiring the
+ * stores belongs in `prompt-builder.ts`.
+ *
+ * Block format (active):
+ *   <current-user-instruction>
+ *     active: <id> · <title>
+ *     age: <h>h
+ *     linked sessions: [<id>, ...]
+ *     pending: <op> (requested by <by.type>:<by.id> at <at>)   // optional
+ *   </current-user-instruction>
+ *
+ * Block format (active:null + candidates):
+ *   <current-user-instruction>
+ *     active: null
+ *     candidates (max 5):
+ *       - <id> · <title> (age <h>h)
+ *       - ...
+ *     + N more (see dashboard)                                  // optional
+ *   </current-user-instruction>
+ */
+
+import type { PendingInstructionConfirm } from '../slack/actions/pending-instruction-confirm-store';
+import type { UserInstruction, UserSessionDoc } from '../user-session-store';
+
+export const CURRENT_INSTRUCTION_BLOCK_OPEN = '<current-user-instruction>';
+export const CURRENT_INSTRUCTION_BLOCK_CLOSE = '</current-user-instruction>';
+
+/** Max candidate rows surfaced when `currentInstructionId === null`. */
+export const CURRENT_INSTRUCTION_CANDIDATE_CAP = 5;
+/** Max chars rendered for the instruction title (active or candidate). */
+export const CURRENT_INSTRUCTION_TITLE_CAP = 120;
+
+export interface BuildCurrentInstructionBlockArgs {
+  /** The full user-scope master doc. */
+  doc: UserSessionDoc;
+  /** Session lookup key — channel|threadTs (matches PendingInstructionConfirm). */
+  sessionKey: string;
+  /** Session pointer; `null`/`undefined` are normal (chat / question turns). */
+  currentInstructionId: string | null | undefined;
+  /** Pending y/n confirm entry for this session, if any. */
+  pending?: PendingInstructionConfirm | undefined;
+  /** Injectable clock — defaults to `new Date().toISOString()`. */
+  now?: () => string;
+}
+
+/**
+ * Whole-hour age between two ISO timestamps. Negative deltas (clock skew)
+ * clamp to 0 so the block never renders a misleading "-3h".
+ */
+function hoursBetween(fromIso: string, nowIso: string): number {
+  const from = Date.parse(fromIso);
+  const to = Date.parse(nowIso);
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return 0;
+  const ms = to - from;
+  if (ms <= 0) return 0;
+  return Math.floor(ms / (3600 * 1000));
+}
+
+function truncateTitle(text: string): string {
+  // Collapse internal whitespace so multi-line instructions render on one
+  // logical row, then cap to keep the block compact.
+  const flat = (text || '').replace(/\s+/g, ' ').trim();
+  if (flat.length <= CURRENT_INSTRUCTION_TITLE_CAP) return flat;
+  return `${flat.slice(0, CURRENT_INSTRUCTION_TITLE_CAP - 1)}…`;
+}
+
+function isUsableActive(inst: UserInstruction | undefined): inst is UserInstruction {
+  return !!inst && inst.status === 'active';
+}
+
+function renderPendingLine(pending: PendingInstructionConfirm): string {
+  // Mirrors the sealed `lifecycleEvents[].by` shape so the same words show
+  // up here as in the audit log; aids cross-referencing during debugging.
+  const at = new Date(pending.createdAt).toISOString();
+  return `pending: ${pending.type} (requested by ${pending.by.type}:${pending.by.id} at ${at})`;
+}
+
+function renderActiveBlock(args: {
+  inst: UserInstruction;
+  nowIso: string;
+  pending?: PendingInstructionConfirm | undefined;
+}): string {
+  const { inst, nowIso, pending } = args;
+  const ageH = hoursBetween(inst.createdAt, nowIso);
+  const linked = inst.linkedSessionIds.join(', ');
+  const lines = [
+    CURRENT_INSTRUCTION_BLOCK_OPEN,
+    `  active: ${inst.id} · ${truncateTitle(inst.text)}`,
+    `  age: ${ageH}h`,
+    `  linked sessions: [${linked}]`,
+  ];
+  if (pending) {
+    lines.push(`  ${renderPendingLine(pending)}`);
+  }
+  lines.push(CURRENT_INSTRUCTION_BLOCK_CLOSE);
+  return lines.join('\n');
+}
+
+/**
+ * Sort candidates newest-first by `createdAt`, breaking ties with `id`
+ * (deterministic — required for byte-stable re-derivation across calls).
+ */
+function sortCandidatesNewestFirst(a: UserInstruction, b: UserInstruction): number {
+  const ta = Date.parse(a.createdAt);
+  const tb = Date.parse(b.createdAt);
+  if (Number.isFinite(ta) && Number.isFinite(tb) && ta !== tb) return tb - ta;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function renderNullBlock(args: {
+  doc: UserSessionDoc;
+  nowIso: string;
+  pending?: PendingInstructionConfirm | undefined;
+}): string {
+  const { doc, nowIso, pending } = args;
+  const candidates = doc.instructions.filter((i) => i.status === 'active').sort(sortCandidatesNewestFirst);
+
+  const lines: string[] = [CURRENT_INSTRUCTION_BLOCK_OPEN, '  active: null'];
+
+  if (candidates.length > 0) {
+    const visible = candidates.slice(0, CURRENT_INSTRUCTION_CANDIDATE_CAP);
+    const overflow = candidates.length - visible.length;
+    lines.push(`  candidates (max ${CURRENT_INSTRUCTION_CANDIDATE_CAP}):`);
+    for (const c of visible) {
+      const ageH = hoursBetween(c.createdAt, nowIso);
+      lines.push(`    - ${c.id} · ${truncateTitle(c.text)} (age ${ageH}h)`);
+    }
+    if (overflow > 0) {
+      lines.push(`  + ${overflow} more (see dashboard)`);
+    }
+  }
+
+  if (pending) {
+    lines.push(`  ${renderPendingLine(pending)}`);
+  }
+
+  lines.push(CURRENT_INSTRUCTION_BLOCK_CLOSE);
+  return lines.join('\n');
+}
+
+/**
+ * Build the `<current-user-instruction>` block.
+ *
+ * Always returns a non-empty string — the block is unconditional so the
+ * model can reliably grep for the tag every turn. When the session has no
+ * active pointer and the user has no active instructions, the block still
+ * renders `active: null` (the model's deterministic fallback).
+ */
+export function buildCurrentInstructionBlock(args: BuildCurrentInstructionBlockArgs): string {
+  const nowIso = (args.now ?? (() => new Date().toISOString()))();
+  const pointer = args.currentInstructionId ?? null;
+
+  let activeInst: UserInstruction | undefined;
+  if (pointer) {
+    activeInst = args.doc.instructions.find((i) => i.id === pointer);
+  }
+
+  if (isUsableActive(activeInst)) {
+    return renderActiveBlock({ inst: activeInst, nowIso, pending: args.pending });
+  }
+
+  // Pointer is null OR resolves to a missing/completed/cancelled row →
+  // surface candidates list (max 5 with overflow notice). The pointer
+  // resolution is intentionally defensive: we mirror the same `active:
+  // null` line either way so the model never sees a half-formed
+  // reference like `active: <stale_id>` after the master moves on.
+  return renderNullBlock({ doc: args.doc, nowIso, pending: args.pending });
+}

--- a/src/slack-handler.ts
+++ b/src/slack-handler.ts
@@ -212,10 +212,19 @@ export class SlackHandler {
     );
 
     // Shared store for deferred user-instruction writes. The SAME instance
-    // must be visible to both `ActionHandlers` (button click reader) and
-    // `StreamExecutor` (write producer) — PLAN §7.
+    // must be visible to both `ActionHandlers` (button click reader),
+    // `StreamExecutor` (write producer), AND the production
+    // `PromptBuilder` owned by `ClaudeHandler` (#756 PR3a fix loop #1,
+    // P1-C). Without the third leg, the `pending: <op>` line in the
+    // `<current-user-instruction>` block never renders in prod even
+    // though the happy-path tests cover it (those inject the store
+    // directly into the builder constructor).
     const pendingInstructionConfirmStore = new PendingInstructionConfirmStore();
     pendingInstructionConfirmStore.loadForms();
+    // Forward the store to the production PromptBuilder via ClaudeHandler.
+    // Optional-chained so existing tests that mock claudeHandler as `{}`
+    // keep working without re-stubbing every test fixture.
+    (this.claudeHandler as any).setPendingInstructionConfirmStore?.(pendingInstructionConfirmStore);
 
     // ActionHandlers needs context
     const actionContext: ActionHandlerContext = {


### PR DESCRIPTION
PR3a (arm A) of stacked PR series on epic #727. Adds a fixed-position `<current-user-instruction>` block to the system prompt so the model retains a single authoritative answer to "which instruction is this turn working on?" even after compact/reset.

Closes #756.

Stacked on PR #755 (`727-2-lifecycle`). Independent of PR3b (#757, arm B).

## Summary
- New pure builder `src/prompt/current-instruction-block.ts` derives the block from a `UserSessionDoc` + session pointer + optional `PendingInstructionConfirm`.
- `PromptBuilder.buildSystemPrompt` reads the user-scope master via `getUserSessionStore()` and renders the block at a fixed bottom position so the highest recency weight in the model's attention is the current instruction.
- Falls back to `active: null` when the pointer is null OR resolves to a missing/completed/cancelled row, surfacing up to 5 newest active candidates with `+ N more (see dashboard)` overflow notice.
- Optional `pendingInstructionConfirmStore` wire-through surfaces a `pending: <op> (requested by <by.type>:<by.id> at <at>)` line when a y/n confirm entry exists for the session.
- Corrupt/missing master degrades gracefully (block omitted, error logged) — sealed contract still bans silent rewrites.

## Compact/reset survival
The host re-runs `buildSystemPrompt` at every reset point (first turn / post-compact / SSOT-mutated cache invalidation, see `claude-handler.ts` §rebuild gate). The block is re-derived from disk each time, so an unchanged master + unchanged session pointer yields byte-identical output (covered by the dedicated re-derivation test).

## Out of scope
- Lifecycle ops (#755, PR2 territory)
- Dashboard (#758/#759)
- TodoWrite (#757, PR3b arm B)
- Raw inputs (#760)

## Commits
- `test(#756): RED` — pure builder contract (12 tests)
- `feat(#756): GREEN` — `current-instruction-block.ts` builder
- `test(#756): RED` — PromptBuilder integration contract (6 tests)
- `feat(#756): GREEN` — wire block into `PromptBuilder.buildSystemPrompt`
- `chore(#756)` — biome format fix on the two new test files

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run check` — 0 biome errors (warnings only, pre-existing)
- [x] Scoped suites all pass — 54/54
- [x] `npm run build` — exits 0
- [x] Full vitest: 165/5882 fail, all are sandbox EPERM/ENOENT on `/opt/soma-work/dev/data/...` (matches baseline 49e7b6b which had 171; none of the failures are in PR3a-touched files)

Co-Authored-By: Zhuge <z@2lab.ai>