### PR TITLE
fix(slack-mcp): restore exports on thread-fetcher helpers (get_thread_messages crash)

### DIFF
--- a/mcp-servers/slack-mcp/helpers/thread-fetcher.test.ts
+++ b/mcp-servers/slack-mcp/helpers/thread-fetcher.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression: the named helpers below are imported by `slack-mcp-server.ts`.
+ * They were silently de-exported once by an unused-export auto-fixer, which
+ * crashed `get_thread_messages` at runtime with
+ *   "(0 , import_thread_fetcher.getTotalCount) is not a function".
+ *
+ * This file pins the public surface so any future tool — or human — that
+ * thinks these are unused has to delete this test first.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getTotalCount,
+  fetchThreadSlice,
+  fetchMessagesBefore,
+  fetchMessagesAfter,
+} from './thread-fetcher.js';
+
+describe('thread-fetcher public surface', () => {
+  it('exports getTotalCount as a function', () => {
+    expect(typeof getTotalCount).toBe('function');
+  });
+
+  it('exports fetchThreadSlice as a function', () => {
+    expect(typeof fetchThreadSlice).toBe('function');
+  });
+
+  it('exports fetchMessagesBefore as a function', () => {
+    expect(typeof fetchMessagesBefore).toBe('function');
+  });
+
+  it('exports fetchMessagesAfter as a function', () => {
+    expect(typeof fetchMessagesAfter).toBe('function');
+  });
+});
+
+describe('fetchMessagesBefore', () => {
+  it('returns empty result without calling Slack when count is 0', async () => {
+    const slack = {
+      conversations: {
+        replies: async () => {
+          throw new Error('Slack API should not be called when count=0');
+        },
+      },
+    } as any;
+
+    const result = await fetchMessagesBefore(slack, 'C', 'T', 'A', 0);
+    expect(result).toEqual({ messages: [], rootWasInjected: false });
+  });
+});
+
+describe('fetchThreadSlice', () => {
+  it('returns empty array when totalCount is 0', async () => {
+    const slack = {
+      conversations: {
+        replies: async () => {
+          throw new Error('Slack API should not be called when totalCount=0');
+        },
+      },
+    } as any;
+
+    const messages = await fetchThreadSlice(slack, 'C', 'T', 0, 10, 0);
+    expect(messages).toEqual([]);
+  });
+
+  it('returns empty array when offset is past totalCount', async () => {
+    const slack = {
+      conversations: {
+        replies: async () => {
+          throw new Error('Slack API should not be called when offset>=totalCount');
+        },
+      },
+    } as any;
+
+    const messages = await fetchThreadSlice(slack, 'C', 'T', 100, 10, 5);
+    expect(messages).toEqual([]);
+  });
+});

--- a/mcp-servers/slack-mcp/helpers/thread-fetcher.ts
+++ b/mcp-servers/slack-mcp/helpers/thread-fetcher.ts
@@ -12,7 +12,7 @@ function extractCursor(response: { response_metadata?: { next_cursor?: string } 
 /**
  * Get total message count in thread (root + replies).
  */
-async function getTotalCount(
+export async function getTotalCount(
   slack: WebClient,
   channel: string,
   threadTs: string,
@@ -39,7 +39,7 @@ async function getTotalCount(
 /**
  * Fetch a slice of thread messages by offset and limit.
  */
-async function fetchThreadSlice(
+export async function fetchThreadSlice(
   slack: WebClient,
   channel: string,
   threadTs: string,
@@ -86,7 +86,7 @@ async function fetchThreadSlice(
  * Returns { messages, rootWasInjected } so the caller can distinguish
  * "extra because root was prepended" from "extra because unseen messages exist."
  */
-async function fetchMessagesBefore(
+export async function fetchMessagesBefore(
   slack: WebClient,
   channel: string,
   threadTs: string,
@@ -136,7 +136,7 @@ async function fetchMessagesBefore(
 /**
  * Fetch up to `count` replies starting after anchorTs (exclusive).
  */
-async function fetchMessagesAfter(
+export async function fetchMessagesAfter(
   slack: WebClient,
   channel: string,
   threadTs: string,


### PR DESCRIPTION
## Summary

`get_thread_messages` is currently broken at runtime with:
```
(0 , import_thread_fetcher.getTotalCount) is not a function
(0 , import_thread_fetcher.fetchMessagesBefore) is not a function
```

Both array mode and legacy mode crash on the very first call — any session that needs to read its own thread context falls back to guessing.

## Root cause

#790 ran `fallow fix` and stripped the `export` keyword from 172 declarations across the repo. Four of those — `getTotalCount`, `fetchThreadSlice`, `fetchMessagesBefore`, `fetchMessagesAfter` in `mcp-servers/slack-mcp/helpers/thread-fetcher.ts` — are still imported by name from `slack-mcp-server.ts`.

At runtime the namespace import resolves to `undefined`, so every code path that touches the helpers throws on the first invocation.

## Fix

1. Re-export the four functions actually consumed across module boundaries. `extractCursor` stays private — no out-of-file caller.
2. Add `mcp-servers/slack-mcp/helpers/thread-fetcher.test.ts` as a regression guard. It pins the public surface so any future unused-export auto-fixer has to delete the test before it can re-break production. Also locks in two early-return contracts (`fetchMessagesBefore` with count=0, `fetchThreadSlice` with totalCount=0/offset past end) so we don't silently hit Slack.

## Verification

- `npx vitest run mcp-servers/slack-mcp/` → 212/212 pass (10 files, including the new 7 cases).
- `npx tsc --noEmit -p tsconfig.json` clean.

## Test plan
- [x] New regression test passes
- [x] All existing slack-mcp tests still pass
- [x] Typecheck clean
- [ ] Reviewer to confirm whether `.fallowrc.json` needs an additional rule so the auto-fixer follows imports out of `dynamicallyLoaded` entry files (separate concern, not blocking this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Z <z@2lab.ai>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>