### PR TITLE
fix(cct): in-place card update + non-admin readonly view (#803)

### DIFF
--- a/src/slack/cct/__tests__/action-value.test.ts
+++ b/src/slack/cct/__tests__/action-value.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Codec tests for `src/slack/cct/action-value.ts` (#803).
+ *
+ * Coverage targets per spec:
+ *   - 9 invalid-decode cases (no legacy fallback)
+ *   - tagged: first-`|` split (payload may contain `|`)
+ *   - legacy: any non-empty, non-whitespace, non-prefixed string
+ *   - encode: rejects unknown mode, empty/whitespace payload, > 2000 chars
+ *   - encode/decode roundtrip
+ */
+
+import { describe, expect, it } from 'vitest';
+import { decodeCctActionValue, encodeCctActionValue, readCctActionPayload } from '../action-value';
+
+describe('decodeCctActionValue — invalid matrix', () => {
+  it('returns invalid for null', () => {
+    expect(decodeCctActionValue(null)).toEqual({ kind: 'invalid', raw: null });
+  });
+
+  it('returns invalid for undefined', () => {
+    expect(decodeCctActionValue(undefined)).toEqual({ kind: 'invalid', raw: undefined });
+  });
+
+  it('returns invalid for non-string number', () => {
+    expect(decodeCctActionValue(123)).toEqual({ kind: 'invalid', raw: 123 });
+  });
+
+  it('returns invalid for empty string', () => {
+    expect(decodeCctActionValue('')).toEqual({ kind: 'invalid', raw: '' });
+  });
+
+  it('returns invalid for whitespace-only string', () => {
+    expect(decodeCctActionValue('   ')).toEqual({ kind: 'invalid', raw: '   ' });
+    expect(decodeCctActionValue('\t\n')).toEqual({ kind: 'invalid', raw: '\t\n' });
+  });
+
+  it('returns invalid for "cm:" (prefix only, no `|`)', () => {
+    expect(decodeCctActionValue('cm:')).toEqual({ kind: 'invalid', raw: 'cm:' });
+  });
+
+  it('returns invalid for "cm:admin" (mode but no `|`)', () => {
+    expect(decodeCctActionValue('cm:admin')).toEqual({ kind: 'invalid', raw: 'cm:admin' });
+  });
+
+  it('returns invalid for "cm:admin|" (empty payload)', () => {
+    expect(decodeCctActionValue('cm:admin|')).toEqual({ kind: 'invalid', raw: 'cm:admin|' });
+  });
+
+  it('returns invalid for "cm:|abc" (empty mode)', () => {
+    expect(decodeCctActionValue('cm:|abc')).toEqual({ kind: 'invalid', raw: 'cm:|abc' });
+  });
+
+  it('returns invalid for "cm:bad|abc" (unknown mode)', () => {
+    expect(decodeCctActionValue('cm:bad|abc')).toEqual({ kind: 'invalid', raw: 'cm:bad|abc' });
+  });
+});
+
+describe('decodeCctActionValue — tagged forms', () => {
+  it('parses "cm:admin|abc"', () => {
+    expect(decodeCctActionValue('cm:admin|abc')).toEqual({ kind: 'tagged', mode: 'admin', payload: 'abc' });
+  });
+
+  it('parses "cm:readonly|abc"', () => {
+    expect(decodeCctActionValue('cm:readonly|abc')).toEqual({ kind: 'tagged', mode: 'readonly', payload: 'abc' });
+  });
+
+  it('splits on the FIRST `|` only — payload retains subsequent separators', () => {
+    expect(decodeCctActionValue('cm:admin|abc|def')).toEqual({
+      kind: 'tagged',
+      mode: 'admin',
+      payload: 'abc|def',
+    });
+  });
+});
+
+describe('decodeCctActionValue — legacy form', () => {
+  it('parses a non-prefixed non-empty string as legacy', () => {
+    expect(decodeCctActionValue('keyid-123')).toEqual({ kind: 'legacy', payload: 'keyid-123' });
+  });
+
+  it('parses "next" (the legacy card-level Next button value) as legacy', () => {
+    expect(decodeCctActionValue('next')).toEqual({ kind: 'legacy', payload: 'next' });
+  });
+
+  it('parses "refresh_card" (legacy Refresh button value) as legacy', () => {
+    expect(decodeCctActionValue('refresh_card')).toEqual({ kind: 'legacy', payload: 'refresh_card' });
+  });
+
+  it('does NOT treat "cm" (no colon) as a tagged form', () => {
+    expect(decodeCctActionValue('cm')).toEqual({ kind: 'legacy', payload: 'cm' });
+  });
+});
+
+describe('encodeCctActionValue', () => {
+  it('encodes admin payload', () => {
+    expect(encodeCctActionValue({ mode: 'admin', payload: 'abc' })).toBe('cm:admin|abc');
+  });
+
+  it('encodes readonly payload', () => {
+    expect(encodeCctActionValue({ mode: 'readonly', payload: 'abc' })).toBe('cm:readonly|abc');
+  });
+
+  it('encodes payload containing `|` — codec is compositional', () => {
+    expect(encodeCctActionValue({ mode: 'admin', payload: 'a|b|c' })).toBe('cm:admin|a|b|c');
+  });
+
+  it('throws on unknown mode', () => {
+    expect(() => encodeCctActionValue({ mode: 'bad' as 'admin', payload: 'abc' })).toThrow(/unknown mode/);
+  });
+
+  it('throws on empty payload', () => {
+    expect(() => encodeCctActionValue({ mode: 'admin', payload: '' })).toThrow(/non-empty/);
+  });
+
+  it('throws on whitespace-only payload', () => {
+    expect(() => encodeCctActionValue({ mode: 'admin', payload: '   ' })).toThrow(/non-empty|non-whitespace/);
+  });
+
+  it('throws when encoded result exceeds Slack 2000-char button-value cap', () => {
+    // 'cm:admin|' = 9 chars; payload of 1992 chars → encoded = 2001 (> 2000)
+    const tooLong = 'x'.repeat(1992);
+    expect(() => encodeCctActionValue({ mode: 'admin', payload: tooLong })).toThrow(/2000/);
+  });
+
+  it('accepts encoded result at the 2000-char cap', () => {
+    // 'cm:admin|' = 9; payload of 1991 → encoded = 2000 (boundary OK)
+    const atCap = 'x'.repeat(1991);
+    expect(encodeCctActionValue({ mode: 'admin', payload: atCap })).toHaveLength(2000);
+  });
+});
+
+describe('encode + decode roundtrip', () => {
+  it('admin roundtrip', () => {
+    const enc = encodeCctActionValue({ mode: 'admin', payload: 'slot-A' });
+    expect(decodeCctActionValue(enc)).toEqual({ kind: 'tagged', mode: 'admin', payload: 'slot-A' });
+  });
+
+  it('readonly roundtrip', () => {
+    const enc = encodeCctActionValue({ mode: 'readonly', payload: 'slot-B' });
+    expect(decodeCctActionValue(enc)).toEqual({ kind: 'tagged', mode: 'readonly', payload: 'slot-B' });
+  });
+});
+
+describe('readCctActionPayload', () => {
+  it('returns the inner payload for tagged values', () => {
+    expect(readCctActionPayload('cm:admin|slot-A')).toBe('slot-A');
+    expect(readCctActionPayload('cm:readonly|slot-B')).toBe('slot-B');
+  });
+
+  it('returns the raw payload for legacy values', () => {
+    expect(readCctActionPayload('slot-legacy')).toBe('slot-legacy');
+    expect(readCctActionPayload('next')).toBe('next');
+  });
+
+  it('returns null for invalid values', () => {
+    expect(readCctActionPayload(null)).toBeNull();
+    expect(readCctActionPayload('')).toBeNull();
+    expect(readCctActionPayload('cm:')).toBeNull();
+    expect(readCctActionPayload('cm:admin|')).toBeNull();
+    expect(readCctActionPayload('cm:bad|x')).toBeNull();
+  });
+});

--- a/src/slack/cct/__tests__/actions-refresh-usage-all.test.ts
+++ b/src/slack/cct/__tests__/actions-refresh-usage-all.test.ts
@@ -62,34 +62,68 @@ function snapshotWith(
   };
 }
 
-async function runHandler(tm: any, body: any = undefined, postEphemeral = vi.fn(async (_arg: any) => undefined)) {
+/**
+ * #803 — handler now does in-place card updates via `chat.update` (message
+ * surface) instead of stacking a fresh ephemeral. The runHandler helper
+ * builds a message-surface body so the in-place path is exercised.
+ *
+ * The mock client therefore captures BOTH `chat.update` (success path
+ * surface) and `chat.postEphemeral` (the residual error-fallback paths
+ * — outerCatch banner, unknown-surface fallback). Tests assert against
+ * whichever call landed for the scenario.
+ *
+ * `mockGetTokenManager`: the in-place path uses `renderCctCard`, which
+ * pulls a token-manager from `getTokenManager()`. We point it at the
+ * same fake the handler dispatched against so the rendered card uses
+ * the same snapshot.
+ */
+async function runHandler(
+  tm: any,
+  body: any = undefined,
+  overrides?: {
+    update?: ReturnType<typeof vi.fn>;
+    postEphemeral?: ReturnType<typeof vi.fn>;
+    respond?: ReturnType<typeof vi.fn>;
+  },
+) {
+  const update = overrides?.update ?? vi.fn(async (_arg: any) => undefined);
+  const postEphemeral = overrides?.postEphemeral ?? vi.fn(async (_arg: any) => undefined);
+  const respond = overrides?.respond ?? vi.fn(async (_arg: any) => undefined);
   const { app, actionHandlers } = makeApp();
   const adminUtils = await import('../../../admin-utils');
   const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+  // Wire the token-manager mock into the cct-topic getTokenManager so the
+  // in-place message-surface path that calls `renderCctCard` doesn't blow
+  // up on a `tokenManager is undefined` lookup.
+  const tmModule = await import('../../../token-manager');
+  const tmSpy = vi.spyOn(tmModule, 'getTokenManager').mockReturnValue(tm);
   try {
     registerCctActions(app, tm);
     const h = actionHandlers.get(CCT_ACTION_IDS.refresh_usage_all);
     const actionBody = body ?? {
       user: { id: 'admin' },
-      container: { channel_id: 'C1' },
-      actions: [{ value: 'all' }],
+      // #803 — message-surface body so the in-place path is exercised.
+      container: { type: 'message', channel_id: 'C1', message_ts: '1.0' },
+      actions: [{ value: 'cm:admin|refresh_all' }],
     };
     await h?.({
       ack: vi.fn(async () => undefined),
       body: actionBody,
-      client: { chat: { postEphemeral } },
+      client: { chat: { update, postEphemeral } },
+      respond,
     });
   } finally {
     spy.mockRestore();
+    tmSpy.mockRestore();
   }
-  return { postEphemeral };
+  return { update, postEphemeral, respond };
 }
 
 /** Narrow `mock.calls[0][0]` for assertion callers; asserts a call happened first. */
 function firstPayload(mock: ReturnType<typeof vi.fn>): any {
   const first = mock.mock.calls[0];
   if (!first || first.length === 0) {
-    throw new Error('expected at least one call to postEphemeral');
+    throw new Error('expected at least one call');
   }
   return first[0];
 }
@@ -173,7 +207,7 @@ describe('#701: refresh_usage_all mixed-failure surface', () => {
     vi.restoreAllMocks();
   });
 
-  it('all ok → single postEphemeral (card only, no banner)', async () => {
+  it('all ok → single chat.update (card only, no banner) [#803]', async () => {
     const keys = [
       { keyId: 'a', name: 'aA' },
       { keyId: 'b', name: 'bB' },
@@ -182,14 +216,23 @@ describe('#701: refresh_usage_all mixed-failure surface', () => {
     const tm = {
       refreshAllAttachedOAuthTokens: vi.fn(async () => ({ a: 'ok', b: 'ok' })),
       getSnapshot: vi.fn(async () => snap),
+      fetchUsageForAllAttached: vi.fn(async () => ({ a: null, b: null })),
     } as any;
-    const { postEphemeral } = await runHandler(tm);
-    expect(postEphemeral).toHaveBeenCalledTimes(1);
-    const payload = firstPayload(postEphemeral);
+    const { update, postEphemeral } = await runHandler(tm);
+    // #803 — successful flow goes in-place via chat.update; ephemeral
+    // fallback is unused on the happy path.
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(postEphemeral).not.toHaveBeenCalled();
+    const payload = firstPayload(update);
     expect(payload.text).toBe(':key: CCT status'); // plain card, no banner header.
+    expect(Array.isArray(payload.blocks)).toBe(true);
+    // No banner section prepended in the success path.
+    const firstBlockText = (payload.blocks as Array<{ text?: { text?: string } }>)[0]?.text?.text ?? '';
+    expect(firstBlockText).not.toContain('nothing refreshed');
+    expect(firstBlockText).not.toContain('partial failure');
   });
 
-  it('all error → allNull banner (single ephemeral, no card)', async () => {
+  it('all error → chat.update with allNull banner section + card [#803]', async () => {
     const keys = [
       { keyId: 'a', name: 'aA' },
       { keyId: 'b', name: 'bB' },
@@ -198,14 +241,21 @@ describe('#701: refresh_usage_all mixed-failure surface', () => {
     const tm = {
       refreshAllAttachedOAuthTokens: vi.fn(async () => ({ a: 'error', b: 'error' })),
       getSnapshot: vi.fn(async () => snap),
+      fetchUsageForAllAttached: vi.fn(async () => ({ a: null, b: null })),
     } as any;
-    const { postEphemeral } = await runHandler(tm);
-    expect(postEphemeral).toHaveBeenCalledTimes(1);
-    const payload = firstPayload(postEphemeral);
-    expect(payload.text).toContain('nothing refreshed');
+    const { update } = await runHandler(tm);
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = firstPayload(update);
+    // #803 — banner is now prepended to the card blocks (in-place
+    // surface), not posted as a text-only ephemeral.
+    const blocks = payload.blocks as Array<{ type: string; text?: { text?: string } }>;
+    expect(blocks[0]?.type).toBe('section');
+    expect(blocks[0]?.text?.text).toContain('nothing refreshed');
+    // Card chrome follows the banner.
+    expect(blocks.length).toBeGreaterThan(1);
   });
 
-  it('mixed (2 ok, 2 error) → SINGLE postEphemeral with banner section + card blocks', async () => {
+  it('mixed (2 ok, 2 error) → SINGLE chat.update with banner section + card blocks [#803]', async () => {
     const keys = [
       { keyId: 'a', name: 'aA' },
       { keyId: 'b', name: 'bB' },
@@ -226,11 +276,12 @@ describe('#701: refresh_usage_all mixed-failure surface', () => {
     const tm = {
       refreshAllAttachedOAuthTokens: vi.fn(async () => ({ a: 'ok', b: 'error', c: 'ok', d: 'error' })),
       getSnapshot: vi.fn(async () => snap),
+      fetchUsageForAllAttached: vi.fn(async () => ({})),
     } as any;
-    const { postEphemeral } = await runHandler(tm);
-    expect(postEphemeral).toHaveBeenCalledTimes(1); // single-surface invariant.
-    const payload = firstPayload(postEphemeral);
-    expect(payload.text).toContain('partial failure');
+    const { update } = await runHandler(tm);
+    expect(update).toHaveBeenCalledTimes(1); // single-surface invariant.
+    const payload = firstPayload(update);
+    expect(payload.text).toBe(':key: CCT status');
     // First block is the banner section with the failure summary.
     const blocks = payload.blocks as Array<{ type: string; text?: { text: string } }>;
     expect(blocks[0]?.type).toBe('section');
@@ -251,15 +302,16 @@ describe('#701: refresh_usage_all mixed-failure surface', () => {
       // `b` didn't settle before the fan-out deadline — not present in results.
       refreshAllAttachedOAuthTokens: vi.fn(async () => ({ a: 'ok' })),
       getSnapshot: vi.fn(async () => snap),
+      fetchUsageForAllAttached: vi.fn(async () => ({})),
     } as any;
-    const { postEphemeral } = await runHandler(tm);
-    const payload = firstPayload(postEphemeral);
+    const { update } = await runHandler(tm);
+    const payload = firstPayload(update);
     const bannerText = (payload.blocks as Array<{ text?: { text?: string } }>)[0]?.text?.text ?? '';
     expect(bannerText).toContain('1 of 2 failed');
     expect(bannerText).toContain('bB (timeout)');
   });
 
-  it('all-timeout (empty results, all still attached) → allNull banner, not mixed surface', async () => {
+  it('all-timeout (empty results, all still attached) → allNull banner [#803 in-place]', async () => {
     // Second-reviewer spec gap: the pre-fix code decided `allFailed` from
     // the raw `results` map. An empty map (every slot hit the fan-out
     // deadline) would slip into the mixed path with a confusing banner.
@@ -273,11 +325,13 @@ describe('#701: refresh_usage_all mixed-failure surface', () => {
     const tm = {
       refreshAllAttachedOAuthTokens: vi.fn(async () => ({})), // all timed out
       getSnapshot: vi.fn(async () => snap),
+      fetchUsageForAllAttached: vi.fn(async () => ({})),
     } as any;
-    const { postEphemeral } = await runHandler(tm);
-    expect(postEphemeral).toHaveBeenCalledTimes(1);
-    const payload = firstPayload(postEphemeral);
-    expect(payload.text).toContain('nothing refreshed');
+    const { update } = await runHandler(tm);
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = firstPayload(update);
+    const blocks = payload.blocks as Array<{ text?: { text?: string } }>;
+    expect(blocks[0]?.text?.text ?? '').toContain('nothing refreshed');
   });
 
   it('mixed + concurrent detach → denominator EXCLUDES torn-down slot', async () => {
@@ -324,9 +378,10 @@ describe('#701: refresh_usage_all mixed-failure surface', () => {
         call += 1;
         return call === 1 ? snap1 : snap2;
       }),
+      fetchUsageForAllAttached: vi.fn(async () => ({})),
     } as any;
-    const { postEphemeral } = await runHandler(tm);
-    const payload = firstPayload(postEphemeral);
+    const { update } = await runHandler(tm);
+    const payload = firstPayload(update);
     const bannerText = (payload.blocks as Array<{ text?: { text?: string } }>)[0]?.text?.text ?? '';
     // effectiveTotal = ok(1) + failed(1) = 2, NOT 3 (starting count).
     expect(bannerText).toContain('1 of 2 failed');
@@ -349,10 +404,14 @@ describe('#701: refresh_usage_all mixed-failure surface', () => {
         call += 1;
         return call === 1 ? snap1 : snap2;
       }),
+      fetchUsageForAllAttached: vi.fn(async () => ({})),
     } as any;
-    const { postEphemeral } = await runHandler(tm);
-    const payload = firstPayload(postEphemeral);
+    const { update } = await runHandler(tm);
+    const payload = firstPayload(update);
     // All-ok path: text is plain card title (no partial failure).
     expect(payload.text).toBe(':key: CCT status');
+    // No banner section prepended.
+    const blocks = payload.blocks as Array<{ text?: { text?: string } }>;
+    expect(blocks[0]?.text?.text ?? '').not.toContain('failed');
   });
 });

--- a/src/slack/cct/__tests__/actions.test.ts
+++ b/src/slack/cct/__tests__/actions.test.ts
@@ -590,7 +590,191 @@ describe('attach/detach action routing (Z2)', () => {
     }
   });
 
-  it('T8d: attach view_submission validate→ack-first→attachOAuth (happy path)', async () => {
+  // ────────────────────────────────────────────────────────────────────
+  // #803 — in-place card update for activate / next / detach
+  // ────────────────────────────────────────────────────────────────────
+
+  it('#803: cct_activate_slot uses chat.update in-place (no fresh ephemeral stack-up)', async () => {
+    const { app, actionHandlers } = makeApp();
+    const applyToken = vi.fn(async () => undefined);
+    const tm = {
+      applyToken,
+      getSnapshot: async () => ({
+        version: 2 as const,
+        revision: 1,
+        registry: {
+          activeKeyId: 'slot-A',
+          slots: [
+            {
+              kind: 'cct' as const,
+              source: 'setup' as const,
+              keyId: 'slot-B',
+              name: 'cctB',
+              setupToken: 'sk-ant-oat01-xxxx',
+              createdAt: '',
+            },
+            {
+              kind: 'cct' as const,
+              source: 'setup' as const,
+              keyId: 'slot-A',
+              name: 'cctA',
+              setupToken: 'sk-ant-oat01-yyyy',
+              createdAt: '',
+            },
+          ],
+        },
+        state: {},
+      }),
+      listTokens: () => [],
+      getActiveToken: () => null,
+      fetchUsageForAllAttached: vi.fn(async () => ({})),
+    } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    const tmModule = await import('../../../token-manager');
+    const tmSpy = vi.spyOn(tmModule, 'getTokenManager').mockReturnValue(tm);
+    const update = vi.fn(async (_arg: any) => undefined);
+    const postEphemeral = vi.fn(async (_arg: any) => undefined);
+    const respond = vi.fn(async (_arg: any) => undefined);
+    try {
+      registerCctActions(app, tm);
+      const h = actionHandlers.get(CCT_ACTION_IDS.activate_slot);
+      await h?.({
+        ack: vi.fn(async () => undefined),
+        body: {
+          user: { id: 'admin' },
+          container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
+          actions: [{ value: 'cm:admin|slot-B' }],
+        },
+        client: { chat: { update, postEphemeral } },
+        respond,
+      });
+      expect(applyToken).toHaveBeenCalledWith('slot-B');
+      // In-place chat.update on the originating message — NOT a fresh
+      // ephemeral stacked on top of the stale card.
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(postEphemeral).not.toHaveBeenCalled();
+      expect(respond).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+      tmSpy.mockRestore();
+    }
+  });
+
+  it('#803: cct_next uses respond({replace_original:true}) on ephemeral surface', async () => {
+    const { app, actionHandlers } = makeApp();
+    const rotateToNext = vi.fn(async () => ({ keyId: 'slot-A', name: 'cctA' }));
+    const tm = {
+      rotateToNext,
+      getSnapshot: async () => ({
+        version: 2 as const,
+        revision: 1,
+        registry: { activeKeyId: 'slot-A', slots: [] },
+        state: {},
+      }),
+      listTokens: () => [],
+      getActiveToken: () => null,
+    } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    const update = vi.fn(async (_arg: any) => undefined);
+    const respond = vi.fn(async (_arg: any) => undefined);
+    try {
+      registerCctActions(app, tm);
+      const h = actionHandlers.get(CCT_ACTION_IDS.next);
+      await h?.({
+        ack: vi.fn(async () => undefined),
+        body: {
+          user: { id: 'admin' },
+          container: { type: 'ephemeral', channel_id: 'C1' },
+          actions: [{ value: 'cm:admin|next' }],
+        },
+        client: { chat: { update, postEphemeral: vi.fn() } },
+        respond,
+      });
+      expect(rotateToNext).toHaveBeenCalledTimes(1);
+      // Ephemeral surface uses respond replace_original — NOT chat.update.
+      expect(respond).toHaveBeenCalledTimes(1);
+      expect(respond).toHaveBeenCalledWith(
+        expect.objectContaining({ response_type: 'ephemeral', replace_original: true }),
+      );
+      expect(update).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('#803: cct_detach uses chat.update on message surface (no fresh ephemeral)', async () => {
+    const { app, actionHandlers } = makeApp();
+    const detachOAuth = vi.fn(async () => undefined);
+    const tm = {
+      detachOAuth,
+      getSnapshot: async () => ({
+        version: 2 as const,
+        revision: 1,
+        registry: { activeKeyId: 'slot-X', slots: [] },
+        state: {},
+      }),
+      listTokens: () => [],
+      getActiveToken: () => null,
+      fetchUsageForAllAttached: vi.fn(async () => ({})),
+    } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    const tmModule = await import('../../../token-manager');
+    const tmSpy = vi.spyOn(tmModule, 'getTokenManager').mockReturnValue(tm);
+    const update = vi.fn(async (_arg: any) => undefined);
+    const postEphemeral = vi.fn(async (_arg: any) => undefined);
+    const respond = vi.fn(async (_arg: any) => undefined);
+    try {
+      registerCctActions(app, tm);
+      const h = actionHandlers.get(CCT_ACTION_IDS.detach);
+      await h?.({
+        ack: vi.fn(async () => undefined),
+        body: {
+          user: { id: 'admin' },
+          container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
+          actions: [{ value: 'cm:admin|slot-X' }],
+        },
+        client: { chat: { update, postEphemeral } },
+        respond,
+      });
+      expect(detachOAuth).toHaveBeenCalledWith('slot-X');
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(postEphemeral).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+      tmSpy.mockRestore();
+    }
+  });
+
+  it('#803: cct_activate_slot rejects invalid action value (no applyToken call)', async () => {
+    const { app, actionHandlers } = makeApp();
+    const applyToken = vi.fn(async () => undefined);
+    const tm = { applyToken, getSnapshot: async () => ({}) as any } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    try {
+      registerCctActions(app, tm);
+      const h = actionHandlers.get(CCT_ACTION_IDS.activate_slot);
+      // 'cm:bad|x' — invalid mode triggers decoder rejection.
+      await h?.({
+        ack: vi.fn(async () => undefined),
+        body: {
+          user: { id: 'admin' },
+          container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
+          actions: [{ value: 'cm:bad|x' }],
+        },
+        client: { chat: { update: vi.fn(), postEphemeral: vi.fn() } },
+        respond: vi.fn(),
+      });
+      expect(applyToken).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('T8d: attach view_submission validate→ack-first→attachOAuth (happy path) [admin gated #803]', async () => {
     const { app, viewHandlers } = makeApp();
     const attachOAuth = vi.fn(async () => undefined);
     const tm = {
@@ -604,40 +788,48 @@ describe('attach/detach action routing (Z2)', () => {
       listTokens: () => [],
       getActiveToken: () => null,
     } as any;
-    registerCctActions(app, tm);
-    const submit = viewHandlers.get('cct_attach_oauth');
-    expect(submit).toBeDefined();
-    const ack = vi.fn(async () => undefined);
-    await submit?.({
-      ack,
-      body: {
-        user: { id: 'admin' },
-        container: { channel_id: 'C1' },
-        view: {
-          private_metadata: 'slot-B',
-          state: {
-            values: {
-              [CCT_BLOCK_IDS.attach_oauth_blob]: {
-                [CCT_ACTION_IDS.attach_oauth_input]: { value: GOOD_OAUTH_BLOB },
-              },
-              [CCT_BLOCK_IDS.attach_tos_ack]: {
-                [CCT_ACTION_IDS.attach_tos_ack]: { selected_options: [{ value: 'ack' }] },
+    // #803 — view submission now has an admin gate. Spy isAdminUser so
+    // the test admin user actually flows past the gate.
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    try {
+      registerCctActions(app, tm);
+      const submit = viewHandlers.get('cct_attach_oauth');
+      expect(submit).toBeDefined();
+      const ack = vi.fn(async () => undefined);
+      await submit?.({
+        ack,
+        body: {
+          user: { id: 'admin' },
+          container: { channel_id: 'C1' },
+          view: {
+            private_metadata: 'slot-B',
+            state: {
+              values: {
+                [CCT_BLOCK_IDS.attach_oauth_blob]: {
+                  [CCT_ACTION_IDS.attach_oauth_input]: { value: GOOD_OAUTH_BLOB },
+                },
+                [CCT_BLOCK_IDS.attach_tos_ack]: {
+                  [CCT_ACTION_IDS.attach_tos_ack]: { selected_options: [{ value: 'ack' }] },
+                },
               },
             },
           },
         },
-      },
-      client: { chat: { postEphemeral: vi.fn(async () => undefined) } },
-    });
-    // Codex P0 fix #1 — plain ack (not an errors-ack) fires BEFORE the
-    // attach mutation so the 3s view_submission budget is never at risk of
-    // CAS retries on a slow disk. Ordering is asserted strictly in T8f.
-    expect(ack).toHaveBeenCalledWith();
-    expect(attachOAuth).toHaveBeenCalledWith(
-      'slot-B',
-      expect.objectContaining({ accessToken: expect.any(String) }),
-      true,
-    );
+        client: { chat: { postEphemeral: vi.fn(async () => undefined) } },
+      });
+      // Codex P0 fix #1 — plain ack (not an errors-ack) fires BEFORE the
+      // attach mutation so the 3s view_submission budget is never at risk of
+      // CAS retries on a slow disk. Ordering is asserted strictly in T8f.
+      expect(ack).toHaveBeenCalledWith();
+      expect(attachOAuth).toHaveBeenCalledWith(
+        'slot-B',
+        expect.objectContaining({ accessToken: expect.any(String) }),
+        true,
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('T8f: attach view_submission acks BEFORE attachOAuth is invoked (Codex P0 fix #1, 3s budget safety)', async () => {
@@ -679,6 +871,9 @@ describe('attach/detach action routing (Z2)', () => {
       listTokens: () => [],
       getActiveToken: () => null,
     } as any;
+    // #803 — view submission admin gate.
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
     registerCctActions(app, tm);
     const submit = viewHandlers.get('cct_attach_oauth');
     const handlerPromise = submit?.({
@@ -712,39 +907,163 @@ describe('attach/detach action routing (Z2)', () => {
     // Release attach so the handler can return cleanly.
     resolveAttach();
     await handlerPromise;
+    spy.mockRestore();
   });
 
   it('T8e: attach view_submission surfaces validation errors (no ack checkbox) as response_action:errors', async () => {
     const { app, viewHandlers } = makeApp();
     const attachOAuth = vi.fn(async () => undefined);
     const tm = { attachOAuth } as any;
-    registerCctActions(app, tm);
-    const submit = viewHandlers.get('cct_attach_oauth');
-    const ack = vi.fn(async () => undefined);
-    await submit?.({
-      ack,
-      body: {
-        user: { id: 'admin' },
-        view: {
-          private_metadata: 'slot-B',
-          state: {
-            values: {
-              [CCT_BLOCK_IDS.attach_oauth_blob]: {
-                [CCT_ACTION_IDS.attach_oauth_input]: { value: GOOD_OAUTH_BLOB },
+    // #803 — view submission admin gate must let this admin user past
+    // so the validation-error path is exercised (otherwise we'd ack
+    // with an `Admin only` error and miss the validation branch).
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    try {
+      registerCctActions(app, tm);
+      const submit = viewHandlers.get('cct_attach_oauth');
+      const ack = vi.fn(async () => undefined);
+      await submit?.({
+        ack,
+        body: {
+          user: { id: 'admin' },
+          view: {
+            private_metadata: 'slot-B',
+            state: {
+              values: {
+                [CCT_BLOCK_IDS.attach_oauth_blob]: {
+                  [CCT_ACTION_IDS.attach_oauth_input]: { value: GOOD_OAUTH_BLOB },
+                },
+                // Intentionally omit the tos_ack block so "ack" is missing.
               },
-              // Intentionally omit the tos_ack block so "ack" is missing.
             },
           },
         },
-      },
-      client: {},
-    });
-    expect(attachOAuth).not.toHaveBeenCalled();
-    // Single ack call with errors payload keyed by the tos block_id.
-    expect(ack).toHaveBeenCalledTimes(1);
-    const ackArg = (ack.mock.calls[0] as any[])[0];
-    expect(ackArg.response_action).toBe('errors');
-    expect(ackArg.errors).toHaveProperty(CCT_BLOCK_IDS.attach_tos_ack);
+        client: {},
+      });
+      expect(attachOAuth).not.toHaveBeenCalled();
+      // Single ack call with errors payload keyed by the tos block_id.
+      expect(ack).toHaveBeenCalledTimes(1);
+      const ackArg = (ack.mock.calls[0] as any[])[0];
+      expect(ackArg.response_action).toBe('errors');
+      expect(ackArg.errors).toHaveProperty(CCT_BLOCK_IDS.attach_tos_ack);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // #803 — view-submission admin gate
+  // ────────────────────────────────────────────────────────────────────
+
+  it('#803: cct_add_slot view submit by non-admin → ack with errors, no addSlot called', async () => {
+    const { app, viewHandlers } = makeApp();
+    const addSlot = vi.fn(async () => undefined);
+    const tm = { addSlot, listTokens: () => [] } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(false);
+    try {
+      registerCctActions(app, tm);
+      const submit = viewHandlers.get('cct_add_slot');
+      const ack = vi.fn(async () => undefined);
+      await submit?.({
+        ack,
+        body: {
+          user: { id: 'random' },
+          view: {
+            state: {
+              values: {
+                [CCT_BLOCK_IDS.add_name]: {
+                  [CCT_ACTION_IDS.name_input]: { value: 'cct1' },
+                },
+                [CCT_BLOCK_IDS.add_kind]: {
+                  [CCT_ACTION_IDS.kind_radio]: { selected_option: { value: 'setup_token' } },
+                },
+                [CCT_BLOCK_IDS.add_setup_token_value]: {
+                  [CCT_ACTION_IDS.setup_token_input]: { value: 'sk-ant-oat01-abc12345' },
+                },
+              },
+            },
+          },
+        },
+        client: {},
+      });
+      expect(addSlot).not.toHaveBeenCalled();
+      expect(ack).toHaveBeenCalledTimes(1);
+      const ackArg = (ack.mock.calls[0] as any[])[0];
+      expect(ackArg.response_action).toBe('errors');
+      expect(ackArg.errors).toHaveProperty(CCT_BLOCK_IDS.add_name);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('#803: cct_remove_slot view submit by non-admin → no removeSlot called', async () => {
+    const { app, viewHandlers } = makeApp();
+    const removeSlot = vi.fn(async () => ({ pendingDrain: false }));
+    const tm = { removeSlot } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(false);
+    try {
+      registerCctActions(app, tm);
+      const submit = viewHandlers.get('cct_remove_slot');
+      const ack = vi.fn(async () => undefined);
+      await submit?.({
+        ack,
+        body: {
+          user: { id: 'random' },
+          view: { private_metadata: 'slot-B' },
+        },
+        client: { chat: { postMessage: vi.fn() }, conversations: { open: vi.fn() } },
+      });
+      expect(removeSlot).not.toHaveBeenCalled();
+      // Plain ack closes the modal silently for non-admin (defense-in-
+      // depth — the UI gate prevented opening this modal in the first
+      // place; the handler just refuses to mutate).
+      expect(ack).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('#803: cct_attach_oauth view submit by non-admin → ack with errors, no attachOAuth called', async () => {
+    const { app, viewHandlers } = makeApp();
+    const attachOAuth = vi.fn(async () => undefined);
+    const tm = { attachOAuth } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(false);
+    try {
+      registerCctActions(app, tm);
+      const submit = viewHandlers.get('cct_attach_oauth');
+      const ack = vi.fn(async () => undefined);
+      await submit?.({
+        ack,
+        body: {
+          user: { id: 'random' },
+          view: {
+            private_metadata: 'slot-B',
+            state: {
+              values: {
+                [CCT_BLOCK_IDS.attach_oauth_blob]: {
+                  [CCT_ACTION_IDS.attach_oauth_input]: { value: GOOD_OAUTH_BLOB },
+                },
+                [CCT_BLOCK_IDS.attach_tos_ack]: {
+                  [CCT_ACTION_IDS.attach_tos_ack]: { selected_options: [{ value: 'ack' }] },
+                },
+              },
+            },
+          },
+        },
+        client: {},
+      });
+      expect(attachOAuth).not.toHaveBeenCalled();
+      expect(ack).toHaveBeenCalledTimes(1);
+      const ackArg = (ack.mock.calls[0] as any[])[0];
+      expect(ackArg.response_action).toBe('errors');
+      expect(ackArg.errors).toHaveProperty(CCT_BLOCK_IDS.attach_oauth_blob);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 
@@ -909,7 +1228,7 @@ describe('refresh_usage action handlers (M1-S4)', () => {
     }
   });
 
-  it('refresh_usage_all → when zero slots are attached, re-post the card normally (empty map is not "all failed")', async () => {
+  it('refresh_usage_all → when zero slots are attached, re-render card in-place [#803]', async () => {
     const { app, actionHandlers } = makeApp();
     const refreshAllAttachedOAuthTokens = vi.fn(async () => ({}) as Record<string, 'ok' | 'error'>);
     const tm = {
@@ -925,7 +1244,11 @@ describe('refresh_usage action handlers (M1-S4)', () => {
     } as any;
     const adminUtils = await import('../../../admin-utils');
     const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    const tmModule = await import('../../../token-manager');
+    const tmSpy = vi.spyOn(tmModule, 'getTokenManager').mockReturnValue(tm);
+    const update = vi.fn(async (_arg: any) => undefined);
     const postEphemeral = vi.fn(async (_arg: any) => undefined);
+    const respond = vi.fn(async (_arg: any) => undefined);
     try {
       registerCctActions(app, tm);
       const h = actionHandlers.get(CCT_ACTION_IDS.refresh_usage_all);
@@ -933,16 +1256,22 @@ describe('refresh_usage action handlers (M1-S4)', () => {
         ack: vi.fn(async () => undefined),
         body: {
           user: { id: 'admin' },
-          container: { channel_id: 'C1' },
-          actions: [{ value: 'all' }],
+          // #803 — message-surface body so renderCardInPlace lands on chat.update.
+          container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
+          actions: [{ value: 'cm:admin|refresh_all' }],
         },
-        client: { chat: { postEphemeral } },
+        client: { chat: { update, postEphemeral } },
+        respond,
       });
-      expect(postEphemeral).toHaveBeenCalledTimes(1);
-      const call = postEphemeral.mock.calls[0]?.[0] as any;
+      // Empty starting set → no failures → no banner; renderCardInPlace
+      // hits the message surface and chat.update is called.
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(postEphemeral).not.toHaveBeenCalled();
+      const call = update.mock.calls[0]?.[0] as any;
       expect(Array.isArray(call.blocks)).toBe(true);
     } finally {
       spy.mockRestore();
+      tmSpy.mockRestore();
     }
   });
 
@@ -1083,7 +1412,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
     };
   }
 
-  it('fans out fetchAndStoreUsage(force:true) for each attached cct slot; chat.update in-place on success (message surface)', async () => {
+  it('fans out fetchAndStoreUsage(force:true) for each attached cct slot; chat.update in-place on success (message surface) [#803 admin+admin-card]', async () => {
     const { app, actionHandlers } = makeApp();
     const fetchAndStoreUsage = vi.fn(async (keyId: string) => ({
       fetchedAt: new Date().toISOString(),
@@ -1095,6 +1424,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
       ...tmWithAttachedSlots(['slot-A', 'slot-B']),
       fetchAndStoreUsage,
       refreshAllAttachedOAuthTokens,
+      fetchUsageForAllAttached: vi.fn(async () => ({})),
     } as any;
     const adminUtils = await import('../../../admin-utils');
     const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
@@ -1111,7 +1441,9 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
-          actions: [{ value: 'refresh_card' }],
+          // #803 — `cm:admin|refresh_card` so the force path engages
+          // (admin actor + admin cardMode = force=true).
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1131,7 +1463,12 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
       // renderCctCard so the trailing z_setting_cct_cancel actions row
       // (built by cct-topic, not by buildCardFromManager) is preserved.
       expect(renderCctCard).toHaveBeenCalledTimes(1);
-      expect(renderCctCard).toHaveBeenCalledWith({ userId: 'admin', issuedAt: expect.any(Number) });
+      // #803 — renderCctCard now also receives viewerMode='admin'.
+      expect(renderCctCard).toHaveBeenCalledWith({
+        userId: 'admin',
+        issuedAt: expect.any(Number),
+        viewerMode: 'admin',
+      });
       const updateCall = update.mock.calls[0]?.[0] as any;
       const blockJson = JSON.stringify(updateCall.blocks);
       expect(blockJson).toContain('z_setting_cct_cancel');
@@ -1168,7 +1505,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1220,7 +1557,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'ephemeral', channel_id: 'C1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1252,7 +1589,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1287,7 +1624,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1325,7 +1662,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1356,7 +1693,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1373,13 +1710,24 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
     }
   });
 
-  it('non-admin click → ack only, no TM call', async () => {
+  it('#803: non-admin click on admin-mode card → non-force fetch, in-place re-render preserves admin cardMode', async () => {
     const { app, actionHandlers } = makeApp();
     const fetchAndStoreUsage = vi.fn();
-    const getSnapshot = vi.fn();
-    const tm = { fetchAndStoreUsage, getSnapshot } as any;
+    const fetchUsageForAllAttached = vi.fn(async () => ({ 'slot-A': null }));
+    const tm = {
+      ...tmWithAttachedSlots(['slot-A']),
+      fetchAndStoreUsage,
+      fetchUsageForAllAttached,
+    } as any;
     const adminUtils = await import('../../../admin-utils');
+    // isAdminUser is called once for actor (non-admin = false). The
+    // renderCctCard mock factory in this file is wired so it doesn't
+    // call isAdminUser internally — we control the spy behavior.
     const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(false);
+    const update = vi.fn(async (_arg: any) => undefined);
+    const postEphemeral = vi.fn(async (_arg: any) => undefined);
+    const respond = vi.fn(async (_arg: any) => undefined);
+    (renderCctCard as any).mockClear();
     try {
       registerCctActions(app, tm);
       const h = actionHandlers.get(CCT_ACTION_IDS.refresh_card);
@@ -1389,16 +1737,173 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'random' },
           container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
-          actions: [{ value: 'refresh_card' }],
+          // admin-mode card stamp → preserved across viewer (#803 spec Q1=A).
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
-        client: {
-          chat: { update: vi.fn(async () => undefined), postEphemeral: vi.fn(async () => undefined) },
-        },
-        respond: vi.fn(async () => undefined),
+        client: { chat: { update, postEphemeral } },
+        respond,
       });
       expect(ack).toHaveBeenCalled();
+      // Force fetch is gated to (admin actor) AND (admin cardMode).
+      // Non-admin actor on admin-mode card → non-force path (uses
+      // fetchUsageForAllAttached, not fetchAndStoreUsage{force:true}).
       expect(fetchAndStoreUsage).not.toHaveBeenCalled();
-      expect(getSnapshot).not.toHaveBeenCalled();
+      expect(fetchUsageForAllAttached).toHaveBeenCalledTimes(1);
+      // Card is re-rendered in place — preserving admin cardMode.
+      expect(update).toHaveBeenCalledTimes(1);
+      // renderCctCard called with viewerMode='admin' (from the
+      // tagged button value), NOT readonly (which would be the
+      // actor-derived fallback).
+      expect(renderCctCard).toHaveBeenCalledWith({
+        userId: 'random',
+        issuedAt: expect.any(Number),
+        viewerMode: 'admin',
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('#803: non-admin click on readonly-mode card → non-force fetch, readonly re-render', async () => {
+    const { app, actionHandlers } = makeApp();
+    const fetchAndStoreUsage = vi.fn();
+    const fetchUsageForAllAttached = vi.fn(async () => ({ 'slot-A': null }));
+    const tm = {
+      ...tmWithAttachedSlots(['slot-A']),
+      fetchAndStoreUsage,
+      fetchUsageForAllAttached,
+    } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(false);
+    const update = vi.fn(async (_arg: any) => undefined);
+    const respond = vi.fn(async (_arg: any) => undefined);
+    (renderCctCard as any).mockClear();
+    try {
+      registerCctActions(app, tm);
+      const h = actionHandlers.get(CCT_ACTION_IDS.refresh_card);
+      await h?.({
+        ack: vi.fn(async () => undefined),
+        body: {
+          user: { id: 'random' },
+          container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
+          actions: [{ value: 'cm:readonly|refresh_card' }],
+        },
+        client: { chat: { update, postEphemeral: vi.fn() } },
+        respond,
+      });
+      expect(fetchAndStoreUsage).not.toHaveBeenCalled();
+      expect(fetchUsageForAllAttached).toHaveBeenCalledTimes(1);
+      expect(renderCctCard).toHaveBeenCalledWith({
+        userId: 'random',
+        issuedAt: expect.any(Number),
+        viewerMode: 'readonly',
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('#803: admin click on readonly-mode card → non-force fetch (force-gate denies), admin actor cannot promote readonly card to force', async () => {
+    const { app, actionHandlers } = makeApp();
+    const fetchAndStoreUsage = vi.fn();
+    const fetchUsageForAllAttached = vi.fn(async () => ({ 'slot-A': null }));
+    const tm = {
+      ...tmWithAttachedSlots(['slot-A']),
+      fetchAndStoreUsage,
+      fetchUsageForAllAttached,
+    } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    const update = vi.fn(async (_arg: any) => undefined);
+    try {
+      registerCctActions(app, tm);
+      const h = actionHandlers.get(CCT_ACTION_IDS.refresh_card);
+      await h?.({
+        ack: vi.fn(async () => undefined),
+        body: {
+          user: { id: 'admin' },
+          container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
+          actions: [{ value: 'cm:readonly|refresh_card' }],
+        },
+        client: { chat: { update, postEphemeral: vi.fn() } },
+        respond: vi.fn(),
+      });
+      // Force gate requires BOTH admin actor AND admin cardMode.
+      // Readonly cardMode → non-force path even when actor is admin.
+      expect(fetchAndStoreUsage).not.toHaveBeenCalled();
+      expect(fetchUsageForAllAttached).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('#803: legacy value (no cm: prefix) forces force=false even for admin actor', async () => {
+    const { app, actionHandlers } = makeApp();
+    const fetchAndStoreUsage = vi.fn();
+    const fetchUsageForAllAttached = vi.fn(async () => ({ 'slot-A': null }));
+    const tm = {
+      ...tmWithAttachedSlots(['slot-A']),
+      fetchAndStoreUsage,
+      fetchUsageForAllAttached,
+    } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(true);
+    const update = vi.fn(async (_arg: any) => undefined);
+    try {
+      registerCctActions(app, tm);
+      const h = actionHandlers.get(CCT_ACTION_IDS.refresh_card);
+      await h?.({
+        ack: vi.fn(async () => undefined),
+        body: {
+          user: { id: 'admin' },
+          container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
+          // legacy form — pre-#803 button. cardMode unknown → safer to throttle.
+          actions: [{ value: 'refresh_card' }],
+        },
+        client: { chat: { update, postEphemeral: vi.fn() } },
+        respond: vi.fn(),
+      });
+      expect(fetchAndStoreUsage).not.toHaveBeenCalled();
+      expect(fetchUsageForAllAttached).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('#803: throttle-all-null on non-force path → in-place card with "Cached usage · refresh limited" banner', async () => {
+    const { app, actionHandlers } = makeApp();
+    const fetchUsageForAllAttached = vi.fn(async () => ({ 'slot-A': null, 'slot-B': null }));
+    const tm = {
+      ...tmWithAttachedSlots(['slot-A', 'slot-B']),
+      fetchAndStoreUsage: vi.fn(),
+      fetchUsageForAllAttached,
+    } as any;
+    const adminUtils = await import('../../../admin-utils');
+    const spy = vi.spyOn(adminUtils, 'isAdminUser').mockReturnValue(false);
+    const update = vi.fn(async (_arg: any) => undefined);
+    const postEphemeral = vi.fn(async (_arg: any) => undefined);
+    try {
+      registerCctActions(app, tm);
+      const h = actionHandlers.get(CCT_ACTION_IDS.refresh_card);
+      await h?.({
+        ack: vi.fn(async () => undefined),
+        body: {
+          user: { id: 'random' },
+          container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
+          actions: [{ value: 'cm:readonly|refresh_card' }],
+        },
+        client: { chat: { update, postEphemeral } },
+        respond: vi.fn(),
+      });
+      // Throttle-all-null on non-force path → still re-renders the
+      // card in place; throttle banner is prepended as the first
+      // section block (NOT a cardNull ephemeral fallback).
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(postEphemeral).not.toHaveBeenCalled();
+      const call = update.mock.calls[0]?.[0] as any;
+      const banner = (call.blocks as Array<{ text?: { text?: string } }>)[0]?.text?.text ?? '';
+      expect(banner).toContain('Cached usage');
+      expect(banner).toContain('refresh limited');
     } finally {
       spy.mockRestore();
     }
@@ -1425,7 +1930,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'ephemeral', channel_id: 'C1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1468,7 +1973,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
           user: { id: 'admin' },
           // Channel-only fallback so the banner has somewhere to land.
           channel: { id: 'C1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1506,7 +2011,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'message', channel_id: 'C1', message_ts: 'ts1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,
@@ -1543,7 +2048,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         body: {
           user: { id: 'admin' },
           container: { type: 'ephemeral', channel_id: 'C1' },
-          actions: [{ value: 'refresh_card' }],
+          actions: [{ value: 'cm:admin|refresh_card' }],
         },
         client: { chat: { update, postEphemeral } },
         respond,

--- a/src/slack/cct/__tests__/actions.test.ts
+++ b/src/slack/cct/__tests__/actions.test.ts
@@ -1468,6 +1468,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         userId: 'admin',
         issuedAt: expect.any(Number),
         viewerMode: 'admin',
+        skipOnOpenFetch: true,
       });
       const updateCall = update.mock.calls[0]?.[0] as any;
       const blockJson = JSON.stringify(updateCall.blocks);
@@ -1758,6 +1759,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         userId: 'random',
         issuedAt: expect.any(Number),
         viewerMode: 'admin',
+        skipOnOpenFetch: true,
       });
     } finally {
       spy.mockRestore();
@@ -1797,6 +1799,7 @@ describe('refresh_card action handler (card v2 follow-up)', () => {
         userId: 'random',
         issuedAt: expect.any(Number),
         viewerMode: 'readonly',
+        skipOnOpenFetch: true,
       });
     } finally {
       spy.mockRestore();

--- a/src/slack/cct/__tests__/builder.test.ts
+++ b/src/slack/cct/__tests__/builder.test.ts
@@ -168,14 +168,16 @@ describe('buildSlotRow', () => {
   // the [Activate] button appears on every non-active slot that
   // can be activated (i.e. cct slots, not api_key). Lock the button shape
   // + styling + value so the actions.ts router keeps routing correctly.
-  it('non-active cct slot gets [Activate] button with style=primary and value=keyId', () => {
+  it('non-active cct slot gets [Activate] button with style=primary and value=cm:admin|keyId (#803)', () => {
     const slot = setupSlot('cct-foo', 'slot-foo');
     const blocks = buildSlotRow(slot, undefined, false, Date.parse('2026-04-21T00:00:00Z'));
     const actions = blocks.find((b: any) => b.type === 'actions') as any;
     const activateBtn = actions.elements.find((e: any) => e.action_id === CCT_ACTION_IDS.activate_slot);
     expect(activateBtn).toBeDefined();
     expect(activateBtn.style).toBe('primary');
-    expect(activateBtn.value).toBe('slot-foo');
+    // #803 — button value is now `cm:<mode>|<payload>` so the action
+    // dispatch can preserve the card mode across re-renders.
+    expect(activateBtn.value).toBe('cm:admin|slot-foo');
   });
 
   it('active cct slot does NOT get [Activate] button (already active)', () => {
@@ -236,7 +238,7 @@ describe('buildSlotRow', () => {
     expect(text).not.toMatch(/OAuth refreshes in -/); // no negative duration
   });
 
-  it('emits per-slot Remove button with value = keyId', () => {
+  it('emits per-slot Remove button with value = cm:admin|keyId (#803)', () => {
     const slot = setupSlot();
     const blocks = buildSlotRow(slot, undefined, false, Date.parse('2026-04-18T00:00:00Z'));
     // Last block should be the actions row with Remove. The per-slot
@@ -245,7 +247,7 @@ describe('buildSlotRow', () => {
     expect(actions).toBeDefined();
     const removeBtn = actions.elements.find((e: any) => e.action_id === 'cct_open_remove');
     expect(removeBtn).toBeDefined();
-    expect(removeBtn.value).toBe(slot.keyId);
+    expect(removeBtn.value).toBe(`cm:admin|${slot.keyId}`);
     // Per-slot Rename no longer exists on the row.
     expect(actions.elements.find((e: any) => e.action_id === 'cct_open_rename')).toBeUndefined();
   });
@@ -290,12 +292,147 @@ describe('buildCctCardBlocks', () => {
       const btn = r.elements.find((e: any) => e.action_id === 'cct_open_remove');
       return btn.value as string;
     });
-    expect(removeValues).toEqual(expect.arrayContaining(['slot-1', 'slot-2']));
+    // #803 — button values are now `cm:admin|<keyId>`.
+    expect(removeValues).toEqual(expect.arrayContaining(['cm:admin|slot-1', 'cm:admin|slot-2']));
     // No rename buttons anywhere on the card.
     const renameRows = blocks.filter(
       (b: any) => b.type === 'actions' && b.elements.some((e: any) => e.action_id === 'cct_open_rename'),
     );
     expect(renameRows).toHaveLength(0);
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // #803 — viewerMode='readonly' (non-admin reveal)
+  // ────────────────────────────────────────────────────────────────────
+
+  it('#803: viewerMode=readonly strips per-slot mutating actions but keeps slot rows', () => {
+    const slot1 = setupSlot('cct1', 'slot-1');
+    const slot2 = setupSlot('cct2', 'slot-2');
+    const blocks = buildCctCardBlocks({
+      slots: [slot1, slot2],
+      states: {},
+      activeKeyId: 'slot-1',
+      viewerMode: 'readonly',
+    });
+    // Slot rows MUST still render — readonly viewer sees the same identity
+    // line and status segments as admin (#803 spec Q3=A).
+    const flat = JSON.stringify(blocks);
+    expect(flat).toContain('cct1');
+    expect(flat).toContain('cct2');
+    // No per-slot Activate / Attach / Detach / Remove anywhere on the card.
+    const allActionIds = blocks
+      .filter((b: any) => b.type === 'actions')
+      .flatMap((b: any) => b.elements.map((e: any) => e.action_id));
+    expect(allActionIds).not.toContain(CCT_ACTION_IDS.activate_slot);
+    expect(allActionIds).not.toContain(CCT_ACTION_IDS.attach);
+    expect(allActionIds).not.toContain(CCT_ACTION_IDS.detach);
+    expect(allActionIds).not.toContain(CCT_ACTION_IDS.remove);
+  });
+
+  it('#803: viewerMode=readonly omits per-slot empty actions block (no zero-element actions row)', () => {
+    const slot = setupSlot('cct1', 'slot-1');
+    const blocks = buildCctCardBlocks({
+      slots: [slot],
+      states: {},
+      activeKeyId: 'slot-1',
+      viewerMode: 'readonly',
+    });
+    // Slack rejects an `actions` block with zero elements. The readonly
+    // path must SKIP the per-slot actions block entirely instead of
+    // emitting an empty one. Only the card-level Refresh actions block
+    // should remain after the slot row + divider.
+    const allActions = blocks.filter((b: any) => b.type === 'actions');
+    for (const a of allActions) {
+      expect((a as any).elements.length).toBeGreaterThan(0);
+    }
+    // Exactly ONE actions block on the card (card-level Refresh only).
+    expect(allActions.length).toBe(1);
+  });
+
+  it('#803: viewerMode=readonly card-level row is Refresh only (no Add/Next/RefreshAll)', () => {
+    const slot = setupSlot('cct1', 'slot-1');
+    const blocks = buildCctCardBlocks({
+      slots: [slot],
+      states: {},
+      activeKeyId: 'slot-1',
+      viewerMode: 'readonly',
+    });
+    const allActions = blocks.filter((b: any) => b.type === 'actions');
+    const lastRow = allActions[allActions.length - 1] as any;
+    const ids = lastRow.elements.map((e: any) => e.action_id);
+    expect(ids).toEqual([CCT_ACTION_IDS.refresh_card]);
+    // The card-level Refresh button carries the readonly mode in its
+    // value so the action handler can preserve the card mode + force
+    // gate on re-render.
+    expect(lastRow.elements[0].value).toBe('cm:readonly|refresh_card');
+  });
+
+  it('#803: viewerMode=readonly empty-state copy switches from "Click *Add*" to "(no slots cached)"', () => {
+    const blocks = buildCctCardBlocks({ slots: [], states: {}, viewerMode: 'readonly' });
+    const flat = JSON.stringify(blocks);
+    expect(flat).toContain('(no slots cached)');
+    expect(flat).not.toMatch(/Click \*Add\*/);
+    // Even in the empty case, the readonly card-level row is Refresh only.
+    const allActions = blocks.filter((b: any) => b.type === 'actions') as any[];
+    expect(allActions).toHaveLength(1);
+    expect(allActions[0].elements.map((e: any) => e.action_id)).toEqual([CCT_ACTION_IDS.refresh_card]);
+  });
+
+  it('#803: viewerMode=admin stamps cm:admin| on every per-slot AND card-level button value', () => {
+    const slot = setupSlot('cct1', 'slot-1');
+    const blocks = buildCctCardBlocks({
+      slots: [slot],
+      states: {},
+      activeKeyId: undefined,
+      viewerMode: 'admin',
+    });
+    const allButtons = blocks
+      .filter((b: any) => b.type === 'actions')
+      .flatMap((b: any) => b.elements.filter((e: any) => e.type === 'button'));
+    for (const btn of allButtons) {
+      expect(btn.value).toMatch(/^cm:admin\|/);
+    }
+  });
+
+  it('#803: usage panel still renders for attached slots in viewerMode=readonly', () => {
+    const slot: AuthKey = {
+      kind: 'cct',
+      source: 'setup',
+      keyId: 'slot-1',
+      name: 'cct1',
+      setupToken: 'sk-ant-oat01-x',
+      oauthAttachment: {
+        accessToken: 't',
+        refreshToken: 'r',
+        expiresAtMs: Date.parse('2026-12-31T00:00:00Z'),
+        scopes: ['user:profile'],
+        acknowledgedConsumerTosRisk: true,
+      },
+      createdAt: '',
+    };
+    const states: Record<string, any> = {
+      'slot-1': {
+        authState: 'healthy',
+        activeLeases: [],
+        usage: {
+          fetchedAt: '2026-04-21T00:00:00Z',
+          fiveHour: { utilization: 50, resetsAt: '2026-04-21T03:00:00Z' },
+          sevenDay: { utilization: 20, resetsAt: '2026-04-28T00:00:00Z' },
+        },
+      },
+    };
+    const blocks = buildCctCardBlocks({
+      slots: [slot],
+      states,
+      activeKeyId: 'slot-1',
+      nowMs: Date.parse('2026-04-21T00:00:00Z'),
+      viewerMode: 'readonly',
+    });
+    // Usage progress glyph must still be present so non-admin sees usage.
+    const flat = JSON.stringify(blocks);
+    expect(flat).toMatch(/█/);
+    expect(flat).toMatch(/5h/);
+    expect(flat).toMatch(/7d/);
   });
 });
 
@@ -394,7 +531,8 @@ describe('buildSlotRow Attach/Detach buttons (Z2)', () => {
     expect(ids).toContain(CCT_ACTION_IDS.attach);
     expect(ids).not.toContain(CCT_ACTION_IDS.detach);
     const attachBtn = actions.elements.find((e: any) => e.action_id === CCT_ACTION_IDS.attach);
-    expect(attachBtn.value).toBe('slot-bare');
+    // #803 — button value is now `cm:admin|<keyId>`.
+    expect(attachBtn.value).toBe('cm:admin|slot-bare');
   });
 
   it('T7c-ii: setup-source cct slot with attachment gets Detach OAuth button', () => {
@@ -405,7 +543,8 @@ describe('buildSlotRow Attach/Detach buttons (Z2)', () => {
     expect(ids).toContain(CCT_ACTION_IDS.detach);
     expect(ids).not.toContain(CCT_ACTION_IDS.attach);
     const detachBtn = actions.elements.find((e: any) => e.action_id === CCT_ACTION_IDS.detach);
-    expect(detachBtn.value).toBe('slot-attached');
+    // #803 — button value is now `cm:admin|<keyId>`.
+    expect(detachBtn.value).toBe('cm:admin|slot-attached');
   });
 
   it('T7c-iii: legacy-attachment cct slot has NO Attach/Detach (mandatory-attachment arm)', () => {

--- a/src/slack/cct/__tests__/render-in-place.test.ts
+++ b/src/slack/cct/__tests__/render-in-place.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for `renderInPlace` transport helper (#803).
+ *
+ * Covers:
+ *   - surface classification: message / ephemeral / unknown
+ *   - channel/ts fallback chain (container preferred, falls back to
+ *     `body.channel.id` / `body.message.ts`)
+ *   - ephemeral surface + missing respond → `unknown` failure
+ *   - chat.update / respond failure paths return `{ ok: false }`
+ *   - unknown surface refuses to stack a fresh ephemeral
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { classifyRenderInPlaceSurface, renderInPlace } from '../render-in-place';
+
+function makeClient(updateImpl?: (args: any) => Promise<unknown>) {
+  return {
+    chat: {
+      update: vi.fn(updateImpl ?? (async () => ({ ok: true }))),
+    },
+  } as any;
+}
+
+function makeBlocks(): Record<string, unknown>[] {
+  return [{ type: 'header', text: { type: 'plain_text', text: ':key: CCT' } }];
+}
+
+describe('classifyRenderInPlaceSurface', () => {
+  it('returns "message" for container.type=message + channel + ts', () => {
+    expect(
+      classifyRenderInPlaceSurface({
+        container: { type: 'message', channel_id: 'C1', message_ts: '1.0' },
+      }),
+    ).toBe('message');
+  });
+
+  it('returns "message" using top-level channel/message fallback', () => {
+    expect(
+      classifyRenderInPlaceSurface({
+        container: { type: 'message' },
+        channel: { id: 'C1' },
+        message: { ts: '1.0' },
+      }),
+    ).toBe('message');
+  });
+
+  it('returns "unknown" when container.type=message but no channel/ts anywhere', () => {
+    expect(classifyRenderInPlaceSurface({ container: { type: 'message' } })).toBe('unknown');
+  });
+
+  it('returns "ephemeral" for container.type=ephemeral', () => {
+    expect(classifyRenderInPlaceSurface({ container: { type: 'ephemeral' } })).toBe('ephemeral');
+  });
+
+  it('returns "ephemeral" when container.is_ephemeral is true (older Bolt shape)', () => {
+    expect(classifyRenderInPlaceSurface({ container: { is_ephemeral: true } })).toBe('ephemeral');
+  });
+
+  it('returns "unknown" when no container present', () => {
+    expect(classifyRenderInPlaceSurface({})).toBe('unknown');
+  });
+
+  it('returns "unknown" for view-tab container type', () => {
+    expect(classifyRenderInPlaceSurface({ container: { type: 'view' } })).toBe('unknown');
+  });
+});
+
+describe('renderInPlace — message surface', () => {
+  it('calls chat.update with channel/ts from container, returns {message, ok:true}', async () => {
+    const client = makeClient();
+    const renderMessageBlocks = vi.fn(async () => makeBlocks());
+    const renderEphemeralBlocks = vi.fn(async () => []);
+    const result = await renderInPlace({
+      body: { container: { type: 'message', channel_id: 'C1', message_ts: '1.0' } },
+      client,
+      text: 'cct',
+      renderMessageBlocks,
+      renderEphemeralBlocks,
+    });
+    expect(result).toEqual({ surface: 'message', ok: true });
+    expect(client.chat.update).toHaveBeenCalledTimes(1);
+    expect(client.chat.update).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C1', ts: '1.0', text: 'cct', blocks: expect.any(Array) }),
+    );
+    // Ephemeral builder must NOT have been invoked on the message path.
+    expect(renderEphemeralBlocks).not.toHaveBeenCalled();
+  });
+
+  it('falls back to body.channel.id / body.message.ts when container omits them', async () => {
+    const client = makeClient();
+    const result = await renderInPlace({
+      body: {
+        container: { type: 'message' },
+        channel: { id: 'C-fallback' },
+        message: { ts: '99.9' },
+      },
+      client,
+      text: 'cct',
+      renderMessageBlocks: async () => makeBlocks(),
+      renderEphemeralBlocks: async () => [],
+    });
+    expect(result.ok).toBe(true);
+    expect(client.chat.update).toHaveBeenCalledWith(expect.objectContaining({ channel: 'C-fallback', ts: '99.9' }));
+  });
+
+  it('returns {message, ok:false} when chat.update throws', async () => {
+    const client = makeClient(async () => {
+      throw new Error('rate_limited');
+    });
+    const result = await renderInPlace({
+      body: { container: { type: 'message', channel_id: 'C1', message_ts: '1.0' } },
+      client,
+      text: 'cct',
+      renderMessageBlocks: async () => makeBlocks(),
+      renderEphemeralBlocks: async () => [],
+    });
+    expect(result).toEqual({ surface: 'message', ok: false });
+  });
+});
+
+describe('renderInPlace — ephemeral surface', () => {
+  it('calls respond({replace_original:true}) and returns {ephemeral, ok:true}', async () => {
+    const respond = vi.fn(async () => ({ ok: true }));
+    const renderMessageBlocks = vi.fn(async () => []);
+    const renderEphemeralBlocks = vi.fn(async () => makeBlocks());
+    const result = await renderInPlace({
+      body: { container: { type: 'ephemeral' } },
+      client: makeClient(),
+      respond,
+      text: 'cct',
+      renderMessageBlocks,
+      renderEphemeralBlocks,
+    });
+    expect(result).toEqual({ surface: 'ephemeral', ok: true });
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        response_type: 'ephemeral',
+        replace_original: true,
+        text: 'cct',
+        blocks: expect.any(Array),
+      }),
+    );
+    expect(renderMessageBlocks).not.toHaveBeenCalled();
+  });
+
+  it('returns {ephemeral, ok:false} when respond is missing', async () => {
+    const result = await renderInPlace({
+      body: { container: { type: 'ephemeral' } },
+      client: makeClient(),
+      // respond intentionally omitted
+      text: 'cct',
+      renderMessageBlocks: async () => [],
+      renderEphemeralBlocks: async () => makeBlocks(),
+    });
+    expect(result).toEqual({ surface: 'ephemeral', ok: false });
+  });
+
+  it('returns {ephemeral, ok:false} when respond throws', async () => {
+    const respond = vi.fn(async () => {
+      throw new Error('expired_url');
+    });
+    const result = await renderInPlace({
+      body: { container: { type: 'ephemeral' } },
+      client: makeClient(),
+      respond,
+      text: 'cct',
+      renderMessageBlocks: async () => [],
+      renderEphemeralBlocks: async () => makeBlocks(),
+    });
+    expect(result).toEqual({ surface: 'ephemeral', ok: false });
+  });
+});
+
+describe('renderInPlace — unknown surface', () => {
+  it('refuses to stack a fresh card and returns {unknown, ok:false}', async () => {
+    const respond = vi.fn(async () => ({ ok: true }));
+    const client = makeClient();
+    const result = await renderInPlace({
+      body: {}, // no container
+      client,
+      respond,
+      text: 'cct',
+      renderMessageBlocks: async () => makeBlocks(),
+      renderEphemeralBlocks: async () => makeBlocks(),
+    });
+    expect(result).toEqual({ surface: 'unknown', ok: false });
+    expect(client.chat.update).not.toHaveBeenCalled();
+    expect(respond).not.toHaveBeenCalled();
+  });
+
+  it('returns {unknown, ok:false} when container.type=message but channel/ts missing', async () => {
+    const respond = vi.fn(async () => ({ ok: true }));
+    const client = makeClient();
+    const result = await renderInPlace({
+      body: { container: { type: 'message' } },
+      client,
+      respond,
+      text: 'cct',
+      renderMessageBlocks: async () => makeBlocks(),
+      renderEphemeralBlocks: async () => makeBlocks(),
+    });
+    expect(result).toEqual({ surface: 'unknown', ok: false });
+  });
+});

--- a/src/slack/cct/__tests__/render-in-place.test.ts
+++ b/src/slack/cct/__tests__/render-in-place.test.ts
@@ -56,6 +56,19 @@ describe('classifyRenderInPlaceSurface', () => {
     expect(classifyRenderInPlaceSurface({ container: { is_ephemeral: true } })).toBe('ephemeral');
   });
 
+  // Codex P2 review (PR #805): Slack/Bolt sometimes ship payloads where
+  // `container.type === 'message'` AND `container.is_ephemeral === true`.
+  // The classifier MUST treat this as ephemeral — `chat.update` is illegal
+  // for ephemeral surfaces, so falling through to the message branch
+  // would attempt an API call Slack rejects, leaving users on stale cards.
+  it('returns "ephemeral" when type=message but is_ephemeral=true (Codex P2)', () => {
+    expect(
+      classifyRenderInPlaceSurface({
+        container: { type: 'message', is_ephemeral: true, channel_id: 'C1', message_ts: '1.0' },
+      }),
+    ).toBe('ephemeral');
+  });
+
   it('returns "unknown" when no container present', () => {
     expect(classifyRenderInPlaceSurface({})).toBe('unknown');
   });

--- a/src/slack/cct/action-value.ts
+++ b/src/slack/cct/action-value.ts
@@ -1,0 +1,142 @@
+/**
+ * CCT button-value codec — encodes / decodes the `cm:<mode>|<payload>` form
+ * stamped onto every CCT card button (#803).
+ *
+ * Why a codec at all?
+ *   - The card is shared across viewers (channel message). The card's
+ *     RENDER mode (`'admin'` vs `'readonly'`) is decided by the viewer who
+ *     opened it; once posted, the mode is frozen on the message and must
+ *     be PRESERVED across re-renders triggered by other viewers (e.g.
+ *     non-admin clicking Refresh on an admin card must not flip it to
+ *     readonly mode and lose the action buttons).
+ *   - Slack passes the original button value through every action
+ *     dispatch — that is the only safely-channel-attached metadata
+ *     surface available to a stateless handler. Encoding mode + payload
+ *     here lets handlers reconstruct the card frozen against whichever
+ *     viewer first posted it.
+ *
+ * Wire format:
+ *   `cm:admin|<payload>`     — card was posted in admin mode
+ *   `cm:readonly|<payload>`  — card was posted in readonly mode
+ *   `<payload>`              — legacy form (no `cm:` prefix). Decoder
+ *     treats this as `kind: 'legacy'` and the handler must force
+ *     `force=false` and fall back to the actor's mode for render.
+ *
+ * Invalid matrix (decoder rejects all of these — NO legacy fallback):
+ *   - `null` / `undefined` / non-string
+ *   - empty string `''`
+ *   - whitespace-only
+ *   - `'cm:'` (no mode, no `|`)
+ *   - `'cm:admin'` (no `|`)
+ *   - `'cm:admin|'` (empty payload)
+ *   - `'cm:|abc'` (empty mode)
+ *   - `'cm:bad|abc'` (unknown mode)
+ *
+ * Slack imposes a 2000-char button-value cap — encoded results are
+ * length-checked at encode time so we fail fast in the builder, not at
+ * dispatch.
+ */
+
+/** The two render modes a card can be frozen into. */
+export type CctCardMode = 'admin' | 'readonly';
+
+const PREFIX = 'cm:';
+const SEP = '|';
+/**
+ * Slack hard cap on button `value`. Encoder rejects above this so a
+ * builder bug surfaces immediately rather than at runtime when Slack
+ * silently drops the dispatch.
+ */
+const SLACK_BUTTON_VALUE_MAX = 2000;
+
+const VALID_MODES: ReadonlySet<string> = new Set<CctCardMode>(['admin', 'readonly']);
+
+/**
+ * Decoder result. `tagged` carries a parsed `cm:`-prefixed value;
+ * `legacy` carries a non-empty string with NO prefix (handlers must
+ * force `force=false` when acting on a legacy value); `invalid` carries
+ * the raw input for logging — handlers MUST ack and refuse the action.
+ */
+export type DecodedCctActionValue =
+  | { kind: 'tagged'; mode: CctCardMode; payload: string }
+  | { kind: 'legacy'; payload: string }
+  | { kind: 'invalid'; raw: unknown };
+
+/**
+ * Encode `mode` + `payload` into a button-value string.
+ *
+ * Throws on:
+ *   - unknown mode
+ *   - empty / whitespace-only payload
+ *   - encoded result exceeds Slack's 2000-char button-value cap
+ *
+ * The throw is intentional — a builder that produces a too-long value
+ * is a code bug, not a runtime input. Surfacing it here keeps the
+ * action-dispatch path total.
+ */
+export function encodeCctActionValue(opts: { mode: CctCardMode; payload: string }): string {
+  const { mode, payload } = opts;
+  if (!VALID_MODES.has(mode)) {
+    throw new Error(`encodeCctActionValue: unknown mode ${JSON.stringify(mode)}`);
+  }
+  if (typeof payload !== 'string' || payload.length === 0 || payload.trim().length === 0) {
+    throw new Error('encodeCctActionValue: payload must be a non-empty, non-whitespace string');
+  }
+  const encoded = `${PREFIX}${mode}${SEP}${payload}`;
+  if (encoded.length > SLACK_BUTTON_VALUE_MAX) {
+    throw new Error(
+      `encodeCctActionValue: encoded value ${encoded.length} chars exceeds Slack cap ${SLACK_BUTTON_VALUE_MAX}`,
+    );
+  }
+  return encoded;
+}
+
+/**
+ * Decode a raw button-value string into a typed result.
+ *
+ * Decoder is INTENTIONALLY conservative: a malformed `cm:`-prefixed
+ * value is `invalid`, NOT `legacy`. Falling through to legacy on a
+ * partial prefix would let a `cm:admin` (missing `|`) sneak past with
+ * the actor's render mode and `force=false` — but the operator who
+ * stamped that value had a typo, not a legacy card. Forcing them to
+ * see "card needs re-render" is the safer failure mode.
+ *
+ * Tagged form parsing rule: split on the FIRST `|` only. So
+ * `cm:admin|abc|def` → `{ mode: 'admin', payload: 'abc|def' }`. This
+ * keeps the codec compositional (a payload may itself contain `|` — for
+ * example a URL-encoded blob) without forcing the caller to escape.
+ */
+export function decodeCctActionValue(raw: unknown): DecodedCctActionValue {
+  if (typeof raw !== 'string') return { kind: 'invalid', raw };
+  if (raw.length === 0 || raw.trim().length === 0) return { kind: 'invalid', raw };
+  if (!raw.startsWith(PREFIX)) {
+    // Legacy: any non-empty, non-whitespace string with no `cm:` prefix.
+    return { kind: 'legacy', payload: raw };
+  }
+  const tail = raw.slice(PREFIX.length);
+  const sepIdx = tail.indexOf(SEP);
+  if (sepIdx === -1) {
+    // `cm:` or `cm:admin` — prefix without the `|` separator.
+    return { kind: 'invalid', raw };
+  }
+  const mode = tail.slice(0, sepIdx);
+  const payload = tail.slice(sepIdx + 1);
+  if (mode.length === 0) return { kind: 'invalid', raw };
+  if (payload.length === 0) return { kind: 'invalid', raw };
+  if (!VALID_MODES.has(mode)) return { kind: 'invalid', raw };
+  return { kind: 'tagged', mode: mode as CctCardMode, payload };
+}
+
+/**
+ * Convenience: pull the inner payload from a button value, regardless of
+ * `tagged` vs `legacy` form. Returns null on `invalid` — caller should
+ * ack and surface a banner.
+ *
+ * Used by handlers that only need the keyId (or other inner ID) and not
+ * the cardMode discriminant.
+ */
+export function readCctActionPayload(raw: unknown): string | null {
+  const decoded = decodeCctActionValue(raw);
+  if (decoded.kind === 'invalid') return null;
+  return decoded.payload;
+}

--- a/src/slack/cct/actions.ts
+++ b/src/slack/cct/actions.ts
@@ -111,30 +111,6 @@ export function buildPartialFailureBanner(failures: RefreshFailureSummary[], tot
 }
 
 /**
- * Surface descriptor for the `refresh_card` handler. Bolt's block_actions
- * payload carries a `container` block whose shape varies by surface:
- *   - `type: 'message'` → posted card; `chat.update(channel, ts, …)` works.
- *   - `type: 'ephemeral'` → ephemeral card from `postEphemeral`; `chat.update`
- *     is forbidden (no `message_ts` for ephemerals), so we use the
- *     `respond` callback with `replace_original: true` against the
- *     response_url Slack hands us per-action.
- * Anything else (`view`, missing container) falls back to the
- * `updateFailed` banner — we refuse to stack a fresh ephemeral card on
- * top of the stale one because that's exactly the bug Codex flagged.
- */
-interface RefreshCardActionBody {
-  user?: { id?: string };
-  container?: {
-    type?: 'message' | 'ephemeral' | string;
-    channel_id?: string;
-    message_ts?: string;
-  };
-  channel?: { id?: string };
-  message?: { ts?: string };
-  actions?: Array<{ value?: string }>;
-}
-
-/**
  * Register all CCT block actions + view submissions on the Bolt app.
  *
  * Registered routes:
@@ -478,21 +454,20 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
       // `force=true` fetch is gated to (admin actor) ∧ (cardMode='admin')
       // so non-admin clicking Refresh on an admin-mode card
       // re-renders without forcing a fresh fetch — throttle is honored.
-      const decoded = decodeActionButtonValue(body);
-      if (!decoded && (body as any)?.actions?.[0]?.value !== undefined) {
-        // Value present but unparseable. Banner + bail.
+      const decoded = decodeCctActionValue((body as { actions?: Array<{ value?: unknown }> })?.actions?.[0]?.value);
+      if (decoded.kind === 'invalid') {
         logger.warn('cct_refresh_card: invalid action value');
         await postEphemeralFailure(client, body, REFRESH_BANNERS.updateFailed);
         return;
       }
       const userIdValue = actorUserId(body);
-      const cardMode = decoded?.cardMode ?? null; // null when legacy / no value.
-      const isLegacy = decoded?.isLegacy ?? false;
+      const cardMode = decoded.kind === 'tagged' ? decoded.mode : null; // null on legacy.
       const actorIsAdmin = userIdValue ? isAdminUser(userIdValue) : false;
-      // Force gate: legacy decode → force=false (cardMode unknown,
-      // safer to throttle); tagged → force only when actor is admin AND
-      // cardMode is 'admin'.
-      const allowForce = !isLegacy && actorIsAdmin && cardMode === 'admin';
+      // Force gate: tagged 'admin' AND admin actor → force fetch.
+      // `cardMode === 'admin'` already implies non-legacy (legacy → null),
+      // so the legacy branch falls through to non-force without a separate
+      // check.
+      const allowForce = actorIsAdmin && cardMode === 'admin';
       const renderMode: CctCardViewerMode = resolveRenderMode(cardMode, userIdValue);
 
       const snap = await tokenManager.getSnapshot();
@@ -534,6 +509,10 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
 
       const banner = throttledAllNull ? ':warning: _Cached usage · refresh limited (5-minute throttle)._' : undefined;
 
+      // skipOnOpenFetch=true — both branches above already settled the
+      // usage refetch (or intentionally skipped it for empty fleets);
+      // a second on-open fan-out from renderCctCard would be redundant
+      // and potentially double-bill against Anthropic on the force path.
       const result = await renderCardInPlace({
         tokenManager,
         body,
@@ -541,6 +520,7 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
         respond,
         viewerMode: renderMode,
         prependBanner: banner,
+        skipOnOpenFetch: true,
       });
       if (result.surface === 'unknown' || !result.ok) {
         // Unknown surface or transport failure — surface the fallback
@@ -549,7 +529,7 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
         // (that's exactly what #803 fixes).
         if (result.surface === 'unknown') {
           logger.warn('cct_refresh_card no surface to update', {
-            container: (body as any)?.container,
+            container: (body as { container?: unknown })?.container,
           });
         }
         await postEphemeralFailure(client, body, REFRESH_BANNERS.updateFailed);
@@ -770,7 +750,7 @@ function decodeActionButtonValue(body: unknown): {
   cardMode: CctCardMode | null;
   isLegacy: boolean;
 } | null {
-  const raw = (body as any)?.actions?.[0]?.value;
+  const raw = (body as { actions?: Array<{ value?: unknown }> })?.actions?.[0]?.value;
   const decoded = decodeCctActionValue(raw);
   if (decoded.kind === 'invalid') return null;
   if (decoded.kind === 'legacy') {
@@ -902,19 +882,16 @@ function readCheckboxes(values: Record<string, Record<string, any>>, blockId: st
   return selected.map((o) => (typeof o?.value === 'string' ? (o.value as string) : '')).filter((v) => v.length > 0);
 }
 
-async function respondWithCard(opts: {
-  tokenManager: TokenManager;
-  respond?: (msg: any) => Promise<unknown>;
-  body: unknown;
-  client: WebClient;
-}): Promise<void> {
-  const { tokenManager, respond, body, client } = opts;
-  const blocks = await buildCardFromManager(tokenManager);
-  if (respond) {
-    await respond({ response_type: 'ephemeral', replace_original: false, blocks, text: ':key: CCT' });
-    return;
-  }
-  await postEphemeralCard(tokenManager, client, body);
+/**
+ * Prepend a Slack `section` banner block to a list of card blocks. Returns
+ * the input untouched when `banner` is empty/undefined so the caller can
+ * always pipe through it. Both `renderCardInPlace` factories and the
+ * future banner sites use this — a single change-point if the banner
+ * markup ever needs `block_id` / `accessory` / styling.
+ */
+function withBannerPrefix(banner: string | undefined, blocks: Record<string, unknown>[]): Record<string, unknown>[] {
+  if (!banner) return blocks;
+  return [{ type: 'section', text: { type: 'mrkdwn', text: banner } }, ...blocks];
 }
 
 /**
@@ -946,17 +923,33 @@ async function renderCardInPlace(opts: {
   viewerMode: CctCardViewerMode;
   text?: string;
   prependBanner?: string;
+  /**
+   * Tell the inner `renderCctCard` to skip its on-open
+   * `fetchUsageForAllAttached` fan-out. Set this when the action
+   * handler has already performed the relevant fetch (force or
+   * non-force) so the card render doesn't fire a second redundant
+   * fan-out against Anthropic.
+   */
+  skipOnOpenFetch?: boolean;
 }): Promise<{ surface: 'message' | 'ephemeral' | 'unknown'; ok: boolean }> {
   const { tokenManager, body, client, respond, viewerMode, prependBanner } = opts;
   const text = opts.text ?? ':key: CCT status';
   const userId = actorUserId(body);
   const renderMessageBlocks = async (): Promise<Record<string, unknown>[]> => {
     // Persistent message surfaces use renderCctCard so the trailing
-    // `z_setting_cct_cancel` chrome row survives chat.update.
+    // `z_setting_cct_cancel` chrome row survives chat.update. The
+    // skipOnOpenFetch hint is set when the action handler ALREADY
+    // performed a usage refetch (force or non-force) — a second
+    // fan-out from renderCctCard's on-open hook would be redundant.
     let blocks: Record<string, unknown>[];
     if (userId) {
       try {
-        const rendered = await renderCctCard({ userId, issuedAt: Date.now(), viewerMode });
+        const rendered = await renderCctCard({
+          userId,
+          issuedAt: Date.now(),
+          viewerMode,
+          skipOnOpenFetch: opts.skipOnOpenFetch,
+        });
         blocks = rendered.blocks as Record<string, unknown>[];
       } catch (err) {
         logger.warn('renderCardInPlace: renderCctCard failed, falling back to buildCardFromManager', {
@@ -967,11 +960,11 @@ async function renderCardInPlace(opts: {
     } else {
       blocks = await buildCardFromManager(tokenManager, { viewerMode });
     }
-    return prependBanner ? [{ type: 'section', text: { type: 'mrkdwn', text: prependBanner } }, ...blocks] : blocks;
+    return withBannerPrefix(prependBanner, blocks);
   };
   const renderEphemeralBlocks = async (): Promise<Record<string, unknown>[]> => {
     const blocks = await buildCardFromManager(tokenManager, { viewerMode });
-    return prependBanner ? [{ type: 'section', text: { type: 'mrkdwn', text: prependBanner } }, ...blocks] : blocks;
+    return withBannerPrefix(prependBanner, blocks);
   };
   return renderInPlace({
     body: body as Parameters<typeof renderInPlace>[0]['body'],
@@ -1017,49 +1010,6 @@ async function postEphemeralCard(tokenManager: TokenManager, client: WebClient, 
     });
   } catch (err) {
     logger.debug('postEphemeralCard failed', { err });
-  }
-}
-
-/**
- * #701 — single-surface partial-failure ephemeral. The banner `section`
- * block is prepended to the card blocks so the operator sees the failure
- * summary AND the updated per-row warnings in a single atomic message.
- * This replaces the pre-#701 "post banner; then post card" sequence that
- * could arrive out of order.
- *
- * On transport failure we fall back to a single `postEphemeralFailure`
- * with just the banner — losing the card detail is acceptable, losing
- * the failure signal entirely is not.
- */
-async function postEphemeralCardWithBanner(
-  tokenManager: TokenManager,
-  client: WebClient,
-  body: unknown,
-  banner: string,
-): Promise<void> {
-  const target = resolveEphemeralTarget(body);
-  if (!target) {
-    logger.warn('postEphemeralCardWithBanner: missing user/channel on action body; banner dropped', { banner });
-    return;
-  }
-  const cardBlocks = await buildCardFromManager(tokenManager);
-  const blocks = [
-    {
-      type: 'section',
-      text: { type: 'mrkdwn', text: banner },
-    },
-    ...cardBlocks,
-  ];
-  try {
-    await client.chat.postEphemeral({
-      channel: target.channel,
-      user: target.userId,
-      text: ':warning: CCT refresh — partial failure',
-      blocks: blocks as any,
-    });
-  } catch (err) {
-    logger.debug('postEphemeralCardWithBanner failed; falling back to banner-only', { err });
-    await postEphemeralFailure(client, body, banner);
   }
 }
 

--- a/src/slack/cct/actions.ts
+++ b/src/slack/cct/actions.ts
@@ -21,11 +21,13 @@ import type { App } from '@slack/bolt';
 import type { WebClient } from '@slack/web-api';
 import { isAdminUser } from '../../admin-utils';
 import type { AuthKey } from '../../auth/auth-key';
+import { config } from '../../config';
 import { Logger } from '../../logger';
 import type { OAuthCredentials } from '../../oauth/refresher';
 import { hasRequiredScopes } from '../../oauth/scope-check';
 import type { TokenManager } from '../../token-manager';
 import { renderCctCard } from '../z/topics/cct-topic';
+import { type CctCardMode, decodeCctActionValue } from './action-value';
 import {
   type AddSlotFormKind,
   appendStoreReadFailureBanner,
@@ -33,8 +35,10 @@ import {
   buildAttachOAuthModal,
   buildCctCardBlocks,
   buildRemoveSlotModal,
+  type CctCardViewerMode,
   escapeMrkdwn,
 } from './builder';
+import { renderInPlace } from './render-in-place';
 import { CCT_ACTION_IDS, CCT_BLOCK_IDS, CCT_VIEW_IDS } from './views';
 
 const logger = new Logger('CctActions');
@@ -184,14 +188,15 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
       if (!requireAdmin(body)) return;
       const triggerId: string | undefined = (body as any)?.trigger_id;
       if (!triggerId) return;
-      // Per-slot Remove button: `value` carries the target keyId. Reject
-      // if absent or unknown — no silent fallback to active/slots[0].
-      const bodyAction = (body as any).actions?.[0];
-      const targetKeyId = typeof bodyAction?.value === 'string' ? bodyAction.value : undefined;
-      if (!targetKeyId) {
-        logger.warn('cct_open_remove: missing keyId on action value');
+      // Per-slot Remove button: `value` carries the target keyId,
+      // tagged via the #803 codec. Reject if invalid — no silent
+      // fallback to active/slots[0].
+      const decoded = decodeActionButtonValue(body);
+      if (!decoded) {
+        logger.warn('cct_open_remove: invalid or missing keyId on action value');
         return;
       }
+      const targetKeyId = decoded.payload;
       const snap = await tokenManager.getSnapshot();
       const target = snap.registry.slots.find((s) => s.keyId === targetKeyId);
       if (!target) {
@@ -219,12 +224,12 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
       if (!requireAdmin(body)) return;
       const triggerId: string | undefined = (body as any)?.trigger_id;
       if (!triggerId) return;
-      const bodyAction = (body as any).actions?.[0];
-      const targetKeyId = typeof bodyAction?.value === 'string' ? bodyAction.value : undefined;
-      if (!targetKeyId) {
-        logger.warn('cct_open_attach: missing keyId on action value');
+      const decoded = decodeActionButtonValue(body);
+      if (!decoded) {
+        logger.warn('cct_open_attach: invalid or missing keyId on action value');
         return;
       }
+      const targetKeyId = decoded.payload;
       const snap = await tokenManager.getSnapshot();
       const target = snap.registry.slots.find((s) => s.keyId === targetKeyId);
       if (!target) {
@@ -248,52 +253,72 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
   });
 
   // Z2 — Detach OAuth. Inline action (no modal): validate → ack → mutate.
-  // The card is re-posted ephemerally so the user immediately sees the
-  // Attach button replace the Detach button for that slot.
-  app.action(CCT_ACTION_IDS.detach, async ({ ack, body, client }) => {
+  //
+  // #803 — replaces the prior `postEphemeralCard` (which spawned a fresh
+  // ephemeral on top of the stale card) with `renderCardInPlace` so the
+  // clicked surface updates in place. cardMode is preserved from the
+  // originating button so a non-admin viewing an admin-mode card who
+  // clicked Detach (which they cannot) would have been refused at the
+  // admin gate; admin-on-admin-card is the only happy path here.
+  app.action(CCT_ACTION_IDS.detach, async ({ ack, body, client, respond }) => {
     await ack();
     try {
       if (!requireAdmin(body)) return;
-      const bodyAction = (body as any).actions?.[0];
-      const targetKeyId = typeof bodyAction?.value === 'string' ? bodyAction.value : undefined;
-      if (!targetKeyId) {
-        logger.warn('cct_detach: missing keyId on action value');
+      const decoded = decodeActionButtonValue(body);
+      if (!decoded) {
+        logger.warn('cct_detach: invalid or missing keyId on action value');
         return;
       }
+      const targetKeyId = decoded.payload;
+      const renderMode = resolveRenderMode(decoded.cardMode, actorUserId(body));
       await tokenManager.detachOAuth(targetKeyId);
-      await postEphemeralCard(tokenManager, client, body);
+      await renderCardInPlace({ tokenManager, body, client, respond, viewerMode: renderMode });
     } catch (err) {
       logger.error('cct_detach failed', err);
     }
   });
 
   // Rotate to next.
+  //
+  // #803 — in-place card update via renderCardInPlace.
   app.action(CCT_ACTION_IDS.next, async ({ ack, body, client, respond }) => {
     await ack();
     try {
       if (!requireAdmin(body)) return;
+      // Decode the button value so legacy `value:'next'` (pre-#803) and
+      // tagged `cm:admin|next` both flow through. cardMode falls back
+      // to actor-derived when legacy.
+      const decoded = decodeActionButtonValue(body);
+      const renderMode = resolveRenderMode(decoded?.cardMode ?? null, actorUserId(body));
       await tokenManager.rotateToNext();
-      await respondWithCard({ tokenManager, respond, body, client });
+      await renderCardInPlace({ tokenManager, body, client, respond, viewerMode: renderMode });
     } catch (err) {
       logger.error('cct_next failed', err);
     }
   });
 
   // Per-slot [Activate] button. Admin gate + `applyToken(keyId)`
-  // + re-post card. Button is only emitted for non-active, non-api_key
-  // slots (see `buildSlotRow`); the handler re-validates server-side so
-  // a stale card (where the user already rotated elsewhere) can't force
-  // a runtime exception into `applyToken`'s api_key reject path.
+  // + in-place card re-render.
+  //
+  // Button is only emitted for non-active, non-api_key slots (see
+  // `buildSlotRow`); the handler re-validates server-side so a stale
+  // card (where the user already rotated elsewhere) can't force a
+  // runtime exception into `applyToken`'s api_key reject path.
+  //
+  // #803 — `respondWithCard` (which posted a fresh ephemeral via
+  // `respond({replace_original:false})`) replaced by `renderCardInPlace`
+  // so the clicked surface updates in place.
   app.action(CCT_ACTION_IDS.activate_slot, async ({ ack, body, client, respond }) => {
     await ack();
     try {
       if (!requireAdmin(body)) return;
-      const bodyAction = (body as any).actions?.[0];
-      const targetKeyId = typeof bodyAction?.value === 'string' ? bodyAction.value : undefined;
-      if (!targetKeyId) {
-        logger.warn('cct_activate_slot: missing keyId on action value');
+      const decoded = decodeActionButtonValue(body);
+      if (!decoded) {
+        logger.warn('cct_activate_slot: invalid or missing keyId on action value');
         return;
       }
+      const targetKeyId = decoded.payload;
+      const renderMode = resolveRenderMode(decoded.cardMode, actorUserId(body));
       const snap = await tokenManager.getSnapshot();
       const target = snap.registry.slots.find((s) => s.keyId === targetKeyId);
       if (!target) {
@@ -305,7 +330,7 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
         return;
       }
       await tokenManager.applyToken(targetKeyId);
-      await respondWithCard({ tokenManager, respond, body, client });
+      await renderCardInPlace({ tokenManager, body, client, respond, viewerMode: renderMode });
     } catch (err) {
       logger.error('cct_activate_slot failed', err);
     }
@@ -324,10 +349,15 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
   // an ephemeral banner instead of silently re-rendering the same stale
   // card. Partial failures still re-post so successful rows update. Empty
   // result map (no attached slots) is not "all failed".
-  app.action(CCT_ACTION_IDS.refresh_usage_all, async ({ ack, body, client }) => {
+  app.action(CCT_ACTION_IDS.refresh_usage_all, async ({ ack, body, client, respond }) => {
     await ack();
     try {
       if (!requireAdmin(body)) return;
+      // #803 — refresh_usage_all is admin-only and only emitted on the
+      // admin card, so cardMode is implicitly 'admin'. Decode for
+      // legacy compat anyway so a pre-#803 button still flows through.
+      const decoded = decodeActionButtonValue(body);
+      const renderMode = resolveRenderMode(decoded?.cardMode ?? null, actorUserId(body));
       // #701 — capture the starting keyIds BEFORE the refresh call so we
       // can detect slots that timed out (missing from `results`) separately
       // from slots that were concurrently removed/detached.
@@ -376,27 +406,44 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
 
       const effectiveTotal = okCount + failures.length;
 
-      // All-failed path — no successes, at least one failure. Covers the
-      // "every slot timed out" case (empty `results`) that the naive
-      // check would have sent into the mixed path with no successes.
+      // #803 — All three outcome arms now go through `renderCardInPlace`
+      // so the originating card surface is updated in place rather than
+      // stacking a fresh ephemeral on top of the stale card.
+      //
+      // All-failed: prepend the `allNull` banner (no successes worth
+      // re-rendering, but still render so the operator sees the card
+      // chrome explaining why).
+      // Partial: prepend the partial-failure banner with name (kind/code)
+      // bullets.
+      // Success-only: render the card with no banner.
+
+      let banner: string | undefined;
       if (failures.length > 0 && okCount === 0 && effectiveTotal > 0) {
-        await postEphemeralFailure(client, body, REFRESH_BANNERS.allNull);
-        return;
+        banner = REFRESH_BANNERS.allNull;
+      } else if (failures.length > 0) {
+        banner = buildPartialFailureBanner(failures, effectiveTotal);
       }
 
-      if (failures.length === 0) {
-        // No partial failures — render the updated card (unchanged path).
-        await postEphemeralCard(tokenManager, client, body);
-        return;
+      const result = await renderCardInPlace({
+        tokenManager,
+        body,
+        client,
+        respond,
+        viewerMode: renderMode,
+        prependBanner: banner,
+      });
+      if (result.surface === 'unknown' || !result.ok) {
+        // Couldn't update the surface — surface the banner via
+        // ephemeral fallback so we at least don't drop the failure
+        // signal on the floor.
+        if (banner) {
+          await postEphemeralFailure(client, body, banner);
+        } else {
+          // Success-only path failed to render. Operator gets a generic
+          // "card update failed" line so they re-invoke /cct.
+          await postEphemeralFailure(client, body, REFRESH_BANNERS.updateFailed);
+        }
       }
-
-      // Mixed outcomes → single ephemeral surface: banner block + card
-      // blocks in one `chat.postEphemeral` call. Prevents the ordering
-      // race that two separate ephemeral posts would introduce. Denominator
-      // is `effectiveTotal` (ok + failed) — concurrent teardown is OMITTED,
-      // matching the spec's accounting rules.
-      const banner = buildPartialFailureBanner(failures, effectiveTotal);
-      await postEphemeralCardWithBanner(tokenManager, client, body, banner);
     } catch (err) {
       logger.error('cct_refresh_usage_all failed', err);
       await postEphemeralFailure(client, body, REFRESH_BANNERS.outerCatch);
@@ -426,84 +473,87 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
   app.action(CCT_ACTION_IDS.refresh_card, async ({ ack, body, client, respond }) => {
     await ack();
     try {
-      if (!requireAdmin(body)) return;
+      // #803 — `refresh_card` is now allowed for non-admin (the only
+      // affordance on the readonly card). Side-effect-bearing
+      // `force=true` fetch is gated to (admin actor) ∧ (cardMode='admin')
+      // so non-admin clicking Refresh on an admin-mode card
+      // re-renders without forcing a fresh fetch — throttle is honored.
+      const decoded = decodeActionButtonValue(body);
+      if (!decoded && (body as any)?.actions?.[0]?.value !== undefined) {
+        // Value present but unparseable. Banner + bail.
+        logger.warn('cct_refresh_card: invalid action value');
+        await postEphemeralFailure(client, body, REFRESH_BANNERS.updateFailed);
+        return;
+      }
+      const userIdValue = actorUserId(body);
+      const cardMode = decoded?.cardMode ?? null; // null when legacy / no value.
+      const isLegacy = decoded?.isLegacy ?? false;
+      const actorIsAdmin = userIdValue ? isAdminUser(userIdValue) : false;
+      // Force gate: legacy decode → force=false (cardMode unknown,
+      // safer to throttle); tagged → force only when actor is admin AND
+      // cardMode is 'admin'.
+      const allowForce = !isLegacy && actorIsAdmin && cardMode === 'admin';
+      const renderMode: CctCardViewerMode = resolveRenderMode(cardMode, userIdValue);
+
       const snap = await tokenManager.getSnapshot();
       const keyIds = snap.registry.slots
         .filter((s) => s.kind === 'cct' && s.oauthAttachment !== undefined)
         .map((s) => s.keyId);
-      const results = await Promise.allSettled(
-        keyIds.map((keyId) => tokenManager.fetchAndStoreUsage(keyId, { force: true })),
-      );
-      const freshCount = results.filter((r) => r.status === 'fulfilled' && r.value !== null).length;
-      if (freshCount === 0 && keyIds.length > 0) {
-        await postEphemeralFailure(client, body, REFRESH_BANNERS.cardNull);
-        return;
-      }
 
-      // Surface-aware renderer choice (Codex P2 follow-up to #679):
-      //   - container.type === 'message'   → renderCctCard (persistent /cct
-      //     and /z cct messages were built by cct-topic and carry the
-      //     trailing z_setting_cct_cancel actions row; chat.update with
-      //     buildCardFromManager output strips that row).
-      //   - container.type === 'ephemeral' → buildCardFromManager (cancel
-      //     button isn't part of the ephemeral surface).
-      // renderCctCard is heavier (admin check + fetchUsageForAllAttached +
-      // buildCctCardBlocks); on failure we fall back to the
-      // buildCardFromManager output so refresh still works.
-      const blocks = await buildCardFromManager(tokenManager);
-      const typed = body as RefreshCardActionBody;
-      const containerType = typed?.container?.type;
-      const channel = typed?.container?.channel_id ?? typed?.channel?.id;
-      const ts = typed?.container?.message_ts ?? typed?.message?.ts;
-      const userId = typed?.user?.id;
-
-      if (containerType === 'message' && channel && ts) {
-        let messageBlocks = blocks;
-        if (userId) {
-          try {
-            const rendered = await renderCctCard({ userId, issuedAt: Date.now() });
-            messageBlocks = rendered.blocks as Record<string, unknown>[];
-          } catch (err) {
-            logger.warn('cct_refresh_card renderCctCard failed, falling back to buildCardFromManager', {
-              err: (err as Error).message,
-            });
-          }
+      let throttledAllNull = false;
+      if (allowForce) {
+        // Admin-on-admin-card: fan-out force fetch (existing behavior).
+        const results = await Promise.allSettled(
+          keyIds.map((keyId) => tokenManager.fetchAndStoreUsage(keyId, { force: true })),
+        );
+        const freshCount = results.filter((r) => r.status === 'fulfilled' && r.value !== null).length;
+        if (freshCount === 0 && keyIds.length > 0) {
+          await postEphemeralFailure(client, body, REFRESH_BANNERS.cardNull);
+          return;
         }
+      } else if (keyIds.length > 0) {
+        // Non-force path (non-admin, OR admin-on-readonly-card, OR
+        // legacy value). `fetchUsageForAllAttached` respects the
+        // per-keyId 5-minute throttle. When the timeout fires before
+        // any slot returns or every slot is throttled, the result map
+        // values are null — surface a context banner that says so but
+        // STILL render the cached card so the user sees something.
         try {
-          await client.chat.update({
-            channel,
-            ts,
-            text: ':key: CCT status',
-            blocks: messageBlocks as any,
+          const results = await tokenManager.fetchUsageForAllAttached({
+            timeoutMs: config.usage.cardOpenTimeoutMs,
           });
+          const fresh = Object.values(results).filter((v) => v !== null).length;
+          if (fresh === 0) throttledAllNull = true;
         } catch (err) {
-          logger.warn('cct_refresh_card chat.update failed', { err: (err as Error).message });
-          await postEphemeralFailure(client, body, REFRESH_BANNERS.updateFailed);
+          logger.debug('cct_refresh_card non-force fetch failed; rendering cached', {
+            err: (err as Error)?.message ?? err,
+          });
+          throttledAllNull = true;
         }
-        return;
       }
 
-      if (containerType === 'ephemeral') {
-        try {
-          await respond({
-            response_type: 'ephemeral',
-            replace_original: true,
-            text: ':key: CCT status',
-            blocks: blocks as any,
-          });
-        } catch (err) {
-          logger.warn('cct_refresh_card respond failed', { err: (err as Error).message });
-          await postEphemeralFailure(client, body, REFRESH_BANNERS.updateFailed);
-        }
-        return;
-      }
+      const banner = throttledAllNull ? ':warning: _Cached usage · refresh limited (5-minute throttle)._' : undefined;
 
-      // Unknown surface — neither a persistent message nor ephemeral.
-      // Could be a view/home-tab surface or a malformed payload; either
-      // way we refuse to stack a fresh ephemeral card and surface the
-      // updateFailed banner so the operator re-invokes `/cct` explicitly.
-      logger.warn('cct_refresh_card no surface to update', { containerType });
-      await postEphemeralFailure(client, body, REFRESH_BANNERS.updateFailed);
+      const result = await renderCardInPlace({
+        tokenManager,
+        body,
+        client,
+        respond,
+        viewerMode: renderMode,
+        prependBanner: banner,
+      });
+      if (result.surface === 'unknown' || !result.ok) {
+        // Unknown surface or transport failure — surface the fallback
+        // banner so the operator re-invokes `/cct` explicitly. Refuse
+        // to stack a fresh ephemeral card on top of the stale one
+        // (that's exactly what #803 fixes).
+        if (result.surface === 'unknown') {
+          logger.warn('cct_refresh_card no surface to update', {
+            container: (body as any)?.container,
+          });
+        }
+        await postEphemeralFailure(client, body, REFRESH_BANNERS.updateFailed);
+      }
     } catch (err) {
       logger.error('cct_refresh_card failed', err);
       await postEphemeralFailure(client, body, REFRESH_BANNERS.outerCatch).catch(() => {
@@ -513,7 +563,23 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
   });
 
   // View submission: Add slot.
+  //
+  // #803 — admin gate added on the view submission entry. The modal-
+  // open gate (`cct_open_add`) is the primary UX gate, but a non-admin
+  // could in theory craft a `view_submission` payload directly via a
+  // leaked view_id. Server-side gate makes the trust boundary
+  // unambiguous.
   app.view(CCT_VIEW_IDS.add, async ({ ack, body, client }) => {
+    if (!requireAdmin(body)) {
+      // ack-with-errors keeps the modal open (non-admin shouldn't have
+      // gotten here in normal flow); we surface a generic error keyed
+      // by the name field so something visible appears.
+      await ack({
+        response_action: 'errors',
+        errors: { [CCT_BLOCK_IDS.add_name]: 'Admin only.' },
+      });
+      return;
+    }
     const values: Record<string, Record<string, any>> = (body as any)?.view?.state?.values ?? {};
     const errors = validateAddSubmission(values, tokenManager);
     if (errors) {
@@ -565,7 +631,16 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
   });
 
   // View submission: Remove slot.
+  //
+  // #803 — admin gate added on the view submission entry. The modal-
+  // open gate (`cct_open_remove`) is the primary UX gate; the
+  // server-side gate here defends against direct view_submission
+  // posts.
   app.view(CCT_VIEW_IDS.remove, async ({ ack, body, client }) => {
+    if (!requireAdmin(body)) {
+      await ack();
+      return;
+    }
     await ack();
     try {
       const keyId = ((body as any)?.view?.private_metadata ?? '') as string;
@@ -599,6 +674,14 @@ export function registerCctActions(app: App, tokenManager: TokenManager): void {
   //   4. Runtime errors from `attachOAuth` (race-lost kind/source checks,
   //      scope drift) surface via ephemeral DM — the modal is already closed.
   app.view(CCT_VIEW_IDS.attach, async ({ ack, body, client }) => {
+    // #803 — admin gate added on the view submission entry.
+    if (!requireAdmin(body)) {
+      await ack({
+        response_action: 'errors',
+        errors: { [CCT_BLOCK_IDS.attach_oauth_blob]: 'Admin only.' },
+      });
+      return;
+    }
     const values: Record<string, Record<string, any>> = (body as any)?.view?.state?.values ?? {};
     const blob = readPlainText(values, CCT_BLOCK_IDS.attach_oauth_blob, CCT_ACTION_IDS.attach_oauth_input);
     const creds = parseOAuthBlob(blob);
@@ -664,6 +747,52 @@ function requireAdmin(body: unknown): boolean {
     return false;
   }
   return true;
+}
+
+/**
+ * Pull the actor user id off the bolt body. Returns null when missing.
+ */
+function actorUserId(body: unknown): string | null {
+  const userId = (body as any)?.user?.id;
+  return typeof userId === 'string' && userId.length > 0 ? userId : null;
+}
+
+/**
+ * Decode a button's `value` into `{ payload, cardMode, isLegacy }`.
+ *
+ * Returns null when the value is invalid — handler must ack and refuse
+ * the action. Legacy values surface as `{ isLegacy: true, cardMode: null }`
+ * so the caller can force `force=false` and fall back to the actor's
+ * render mode. Tagged values surface the encoded mode verbatim.
+ */
+function decodeActionButtonValue(body: unknown): {
+  payload: string;
+  cardMode: CctCardMode | null;
+  isLegacy: boolean;
+} | null {
+  const raw = (body as any)?.actions?.[0]?.value;
+  const decoded = decodeCctActionValue(raw);
+  if (decoded.kind === 'invalid') return null;
+  if (decoded.kind === 'legacy') {
+    return { payload: decoded.payload, cardMode: null, isLegacy: true };
+  }
+  return { payload: decoded.payload, cardMode: decoded.mode, isLegacy: false };
+}
+
+/**
+ * Resolve the effective render mode for an action handler.
+ *
+ *   - tagged value (cardMode='admin'|'readonly') → use it. This is the
+ *     "preserve cardMode across viewers" rule (#803 spec Q1=A).
+ *   - legacy value (no `cm:` prefix) → fall back to the actor's mode.
+ *     Legacy buttons can only have been emitted before #803 landed, so
+ *     the safest mapping is "render the card as the actor would see a
+ *     fresh /cct".
+ */
+function resolveRenderMode(cardMode: CctCardMode | null, actorUserIdValue: string | null): CctCardMode {
+  if (cardMode !== null) return cardMode;
+  if (actorUserIdValue && isAdminUser(actorUserIdValue)) return 'admin';
+  return 'readonly';
 }
 
 /**
@@ -789,6 +918,73 @@ async function respondWithCard(opts: {
 }
 
 /**
+ * #803 — Render an in-place card update across the message + ephemeral
+ * surfaces.
+ *
+ * `viewerMode` determines what the user sees — locked to the cardMode
+ * stamped on the originating button (or actor-derived fallback when the
+ * button was a legacy raw value).
+ *
+ * Message surface: delegate to `renderCctCard` so the trailing
+ * `z_setting_cct_cancel` actions row that the cct-topic adds is
+ * preserved across `chat.update` (a `buildCardFromManager` blob would
+ * strip that chrome row).
+ *
+ * Ephemeral surface: lighter `buildCardFromManager` is sufficient — the
+ * cancel row only lives on persistent message cards.
+ *
+ * `prependBanner` lets the caller layer a single section block above
+ * the card (used by refresh_card on the throttle-all-null path and the
+ * refresh_usage_all partial-failure path). The banner is a Slack
+ * mrkdwn string.
+ */
+async function renderCardInPlace(opts: {
+  tokenManager: TokenManager;
+  body: unknown;
+  client: WebClient;
+  respond?: (msg: any) => Promise<unknown>;
+  viewerMode: CctCardViewerMode;
+  text?: string;
+  prependBanner?: string;
+}): Promise<{ surface: 'message' | 'ephemeral' | 'unknown'; ok: boolean }> {
+  const { tokenManager, body, client, respond, viewerMode, prependBanner } = opts;
+  const text = opts.text ?? ':key: CCT status';
+  const userId = actorUserId(body);
+  const renderMessageBlocks = async (): Promise<Record<string, unknown>[]> => {
+    // Persistent message surfaces use renderCctCard so the trailing
+    // `z_setting_cct_cancel` chrome row survives chat.update.
+    let blocks: Record<string, unknown>[];
+    if (userId) {
+      try {
+        const rendered = await renderCctCard({ userId, issuedAt: Date.now(), viewerMode });
+        blocks = rendered.blocks as Record<string, unknown>[];
+      } catch (err) {
+        logger.warn('renderCardInPlace: renderCctCard failed, falling back to buildCardFromManager', {
+          err: (err as Error).message,
+        });
+        blocks = await buildCardFromManager(tokenManager, { viewerMode });
+      }
+    } else {
+      blocks = await buildCardFromManager(tokenManager, { viewerMode });
+    }
+    return prependBanner ? [{ type: 'section', text: { type: 'mrkdwn', text: prependBanner } }, ...blocks] : blocks;
+  };
+  const renderEphemeralBlocks = async (): Promise<Record<string, unknown>[]> => {
+    const blocks = await buildCardFromManager(tokenManager, { viewerMode });
+    return prependBanner ? [{ type: 'section', text: { type: 'mrkdwn', text: prependBanner } }, ...blocks] : blocks;
+  };
+  return renderInPlace({
+    body: body as Parameters<typeof renderInPlace>[0]['body'],
+    client,
+    respond,
+    text,
+    renderMessageBlocks,
+    renderEphemeralBlocks,
+    logger,
+  });
+}
+
+/**
  * Shared destination resolver for ephemeral helpers below. Bolt carries
  * the invoking user + channel in two shapes (`container.channel_id` for
  * block_actions, `channel.id` for view_submission). Returns `null` when
@@ -890,7 +1086,21 @@ async function postEphemeralFailure(client: WebClient, body: unknown, message: s
   }
 }
 
-export async function buildCardFromManager(tokenManager: TokenManager): Promise<Record<string, unknown>[]> {
+/**
+ * Build a CCT card from the live `TokenManager` snapshot.
+ *
+ * `viewerMode` is forwarded to `buildCctCardBlocks` so callers that
+ * render an in-place ephemeral update can preserve the cardMode that
+ * was stamped onto the originating button (#803). Default is `'admin'`
+ * for backward compatibility with the small number of legacy call
+ * sites that don't pass an explicit mode (kept until those callers are
+ * audited in a follow-up).
+ */
+export async function buildCardFromManager(
+  tokenManager: TokenManager,
+  opts: { viewerMode?: CctCardViewerMode } = {},
+): Promise<Record<string, unknown>[]> {
+  const viewerMode: CctCardViewerMode = opts.viewerMode ?? 'admin';
   // Always load the authoritative snapshot so post-action ephemeral cards
   // reflect current per-slot state (rate-limit timestamps, usage, cooldown)
   // rather than rendering with an empty `states` map.
@@ -910,6 +1120,7 @@ export async function buildCardFromManager(tokenManager: TokenManager): Promise<
       states: snap.state ?? {},
       activeKeyId: snap.registry.activeKeyId,
       nowMs: Date.now(),
+      viewerMode,
     });
     if (hiddenApiKeyCount > 0) {
       blocks.push({
@@ -940,6 +1151,7 @@ export async function buildCardFromManager(tokenManager: TokenManager): Promise<
       slots: visibleSlots,
       states: {},
       activeKeyId: active?.keyId,
+      viewerMode,
     });
     // Surface the store-read failure with the shared banner wording.
     appendStoreReadFailureBanner(blocks);

--- a/src/slack/cct/builder.ts
+++ b/src/slack/cct/builder.ts
@@ -10,6 +10,7 @@ import type { AuthKey, AuthState, SlotState, UsageSnapshot } from '../../cct-sto
 import { isCctSlot } from '../../cct-store';
 import { formatRateLimitedAt } from '../../util/format-rate-limited-at';
 import type { ZBlock } from '../z/types';
+import { type CctCardMode, encodeCctActionValue } from './action-value';
 import {
   CCT_ACTION_IDS,
   CCT_BLOCK_IDS,
@@ -18,6 +19,26 @@ import {
   OAUTH_BLOB_HELP,
   SLACK_PLAIN_TEXT_INPUT_MAX,
 } from './views';
+
+/**
+ * Card render mode for the viewer of THIS render pass (#803).
+ *
+ *   - `'admin'`    — full mutating affordances (Activate, Attach, Detach,
+ *                    Remove, Add, Next-rotate, Refresh All OAuth Tokens,
+ *                    Refresh).
+ *   - `'readonly'` — every per-slot mutating action is stripped, the
+ *                    card-level Add / Next / Refresh-All are stripped,
+ *                    only a single card-level Refresh button remains.
+ *                    Used for the non-admin reveal of cached slot state
+ *                    (#803). The Refresh action is wired to non-force
+ *                    fetch on the handler side so the throttle is
+ *                    respected.
+ *
+ * The mode is also stamped into every emitted button's `value` via the
+ * `cm:<mode>|<payload>` codec so the action-dispatch handler can
+ * preserve the card mode across re-renders triggered by another viewer.
+ */
+export type CctCardViewerMode = CctCardMode;
 
 /** Shape used by the card renderer. */
 export interface CctCardInput {
@@ -29,6 +50,13 @@ export interface CctCardInput {
   nowMs?: number;
   /** IANA timezone for rate-limit timestamps. Default: Asia/Seoul. */
   userTz?: string;
+  /**
+   * Viewer-mode for this render pass. Default `'admin'` for backward
+   * compatibility — every existing call site that did not pass this
+   * field rendered the admin layout. Non-admin viewers must pass
+   * `'readonly'` explicitly.
+   */
+  viewerMode?: CctCardViewerMode;
 }
 
 /**
@@ -649,12 +677,18 @@ export function buildSlotRow(
   isActive: boolean,
   nowMs: number,
   userTz: string = 'Asia/Seoul',
+  viewerMode: CctCardViewerMode = 'admin',
 ): ZBlock[] {
   const blocks: ZBlock[] = [];
   // Line 1: identity (name · kind · tier · ToS-risk). Tier + active marker
   // are now emitted for EVERY slot — #653 M2 removes the prior isActive
   // gating so inactive rows carry the full signal (user specifically wants
   // tier + 5h + 7d always visible, not just on the currently-selected row).
+  //
+  // #803 — readonly viewers see the SAME identity / status / usage rows
+  // as admin viewers. Only the per-slot mutating actions are removed
+  // (a few lines below). The user explicitly requested
+  // "non-admin shows email/tier/usage too, no masking".
   const line1 = [
     ':key:',
     `*${escapeMrkdwn(slot.name)}*`,
@@ -683,44 +717,51 @@ export function buildSlotRow(
   // Per-slot Refresh / Rename buttons were removed in the card v2
   // follow-up: Refresh is now a card-level fan-out
   // (`CCT_ACTION_IDS.refresh_card`), and Rename was unused in practice.
-  const actionElements: ZBlock[] = [];
-  if (!isActive && slot.kind !== 'api_key') {
-    actionElements.push({
-      type: 'button',
-      action_id: CCT_ACTION_IDS.activate_slot,
-      style: 'primary',
-      text: { type: 'plain_text', text: ':arrow_forward: Activate', emoji: true },
-      value: slot.keyId,
-    });
-  }
-  if (isCctSlot(slot) && slot.source === 'setup') {
-    if (slot.oauthAttachment === undefined) {
+  //
+  // #803 — readonly viewers strip the entire per-slot mutating action
+  // row. We also OMIT the empty `actions` block instead of emitting an
+  // `actions` block with zero elements (which Slack rejects). The card-
+  // level Refresh button is still rendered by `buildCctCardBlocks`.
+  if (viewerMode === 'admin') {
+    const actionElements: ZBlock[] = [];
+    if (!isActive && slot.kind !== 'api_key') {
       actionElements.push({
         type: 'button',
-        action_id: CCT_ACTION_IDS.attach,
-        text: { type: 'plain_text', text: ':link: Attach OAuth', emoji: true },
-        value: slot.keyId,
-      });
-    } else {
-      actionElements.push({
-        type: 'button',
-        action_id: CCT_ACTION_IDS.detach,
-        text: { type: 'plain_text', text: ':unlock: Detach OAuth', emoji: true },
-        value: slot.keyId,
+        action_id: CCT_ACTION_IDS.activate_slot,
+        style: 'primary',
+        text: { type: 'plain_text', text: ':arrow_forward: Activate', emoji: true },
+        value: encodeCctActionValue({ mode: viewerMode, payload: slot.keyId }),
       });
     }
+    if (isCctSlot(slot) && slot.source === 'setup') {
+      if (slot.oauthAttachment === undefined) {
+        actionElements.push({
+          type: 'button',
+          action_id: CCT_ACTION_IDS.attach,
+          text: { type: 'plain_text', text: ':link: Attach OAuth', emoji: true },
+          value: encodeCctActionValue({ mode: viewerMode, payload: slot.keyId }),
+        });
+      } else {
+        actionElements.push({
+          type: 'button',
+          action_id: CCT_ACTION_IDS.detach,
+          text: { type: 'plain_text', text: ':unlock: Detach OAuth', emoji: true },
+          value: encodeCctActionValue({ mode: viewerMode, payload: slot.keyId }),
+        });
+      }
+    }
+    actionElements.push({
+      type: 'button',
+      action_id: CCT_ACTION_IDS.remove,
+      style: 'danger',
+      text: { type: 'plain_text', text: ':wastebasket: Remove', emoji: true },
+      value: encodeCctActionValue({ mode: viewerMode, payload: slot.keyId }),
+    });
+    blocks.push({
+      type: 'actions',
+      elements: actionElements,
+    });
   }
-  actionElements.push({
-    type: 'button',
-    action_id: CCT_ACTION_IDS.remove,
-    style: 'danger',
-    text: { type: 'plain_text', text: ':wastebasket: Remove', emoji: true },
-    value: slot.keyId,
-  });
-  blocks.push({
-    type: 'actions',
-    elements: actionElements,
-  });
 
   // Usage panel — only when the slot has a persisted usage snapshot. The
   // panel is emitted for EVERY attached slot (no longer isActive-gated);
@@ -798,10 +839,23 @@ function trimBlocksToSlackCap(blocks: ZBlock[]): ZBlock[] {
 
 /**
  * Build the full CCT card: header + per-slot rows + action row.
+ *
+ * #803 — `viewerMode='readonly'` strips every mutating affordance:
+ *   - per-slot Activate/Attach/Detach/Remove (inside `buildSlotRow`).
+ *   - card-level Add / Next-rotate / Refresh-All-OAuth.
+ *   - empty-slots prompt switches from "Click *Add* to create one" to
+ *     a neutral "(no slots cached)" so the readonly viewer isn't told to
+ *     do something they cannot do.
+ *
+ * Only the card-level Refresh button survives in readonly. The handler
+ * checks the encoded `cm:` mode + actor admin state to decide whether
+ * the underlying fetch goes force/non-force (admin-actor-on-admin-card
+ * is force, everything else is non-force).
  */
 export function buildCctCardBlocks(input: CctCardInput): ZBlock[] {
   const nowMs = input.nowMs ?? Date.now();
   const userTz = input.userTz ?? 'Asia/Seoul';
+  const viewerMode: CctCardViewerMode = input.viewerMode ?? 'admin';
   const blocks: ZBlock[] = [];
 
   blocks.push({
@@ -810,53 +864,76 @@ export function buildCctCardBlocks(input: CctCardInput): ZBlock[] {
   });
 
   if (input.slots.length === 0) {
+    // Empty-state copy diverges by viewerMode: admin sees the call-to-
+    // action, readonly sees a neutral "(no slots cached)" sentinel.
+    const text =
+      viewerMode === 'admin'
+        ? 'No CCT slots configured. Click *Add* to create one, or set `CLAUDE_CODE_OAUTH_TOKEN_LIST`.'
+        : '(no slots cached)';
     blocks.push({
       type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: 'No CCT slots configured. Click *Add* to create one, or set `CLAUDE_CODE_OAUTH_TOKEN_LIST`.',
-      },
+      text: { type: 'mrkdwn', text },
     });
   } else {
     for (const slot of input.slots) {
-      const rowBlocks = buildSlotRow(slot, input.states[slot.keyId], slot.keyId === input.activeKeyId, nowMs, userTz);
+      const rowBlocks = buildSlotRow(
+        slot,
+        input.states[slot.keyId],
+        slot.keyId === input.activeKeyId,
+        nowMs,
+        userTz,
+        viewerMode,
+      );
       for (const b of rowBlocks) blocks.push(b);
       blocks.push({ type: 'divider' });
     }
   }
 
-  // Card-level action row: Next rotate / Add / Refresh All OAuth Tokens. Per-slot
-  // [Activate] / [Remove] / [Attach|Detach] live on each slot row (see
-  // `buildSlotRow`). The per-slot inline [Activate] button is the only
-  // activation affordance; the legacy `set_active` fallback dropdown was
-  // dropped in the card v2 follow-up.
-  const actionElements: ZBlock[] = [
-    {
-      type: 'button',
-      action_id: CCT_ACTION_IDS.next,
-      text: { type: 'plain_text', text: ':arrows_counterclockwise: Next rotate', emoji: true },
-      value: 'next',
-    },
-    {
-      type: 'button',
-      action_id: CCT_ACTION_IDS.add,
-      style: 'primary',
-      text: { type: 'plain_text', text: ':heavy_plus_sign: Add', emoji: true },
-      value: 'add',
-    },
-    {
-      type: 'button',
-      action_id: CCT_ACTION_IDS.refresh_usage_all,
-      text: { type: 'plain_text', text: ':arrows_counterclockwise: Refresh All OAuth Tokens', emoji: true },
-      value: 'refresh_all',
-    },
-    {
-      type: 'button',
-      action_id: CCT_ACTION_IDS.refresh_card,
-      text: { type: 'plain_text', text: ':arrows_counterclockwise: Refresh', emoji: true },
-      value: 'refresh_card',
-    },
-  ];
+  // Card-level action row.
+  //
+  // Admin viewer:
+  //   Next rotate / Add / Refresh All OAuth Tokens / Refresh
+  // Readonly viewer:
+  //   Refresh (alone). The button label changes to make it clear this
+  //   is a non-force, throttle-respecting refresh.
+  //
+  // Per-slot [Activate] / [Remove] / [Attach|Detach] live on each slot
+  // row (see `buildSlotRow`). The per-slot inline [Activate] button is
+  // the only activation affordance; the legacy `set_active` fallback
+  // dropdown was dropped in the card v2 follow-up.
+  const actionElements: ZBlock[] = [];
+  if (viewerMode === 'admin') {
+    actionElements.push(
+      {
+        type: 'button',
+        action_id: CCT_ACTION_IDS.next,
+        text: { type: 'plain_text', text: ':arrows_counterclockwise: Next rotate', emoji: true },
+        value: encodeCctActionValue({ mode: viewerMode, payload: 'next' }),
+      },
+      {
+        type: 'button',
+        action_id: CCT_ACTION_IDS.add,
+        style: 'primary',
+        text: { type: 'plain_text', text: ':heavy_plus_sign: Add', emoji: true },
+        value: encodeCctActionValue({ mode: viewerMode, payload: 'add' }),
+      },
+      {
+        type: 'button',
+        action_id: CCT_ACTION_IDS.refresh_usage_all,
+        text: { type: 'plain_text', text: ':arrows_counterclockwise: Refresh All OAuth Tokens', emoji: true },
+        value: encodeCctActionValue({ mode: viewerMode, payload: 'refresh_all' }),
+      },
+    );
+  }
+  // Refresh button is rendered for BOTH viewer modes. The mode is
+  // encoded into the button's value so the handler can preserve the
+  // card mode + decide the force gate.
+  actionElements.push({
+    type: 'button',
+    action_id: CCT_ACTION_IDS.refresh_card,
+    text: { type: 'plain_text', text: ':arrows_counterclockwise: Refresh', emoji: true },
+    value: encodeCctActionValue({ mode: viewerMode, payload: 'refresh_card' }),
+  });
   blocks.push({ type: 'actions', elements: actionElements });
 
   // Apply the overflow guard AFTER chrome is added so dividers inside

--- a/src/slack/cct/render-in-place.ts
+++ b/src/slack/cct/render-in-place.ts
@@ -110,13 +110,21 @@ export type RenderInPlaceSurface = 'message' | 'ephemeral' | 'unknown';
 
 export function classifyRenderInPlaceSurface(body: RenderInPlaceBody): RenderInPlaceSurface {
   const containerType = body.container?.type;
+  // Ephemeral check FIRST. Slack/Bolt sometimes ship payloads where
+  // `container.type === 'message'` AND `container.is_ephemeral === true`
+  // for ephemeral messages — the `type` field describes the kind of
+  // surface (chat message, view, etc.) but `is_ephemeral` is what
+  // governs which API works. `chat.update` is illegal for ephemerals
+  // (no `message_ts` is ever surfaced), so any payload claiming
+  // `is_ephemeral` MUST go through `respond({ replace_original: true })`
+  // regardless of the `type` field's value. (Codex P2 review on PR #805.)
+  if (containerType === 'ephemeral' || body.container?.is_ephemeral === true) {
+    return 'ephemeral';
+  }
   if (containerType === 'message') {
     const { channel, ts } = extractMessageRef(body);
     if (channel && ts) return 'message';
     return 'unknown';
-  }
-  if (containerType === 'ephemeral' || body.container?.is_ephemeral === true) {
-    return 'ephemeral';
   }
   return 'unknown';
 }

--- a/src/slack/cct/render-in-place.ts
+++ b/src/slack/cct/render-in-place.ts
@@ -1,0 +1,210 @@
+/**
+ * `renderInPlace` — surface-aware in-place CCT card update (#803).
+ *
+ * Why this helper exists:
+ *   - Pre-#803, `activate_slot` / `next` / `detach` all called
+ *     `respondWithCard(...)` which emits a fresh ephemeral card via
+ *     `respond({replace_original: false})`. Result: the user clicks
+ *     Activate, the original card stays stale, and a NEW ephemeral
+ *     stack-up appears. Three problems:
+ *       1. The active marker on the original card is wrong.
+ *       2. The user has to scroll up to find the original card or
+ *          re-trigger `/cct`.
+ *       3. Channels accumulate stale ephemeral cards from each click.
+ *   - The fix is the same surface-aware update path that
+ *     `refresh_card` already uses: detect `container.type` and either
+ *     `chat.update` (message) or `respond({replace_original: true})`
+ *     (ephemeral). This helper extracts that decision out of every
+ *     handler so each handler stays focused on its mutation.
+ *
+ * The helper is INTENTIONALLY transport-only — it accepts pre-built
+ * `messageBlocks` / `ephemeralBlocks` factories so the caller controls
+ * the render pipeline (e.g. `refresh_card` calls `renderCctCard` for
+ * message surfaces to preserve the trailing `z_setting_cct_cancel`
+ * actions row, while ephemerals use the lighter `buildCardFromManager`).
+ *
+ * On unknown surface (no container, view-tab, etc.) we LOG-AND-DROP
+ * rather than stack a fresh ephemeral card on top — that is exactly the
+ * bug we're fixing here. The caller can decide whether to surface a
+ * banner separately.
+ */
+
+import type { WebClient } from '@slack/web-api';
+import { Logger } from '../../logger';
+
+/**
+ * Bolt action body shape we depend on. Kept narrow to avoid pulling
+ * the full Bolt typing surface into a transport helper that doesn't
+ * own action dispatch.
+ */
+export interface RenderInPlaceBody {
+  container?: {
+    type?: 'message' | 'ephemeral' | string;
+    channel_id?: string;
+    message_ts?: string;
+    is_ephemeral?: boolean;
+  };
+  channel?: { id?: string };
+  message?: { ts?: string };
+}
+
+/**
+ * `respond` callback shape. Bolt passes a function; we accept anything
+ * with the right thenable contract.
+ */
+export type RespondFn = (msg: Record<string, unknown>) => Promise<unknown>;
+
+export interface RenderInPlaceOpts {
+  body: RenderInPlaceBody;
+  client: WebClient;
+  /** Bolt's `respond` callback. May be undefined when the action body has no response_url. */
+  respond?: RespondFn;
+  /** Plain-text fallback for non-block clients (Slack contract). */
+  text: string;
+  /**
+   * Render the card blocks for a `chat.update` (message) surface. The
+   * message-surface branch typically renders heavier (e.g. with the
+   * trailing `z_setting_cct_cancel` row that the `/z cct` topic adds).
+   */
+  renderMessageBlocks: () => Promise<Record<string, unknown>[]> | Record<string, unknown>[];
+  /**
+   * Render the card blocks for an ephemeral `respond({replace_original})`
+   * surface. Often lighter than the message-surface variant.
+   */
+  renderEphemeralBlocks: () => Promise<Record<string, unknown>[]> | Record<string, unknown>[];
+  /**
+   * Logger. Defaults to a module-scoped `CctRenderInPlace` logger when
+   * absent so unit tests don't need to plumb one through.
+   */
+  logger?: Logger;
+}
+
+const defaultLogger = new Logger('CctRenderInPlace');
+
+/** Extract `(channel, ts)` with the documented fallback chain. */
+function extractMessageRef(body: RenderInPlaceBody): { channel?: string; ts?: string } {
+  // `container.channel_id` / `container.message_ts` is Bolt's normalized
+  // shape for block_action payloads. Older shapes (or some test fakes)
+  // ship `channel.id` / `message.ts` at the top level. We accept either,
+  // preferring container so future Bolt versions stay forward-compatible.
+  const channel = body.container?.channel_id ?? body.channel?.id;
+  const ts = body.container?.message_ts ?? body.message?.ts;
+  return { channel, ts };
+}
+
+/**
+ * Classify the surface so handlers can branch deterministically.
+ *
+ * Slack's container types we care about:
+ *   - `'message'`     — persistent chat post; `chat.update` is the only
+ *                       in-place mutation path.
+ *   - `'ephemeral'`   — single-recipient post; `respond({replace_original})`
+ *                       is the only in-place path. Some Bolt versions also
+ *                       set `is_ephemeral: true` instead of typing it.
+ *   - `'view'` / etc. — modal / app home; `chat.update` and `respond` are
+ *                       both inappropriate. Caller should branch on
+ *                       `'unknown'` and either show a banner or fall
+ *                       through silently.
+ */
+export type RenderInPlaceSurface = 'message' | 'ephemeral' | 'unknown';
+
+export function classifyRenderInPlaceSurface(body: RenderInPlaceBody): RenderInPlaceSurface {
+  const containerType = body.container?.type;
+  if (containerType === 'message') {
+    const { channel, ts } = extractMessageRef(body);
+    if (channel && ts) return 'message';
+    return 'unknown';
+  }
+  if (containerType === 'ephemeral' || body.container?.is_ephemeral === true) {
+    return 'ephemeral';
+  }
+  return 'unknown';
+}
+
+/**
+ * Update the clicked card surface in-place.
+ *
+ * Returns `'message'` / `'ephemeral'` / `'unknown'` so the caller can
+ * decide whether to surface a separate banner on the unknown branch.
+ *
+ * Failure modes:
+ *   - `chat.update` throws (rate-limit, gone-channel, …) — logged, returns
+ *     `'message'` so the caller knows the surface was message but the
+ *     update did not land. Callers that want to surface the failure to
+ *     the user must check the second return value.
+ *   - `respond` is missing on an ephemeral surface — logged, returns
+ *     `'ephemeral'` with `ok: false`.
+ */
+export interface RenderInPlaceResult {
+  surface: RenderInPlaceSurface;
+  /** True when the in-place update landed; false on transport failure. */
+  ok: boolean;
+}
+
+export async function renderInPlace(opts: RenderInPlaceOpts): Promise<RenderInPlaceResult> {
+  const { body, client, respond, text, renderMessageBlocks, renderEphemeralBlocks } = opts;
+  const log = opts.logger ?? defaultLogger;
+  const surface = classifyRenderInPlaceSurface(body);
+
+  if (surface === 'message') {
+    const { channel, ts } = extractMessageRef(body);
+    // `surface === 'message'` already guarantees both are set, but the
+    // narrowing is local to extract — assert here so the call site is
+    // total without a non-null bang.
+    if (!channel || !ts) {
+      log.warn('renderInPlace: classified as message but channel/ts missing', { container: body.container });
+      return { surface: 'unknown', ok: false };
+    }
+    try {
+      const blocks = await renderMessageBlocks();
+      // `WebClient.chat.update` returns a typed result we don't need.
+      // Cast through unknown to avoid pulling Slack's argument typing
+      // into the transport helper signature.
+      await client.chat.update({
+        channel,
+        ts,
+        text,
+        blocks: blocks as unknown as never,
+      });
+      return { surface: 'message', ok: true };
+    } catch (err) {
+      log.warn('renderInPlace: chat.update failed', {
+        err: (err as Error)?.message ?? String(err),
+      });
+      return { surface: 'message', ok: false };
+    }
+  }
+
+  if (surface === 'ephemeral') {
+    if (!respond) {
+      // Ephemeral surface with no `respond` is a Bolt wiring bug — the
+      // response_url is short-lived (30 minutes) and only delivered
+      // through the ack callback. We log loud so someone notices.
+      log.warn('renderInPlace: ephemeral surface but respond fn is missing', { container: body.container });
+      return { surface: 'ephemeral', ok: false };
+    }
+    try {
+      const blocks = await renderEphemeralBlocks();
+      await respond({
+        response_type: 'ephemeral',
+        replace_original: true,
+        text,
+        blocks,
+      });
+      return { surface: 'ephemeral', ok: true };
+    } catch (err) {
+      log.warn('renderInPlace: respond failed', {
+        err: (err as Error)?.message ?? String(err),
+      });
+      return { surface: 'ephemeral', ok: false };
+    }
+  }
+
+  // Unknown surface — refuse to stack a fresh ephemeral on top of the
+  // stale card. Caller may surface a banner separately if it has the
+  // user/channel anchored.
+  log.warn('renderInPlace: unknown surface; refusing to stack a fresh card', {
+    container: body.container,
+  });
+  return { surface: 'unknown', ok: false };
+}

--- a/src/slack/commands/__tests__/cct-handler.test.ts
+++ b/src/slack/commands/__tests__/cct-handler.test.ts
@@ -590,6 +590,67 @@ describe('CctHandler — Wave 5', () => {
     expect(text).toMatch(/\(\d+m ago\)/);
     expect(text).toContain('response_header');
   });
+
+  // ────────────────────────────────────────────────────────────────────
+  // #803 — non-admin can run `cct status` (the only non-mutating arm)
+  // ────────────────────────────────────────────────────────────────────
+
+  it('#803: non-admin user runs `cct` (status) → renderCctCard is called, no admin-only banner', async () => {
+    const { CctHandler } = await loadHandlerWithMockTm({
+      tokens: [{ keyId: 'k1', name: 'cct1', kind: 'cct', status: 'healthy' }],
+      active: { keyId: 'k1', name: 'cct1', kind: 'cct' },
+    });
+    const say = makeSay();
+    // 'U_OTHER' is NOT in ADMIN_USERS (the loadHandler mock only accepts adminUser).
+    await new CctHandler().execute({ user: 'U_OTHER', channel: 'C', threadTs: 'T', text: 'cct', say: say.fn });
+    expect(say.calls[0].text).not.toBe('⛔ Admin only command');
+    // The mocked renderCctCard returns this exact text.
+    expect(say.calls[0].text).toContain('CCT');
+    expect(Array.isArray(say.calls[0].blocks)).toBe(true);
+  });
+
+  it('#803: non-admin `cct next` → "⛔ Admin only command", no rotateToNext call', async () => {
+    const rotateToNext = vi.fn(async () => null);
+    const { CctHandler } = await loadHandlerWithMockTm({
+      tokens: [{ keyId: 'k1', name: 'cct1', kind: 'cct', status: 'healthy' }],
+      rotateToNext,
+    });
+    const say = makeSay();
+    await new CctHandler().execute({ user: 'U_OTHER', channel: 'C', threadTs: 'T', text: 'cct next', say: say.fn });
+    expect(say.calls[0].text).toBe('⛔ Admin only command');
+    expect(rotateToNext).not.toHaveBeenCalled();
+  });
+
+  it('#803: non-admin `cct set <name>` → "⛔ Admin only command", no applyToken call', async () => {
+    const applyToken = vi.fn(async () => undefined);
+    const { CctHandler } = await loadHandlerWithMockTm({
+      tokens: [{ keyId: 'k1', name: 'cct1', kind: 'cct', status: 'healthy' }],
+      applyToken,
+    });
+    const say = makeSay();
+    await new CctHandler().execute({
+      user: 'U_OTHER',
+      channel: 'C',
+      threadTs: 'T',
+      text: 'cct set cct1',
+      say: say.fn,
+    });
+    expect(say.calls[0].text).toBe('⛔ Admin only command');
+    expect(applyToken).not.toHaveBeenCalled();
+  });
+
+  it('#803: non-admin `cct usage` → "⛔ Admin only command", no fetchAndStoreUsage call', async () => {
+    const fetchAndStoreUsage = vi.fn(async () => null);
+    const { CctHandler } = await loadHandlerWithMockTm({
+      tokens: [{ keyId: 'k1', name: 'cct1', kind: 'cct', status: 'healthy' }],
+      active: { keyId: 'k1', name: 'cct1', kind: 'cct' },
+      fetchAndStoreUsage,
+    });
+    const say = makeSay();
+    await new CctHandler().execute({ user: 'U_OTHER', channel: 'C', threadTs: 'T', text: 'cct usage', say: say.fn });
+    expect(say.calls[0].text).toBe('⛔ Admin only command');
+    expect(fetchAndStoreUsage).not.toHaveBeenCalled();
+  });
 });
 
 describe('renderUsageLines', () => {

--- a/src/slack/commands/__tests__/cct-handler.test.ts
+++ b/src/slack/commands/__tests__/cct-handler.test.ts
@@ -651,6 +651,52 @@ describe('CctHandler — Wave 5', () => {
     expect(say.calls[0].text).toBe('⛔ Admin only command');
     expect(fetchAndStoreUsage).not.toHaveBeenCalled();
   });
+
+  // Codex P2 review (PR #805): empty-store informational message must
+  // not be reachable for non-admin mutating arms. Otherwise a non-admin
+  // running `cct next` against an empty fleet would learn the store is
+  // empty (configuration leak) instead of seeing `⛔ Admin only command`.
+  it('Codex P2: non-admin `cct next` against EMPTY store → "⛔ Admin only command", not "No CCT tokens configured"', async () => {
+    const rotateToNext = vi.fn(async () => null);
+    const { CctHandler } = await loadHandlerWithMockTm({
+      tokens: [], // empty store
+      rotateToNext,
+    });
+    const say = makeSay();
+    await new CctHandler().execute({ user: 'U_OTHER', channel: 'C', threadTs: 'T', text: 'cct next', say: say.fn });
+    expect(say.calls[0].text).toBe('⛔ Admin only command');
+    expect(say.calls[0].text).not.toMatch(/No CCT tokens configured/);
+    expect(rotateToNext).not.toHaveBeenCalled();
+  });
+
+  it('Codex P2: non-admin `cct usage` against EMPTY store → "⛔ Admin only command"', async () => {
+    const fetchAndStoreUsage = vi.fn(async () => null);
+    const { CctHandler } = await loadHandlerWithMockTm({
+      tokens: [],
+      fetchAndStoreUsage,
+    });
+    const say = makeSay();
+    await new CctHandler().execute({ user: 'U_OTHER', channel: 'C', threadTs: 'T', text: 'cct usage', say: say.fn });
+    expect(say.calls[0].text).toBe('⛔ Admin only command');
+    expect(fetchAndStoreUsage).not.toHaveBeenCalled();
+  });
+
+  it('Codex P2: non-admin `cct` (status) against EMPTY store still sees informational empty-store message (status is non-mutating)', async () => {
+    const { CctHandler } = await loadHandlerWithMockTm({ tokens: [] });
+    const say = makeSay();
+    await new CctHandler().execute({ user: 'U_OTHER', channel: 'C', threadTs: 'T', text: 'cct', say: say.fn });
+    // Status is still allowed for non-admin even on empty store.
+    expect(say.calls[0].text).toMatch(/No CCT tokens configured/);
+  });
+
+  it('Codex P2: admin `cct next` against EMPTY store → informational empty-store message (admin still gets actionable hint)', async () => {
+    const rotateToNext = vi.fn(async () => null);
+    const { CctHandler } = await loadHandlerWithMockTm({ tokens: [], rotateToNext });
+    const say = makeSay();
+    await new CctHandler().execute({ user: adminUser, channel: 'C', threadTs: 'T', text: 'cct next', say: say.fn });
+    expect(say.calls[0].text).toMatch(/No CCT tokens configured/);
+    expect(rotateToNext).not.toHaveBeenCalled();
+  });
 });
 
 describe('renderUsageLines', () => {

--- a/src/slack/commands/cct-handler.ts
+++ b/src/slack/commands/cct-handler.ts
@@ -31,15 +31,6 @@ export class CctHandler implements CommandHandler {
   async execute(ctx: CommandContext): Promise<CommandResult> {
     const { user, text, threadTs, say } = ctx;
 
-    // Admin check
-    if (!isAdminUser(user)) {
-      await say({
-        text: '⛔ Admin only command',
-        thread_ts: threadTs,
-      });
-      return { handled: true };
-    }
-
     const action = CommandParser.parseCctCommand(text);
     const tm = getTokenManager();
     // Z3 runtime fence (PR-B phase1): `cct set <name>` / `cct usage <name>`
@@ -49,10 +40,29 @@ export class CctHandler implements CommandHandler {
     // spawn isolation and will remove the filter.
     const tokens = tm.listRuntimeSelectableTokens();
 
+    // #803 — non-admin users may now run `cct status` (the default) so
+    // they can see cached slot state. All MUTATING actions (set, next,
+    // add, rm, usage refetch, auto) remain admin-only. The admin gate
+    // is therefore moved AFTER the action-discriminator dispatch and
+    // only fires on the mutating arms.
+    const admin = isAdminUser(user);
+    const denyNonAdmin = async (): Promise<CommandResult> => {
+      await say({
+        text: '⛔ Admin only command',
+        thread_ts: threadTs,
+      });
+      return { handled: true };
+    };
+
     // `cct add …` / `cct rm …` are forbidden via text — the modal on the
     // `/z cct` card is the only path for token mutation (ToS ack, split
     // fields, lease drain semantics live there).
+    //
+    // These two arms are admin-only because they hint at the admin
+    // path. Non-admin sees the standard `⛔ Admin only command` line so
+    // we don't leak the existence of the modal-only mutation surface.
     if (action.action === 'add-forbidden') {
+      if (!admin) return denyNonAdmin();
       await say({
         text: 'Token add via text is disabled. Open the `/z cct` card and use the *Add* button.',
         thread_ts: threadTs,
@@ -60,6 +70,7 @@ export class CctHandler implements CommandHandler {
       return { handled: true };
     }
     if (action.action === 'rm-forbidden') {
+      if (!admin) return denyNonAdmin();
       await say({
         text: 'Token remove via text is disabled. Open the `/z cct` card and use the *Remove* button.',
         thread_ts: threadTs,
@@ -68,6 +79,9 @@ export class CctHandler implements CommandHandler {
     }
 
     if (tokens.length === 0) {
+      // Empty-store message is informational, not a mutation. Fine for
+      // every viewer — the renderCctCard path also tells non-admin the
+      // empty state.
       await say({
         text: 'No CCT tokens configured. Set `CLAUDE_CODE_OAUTH_TOKEN_LIST` environment variable.',
         thread_ts: threadTs,
@@ -76,9 +90,9 @@ export class CctHandler implements CommandHandler {
     }
 
     if (action.action === 'status') {
-      // Render the Block Kit card. The plain-text fallback composes the
-      // active slot's rate-limited timestamp via `formatRateLimitedAt`
-      // so non-block clients see `YYYY-MM-DD HH:mm KST / HH:mmZ (Nm ago)`.
+      // #803 — `status` is the only non-mutating arm. Both admin and
+      // non-admin can read it; renderCctCard derives the viewerMode
+      // from `isAdminUser(userId)` so non-admin sees the readonly card.
       const { text: cardFallback, blocks } = await renderCctCard({
         userId: user,
         issuedAt: Date.now(),
@@ -86,6 +100,9 @@ export class CctHandler implements CommandHandler {
       const fallback = await buildStatusTextFallback(cardFallback);
       await say({ text: fallback, blocks, thread_ts: threadTs });
     } else if (action.action === 'next') {
+      // #803 — admin gate on the mutating arms. Status was the only arm
+      // that flowed past without an admin check.
+      if (!admin) return denyNonAdmin();
       const result = await tm.rotateToNext();
       if (result) {
         const active = tm.getActiveToken();
@@ -100,6 +117,7 @@ export class CctHandler implements CommandHandler {
         });
       }
     } else if (action.action === 'set') {
+      if (!admin) return denyNonAdmin();
       const match = tokens.find((t: TokenSummary) => t.name === action.target);
       if (match) {
         await tm.applyToken(match.keyId);
@@ -116,8 +134,17 @@ export class CctHandler implements CommandHandler {
         });
       }
     } else if (action.action === 'usage') {
+      // `cct usage [<name>]` issues an Anthropic API call (force-fetch
+      // to bypass the cached snapshot), so it must remain admin-only —
+      // it triggers a side effect on Anthropic's billing meter and is
+      // the same surface the in-card Refresh All OAuth Tokens fan-out
+      // hits. The readonly card surface gives non-admin a Refresh
+      // button that is non-force and respects the throttle, which is
+      // the appropriate non-admin affordance.
+      if (!admin) return denyNonAdmin();
       await handleUsage(action.target, tm, tokens, (t) => say({ text: t, thread_ts: threadTs }));
     } else if (action.action === 'auto') {
+      if (!admin) return denyNonAdmin();
       // Manual operator trigger of the #737 auto-rotate evaluator. Force-on:
       // we deliberately ignore `config.autoRotate.enabled` because that env
       // knob gates the *hourly tick*; an operator typing `cct auto` expects

--- a/src/slack/commands/cct-handler.ts
+++ b/src/slack/commands/cct-handler.ts
@@ -78,10 +78,21 @@ export class CctHandler implements CommandHandler {
       return { handled: true };
     }
 
+    // #803 + Codex P2 review (PR #805): admin-gate mutating actions
+    // BEFORE the empty-store shortcut so a non-admin running
+    // `cct next` / `cct set` / `cct usage` / `cct auto` against an
+    // empty store still gets `⛔ Admin only command`, not the
+    // configuration-state leak "No CCT tokens configured".
+    const isMutatingAction =
+      action.action === 'next' || action.action === 'set' || action.action === 'usage' || action.action === 'auto';
+    if (isMutatingAction && !admin) return denyNonAdmin();
+
     if (tokens.length === 0) {
-      // Empty-store message is informational, not a mutation. Fine for
-      // every viewer — the renderCctCard path also tells non-admin the
-      // empty state.
+      // Empty-store message is informational. Reachable by:
+      //   - admin running any arm (including mutating ones — they still
+      //     deserve the actionable hint),
+      //   - non-admin running `status` (the only non-mutating arm).
+      // Mutating non-admin paths were already filtered above.
       await say({
         text: 'No CCT tokens configured. Set `CLAUDE_CODE_OAUTH_TOKEN_LIST` environment variable.',
         thread_ts: threadTs,

--- a/src/slack/z/topics/__tests__/cct-topic.test.ts
+++ b/src/slack/z/topics/__tests__/cct-topic.test.ts
@@ -225,6 +225,17 @@ describe('cct-topic.renderCctCard', () => {
     expect(mockStore.fetchUsageForAllAttachedCalls).toBe(0);
   });
 
+  it('#803: skipOnOpenFetch=true skips on-open fan-out even for admin viewer (avoids double-fetch from refresh handler)', async () => {
+    resetMockStore();
+    vi.mocked(isAdminUser).mockReturnValue(true);
+    // refresh_card path: actor is admin, viewerMode='admin', but the
+    // handler already performed the usage refetch — passing
+    // skipOnOpenFetch=true must prevent renderCctCard from firing a
+    // second redundant fan-out against Anthropic.
+    await renderCctCard({ userId: 'U1', issuedAt: 33, viewerMode: 'admin', skipOnOpenFetch: true });
+    expect(mockStore.fetchUsageForAllAttachedCalls).toBe(0);
+  });
+
   it('T9-force: card-open fan-out never forwards force (local throttle must hold)', async () => {
     // Card-open is a read path — it must never bypass the per-slot
     // `nextUsageFetchAllowedAt` gate that protects Anthropic from

--- a/src/slack/z/topics/__tests__/cct-topic.test.ts
+++ b/src/slack/z/topics/__tests__/cct-topic.test.ts
@@ -139,13 +139,30 @@ function blocksText(blocks: any[]): string {
 }
 
 describe('cct-topic.renderCctCard', () => {
-  it('non-admin card omits set/next buttons', async () => {
+  it('#803: non-admin card renders readonly slot list (no admin early return)', async () => {
+    // Pre-#803 behavior: non-admin saw a single "🚫 admin only" message.
+    // Post-#803: non-admin sees the FULL slot list with mutating actions
+    // stripped. Only the trailing `z_setting_cct_cancel` chrome button
+    // and the card-level `cct_refresh_card` button remain on the action
+    // surfaces — Activate/Attach/Detach/Remove/Add/Next/RefreshAll are
+    // all gone. The "admin only" copy is also gone.
     resetMockStore();
     vi.mocked(isAdminUser).mockReturnValue(false);
     const { blocks, text } = await renderCctCard({ userId: 'U1', issuedAt: 1 });
-    expect(text).toContain('admin only');
+    // No "admin only" sentinel anywhere.
+    expect((text ?? '').toLowerCase()).not.toContain('admin only');
     const ids = actionIds(blocks);
-    expect(ids).not.toContain('z_setting_cct_set_next');
+    // Mutating buttons and card-level admin-only buttons are absent.
+    expect(ids).not.toContain('cct_activate_slot');
+    expect(ids).not.toContain('cct_open_attach');
+    expect(ids).not.toContain('cct_detach');
+    expect(ids).not.toContain('cct_open_remove');
+    expect(ids).not.toContain('cct_open_add');
+    expect(ids).not.toContain('cct_next');
+    expect(ids).not.toContain('cct_refresh_usage_all');
+    // Card-level Refresh stays for non-admin (non-force, throttle-respecting).
+    expect(ids).toContain('cct_refresh_card');
+    // Trailing cancel chrome row is still emitted.
     expect(ids).toContain('z_setting_cct_cancel');
   });
 
@@ -168,6 +185,44 @@ describe('cct-topic.renderCctCard', () => {
     vi.mocked(isAdminUser).mockReturnValue(true);
     await renderCctCard({ userId: 'U1', issuedAt: 3 });
     expect(mockStore.fetchUsageForAllAttachedCalls).toBe(1);
+  });
+
+  it('#803: readonly viewer SKIPS on-open fetchUsageForAllAttached (admin-only side effect)', async () => {
+    resetMockStore();
+    vi.mocked(isAdminUser).mockReturnValue(false);
+    await renderCctCard({ userId: 'U1', issuedAt: 30 });
+    // Non-admin viewer must not trigger the on-open fan-out — the
+    // refresh button on the readonly card is the explicit fetch path
+    // and that one calls fetchUsageForAllAttached non-force itself.
+    expect(mockStore.fetchUsageForAllAttachedCalls).toBe(0);
+  });
+
+  it('#803: viewerMode override forces "admin" render even when actor is non-admin', async () => {
+    resetMockStore();
+    vi.mocked(isAdminUser).mockReturnValue(false);
+    const { blocks } = await renderCctCard({ userId: 'U1', issuedAt: 31, viewerMode: 'admin' });
+    const ids = actionIds(blocks);
+    // Override forces admin layout — the per-slot mutating actions
+    // are present even though the actor is non-admin.
+    expect(ids).toContain('cct_open_remove');
+    expect(ids).toContain('cct_open_add');
+    expect(ids).toContain('cct_next');
+    // On-open fan-out IS triggered when effective mode is admin.
+    expect(mockStore.fetchUsageForAllAttachedCalls).toBe(1);
+  });
+
+  it('#803: viewerMode override forces "readonly" render even when actor is admin', async () => {
+    resetMockStore();
+    vi.mocked(isAdminUser).mockReturnValue(true);
+    const { blocks } = await renderCctCard({ userId: 'U1', issuedAt: 32, viewerMode: 'readonly' });
+    const ids = actionIds(blocks);
+    expect(ids).not.toContain('cct_open_remove');
+    expect(ids).not.toContain('cct_open_add');
+    expect(ids).not.toContain('cct_next');
+    // Refresh stays.
+    expect(ids).toContain('cct_refresh_card');
+    // Readonly skips on-open fan-out even for admin actors.
+    expect(mockStore.fetchUsageForAllAttachedCalls).toBe(0);
   });
 
   it('T9-force: card-open fan-out never forwards force (local throttle must hold)', async () => {

--- a/src/slack/z/topics/cct-topic.ts
+++ b/src/slack/z/topics/cct-topic.ts
@@ -52,40 +52,39 @@ async function loadSnapshotOrEmpty(): Promise<{
 /**
  * Render the `/cct` Block Kit card.
  *
- * #803 — Non-admin users now see the FULL slot status (mode='readonly')
- * with mutating affordances stripped. The `viewerMode` opt allows
- * action-handler callers (e.g. `refresh_card`) to override the
- * actor-derived default so a non-admin clicking Refresh on an admin
- * card preserves the admin layout instead of flipping it to readonly.
- *
  * Render-mode rules:
  *   - Pass an explicit `viewerMode` → use it verbatim. This is the
- *     "preserve cardMode across viewers" path (#803 spec Q1=A).
+ *     "preserve cardMode across viewers" path (#803 spec Q1=A) — used
+ *     by action handlers that decode the originating button's
+ *     `cm:<mode>|<payload>` value and want re-rendering to keep that
+ *     mode regardless of who clicked.
  *   - Otherwise → derive from `isAdminUser(userId)` (admin↔'admin',
  *     non-admin↔'readonly').
  *
  * Side effects:
  *   - Admin viewer (effective mode = 'admin') triggers the on-open
  *     `fetchUsageForAllAttached` fan-out so the card reflects fresh
- *     usage on every open. (Z1 contract — preserved.)
- *   - Readonly viewer (effective mode = 'readonly') SKIPS the fetch
- *     fan-out. Live refetch is an admin-only mutation against the
- *     Anthropic API; non-admin viewers see the latest cached snapshot
- *     ONLY (#803 spec Q2=B / Q3=A).
+ *     usage on every open (Z1 contract).
+ *   - Readonly viewer SKIPS the fetch fan-out — live refetch is an
+ *     admin-only mutation against the Anthropic API; non-admin viewers
+ *     see the latest cached snapshot only.
+ *   - `skipOnOpenFetch: true` → caller has already performed the
+ *     relevant fetch (e.g. the `refresh_card` action handler) and
+ *     wants the card render to read snapshot only. Avoids double
+ *     fan-out against Anthropic on the same click.
  */
 export async function renderCctCard(args: {
   userId: string;
   issuedAt: number;
   viewerMode?: CctCardViewerMode;
+  skipOnOpenFetch?: boolean;
 }): Promise<RenderResult> {
-  const { userId, viewerMode: viewerModeOverride } = args;
+  const { userId, viewerMode: viewerModeOverride, skipOnOpenFetch } = args;
   const effectiveViewerMode: CctCardViewerMode = viewerModeOverride ?? (isAdminUser(userId) ? 'admin' : 'readonly');
 
-  // #803 — On-open fetchUsage fan-out is admin-only. Readonly viewers
-  // see whatever is already in the cached snapshot. The Refresh button
-  // on the readonly card calls `fetchUsageForAllAttached` non-force,
-  // which still respects the per-slot 5-minute throttle.
-  if (effectiveViewerMode === 'admin') {
+  // Admin viewer triggers the on-open fan-out unless the caller has
+  // already settled the usage refresh.
+  if (effectiveViewerMode === 'admin' && !skipOnOpenFetch) {
     try {
       await getTokenManager()
         .fetchUsageForAllAttached({ timeoutMs: config.usage.cardOpenTimeoutMs })

--- a/src/slack/z/topics/cct-topic.ts
+++ b/src/slack/z/topics/cct-topic.ts
@@ -17,7 +17,7 @@ import { config } from '../../../config';
 import { Logger } from '../../../logger';
 import { getTokenManager, type TokenSummary } from '../../../token-manager';
 import type { ApplyResult, RenderResult, ZTopicBinding } from '../../actions/z-settings-actions';
-import { appendStoreReadFailureBanner, buildCctCardBlocks } from '../../cct/builder';
+import { appendStoreReadFailureBanner, buildCctCardBlocks, type CctCardViewerMode } from '../../cct/builder';
 
 const logger = new Logger('CctTopic');
 
@@ -49,55 +49,54 @@ async function loadSnapshotOrEmpty(): Promise<{
   }
 }
 
-export async function renderCctCard(args: { userId: string; issuedAt: number }): Promise<RenderResult> {
-  const { userId } = args;
-  const admin = isAdminUser(userId);
-  if (!admin) {
-    return {
-      text: '🚫 CCT (admin only)',
-      blocks: [
-        {
-          type: 'header',
-          text: { type: 'plain_text', text: '🔑 CCT Tokens', emoji: true },
-        },
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: '🚫 *CCT Token — admin only*\nOnly administrators may view or change CCT tokens.',
-          },
-        },
-        {
-          type: 'actions',
-          elements: [
-            {
-              type: 'button',
-              action_id: 'z_setting_cct_cancel',
-              text: { type: 'plain_text', text: '❌ 취소' },
-              style: 'danger',
-              value: 'cancel',
-            },
-          ],
-        },
-      ],
-    };
-  }
+/**
+ * Render the `/cct` Block Kit card.
+ *
+ * #803 — Non-admin users now see the FULL slot status (mode='readonly')
+ * with mutating affordances stripped. The `viewerMode` opt allows
+ * action-handler callers (e.g. `refresh_card`) to override the
+ * actor-derived default so a non-admin clicking Refresh on an admin
+ * card preserves the admin layout instead of flipping it to readonly.
+ *
+ * Render-mode rules:
+ *   - Pass an explicit `viewerMode` → use it verbatim. This is the
+ *     "preserve cardMode across viewers" path (#803 spec Q1=A).
+ *   - Otherwise → derive from `isAdminUser(userId)` (admin↔'admin',
+ *     non-admin↔'readonly').
+ *
+ * Side effects:
+ *   - Admin viewer (effective mode = 'admin') triggers the on-open
+ *     `fetchUsageForAllAttached` fan-out so the card reflects fresh
+ *     usage on every open. (Z1 contract — preserved.)
+ *   - Readonly viewer (effective mode = 'readonly') SKIPS the fetch
+ *     fan-out. Live refetch is an admin-only mutation against the
+ *     Anthropic API; non-admin viewers see the latest cached snapshot
+ *     ONLY (#803 spec Q2=B / Q3=A).
+ */
+export async function renderCctCard(args: {
+  userId: string;
+  issuedAt: number;
+  viewerMode?: CctCardViewerMode;
+}): Promise<RenderResult> {
+  const { userId, viewerMode: viewerModeOverride } = args;
+  const effectiveViewerMode: CctCardViewerMode = viewerModeOverride ?? (isAdminUser(userId) ? 'admin' : 'readonly');
 
-  // Z1 — Card open fan-out: refresh usage for every CCT slot that
-  // currently carries an OAuthAttachment so inactive slots don't render
-  // with stale/empty usage. Await (not fire-and-forget) per plan §3.6 so
-  // "한눈에" semantics hold; fall back to `.catch()` and whatever is in
-  // the snapshot if the fan-out throws or hits the timeout.
-  try {
-    await getTokenManager()
-      .fetchUsageForAllAttached({ timeoutMs: config.usage.cardOpenTimeoutMs })
-      .catch((err: unknown) => {
-        logger.debug(`fetchUsageForAllAttached: ignored error on card open: ${(err as Error)?.message ?? err}`);
-      });
-  } catch (err) {
-    // Defensive: a non-async throw from the getTokenManager() accessor must
-    // not brick card rendering.
-    logger.debug(`fetchUsageForAllAttached accessor threw: ${(err as Error)?.message ?? err}`);
+  // #803 — On-open fetchUsage fan-out is admin-only. Readonly viewers
+  // see whatever is already in the cached snapshot. The Refresh button
+  // on the readonly card calls `fetchUsageForAllAttached` non-force,
+  // which still respects the per-slot 5-minute throttle.
+  if (effectiveViewerMode === 'admin') {
+    try {
+      await getTokenManager()
+        .fetchUsageForAllAttached({ timeoutMs: config.usage.cardOpenTimeoutMs })
+        .catch((err: unknown) => {
+          logger.debug(`fetchUsageForAllAttached: ignored error on card open: ${(err as Error)?.message ?? err}`);
+        });
+    } catch (err) {
+      // Defensive: a non-async throw from the getTokenManager() accessor must
+      // not brick card rendering.
+      logger.debug(`fetchUsageForAllAttached accessor threw: ${(err as Error)?.message ?? err}`);
+    }
   }
 
   const { slots, states, activeKeyId, loadFailed } = await loadSnapshotOrEmpty();
@@ -112,6 +111,7 @@ export async function renderCctCard(args: { userId: string; issuedAt: number }):
     states,
     activeKeyId,
     nowMs: Date.now(),
+    viewerMode: effectiveViewerMode,
   });
 
   // #644 review P3 — surface store-read failures as a visible warning
@@ -209,6 +209,10 @@ export function createCctTopicBinding(): ZTopicBinding {
   return {
     topic: 'cct',
     apply: (args) => applyCct({ userId: args.userId, value: args.value }),
+    // #803 — `viewerMode` is decided by `renderCctCard` from
+    // `isAdminUser(userId)` when not explicitly overridden by an
+    // action-handler caller. The /z dispatcher does not know which
+    // mode to render in, so we let renderCctCard derive it.
     renderCard: (args) => renderCctCard({ userId: args.userId, issuedAt: args.issuedAt }),
   };
 }


### PR DESCRIPTION
## Summary
- /cct activate/next/detach now update the originating card in-place via `chat.update` (message) or `respond({replace_original:true})` (ephemeral) instead of stacking a fresh ephemeral on top of a stale card.
- Non-admin users now see the FULL cached slot status (email / tier / usage) with a readonly card layout — mutating buttons stripped, single Refresh button (non-force, throttle-respecting) remains.
- Channel-shared cards preserve their render mode across viewers via a new `cm:<mode>|<payload>` button-value codec.

Closes #803

## Test plan
- [x] codec: 30 unit tests (9 invalid cases, tagged/legacy/roundtrip, 2000-char cap)
- [x] renderInPlace: 15 unit tests (surface classification, channel/ts fallback chain, ephemeral missing-respond guard, transport failure modes)
- [x] builder readonly: viewerMode strips mutating actions, no empty `actions` block, refresh-only card row, usage panel still renders, admin tags `cm:admin|` on every button
- [x] refresh_card 6-case matrix: admin/admin-card force, non-admin/admin-card preserves cardMode non-force, non-admin/readonly non-force, admin/readonly force-gate denies, legacy force=false, throttle-all-null banner in-place
- [x] activate/next/detach: in-place across message + ephemeral surfaces; invalid action values rejected
- [x] view_submission admin gates: add/remove/attach reject non-admin server-side
- [x] cct-topic readonly: skips on-open fetchUsageForAllAttached, viewerMode override honored both directions
- [x] cct-handler non-admin: `cct` status OK, `cct next` / `cct set` / `cct usage` rejected
- [x] 340/340 cct + cct-topic + cct-handler tests pass
- [x] `tsc --noEmit` clean
- [x] `npm run check` clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <z@2lab.ai>