### PR TITLE
feat(deploy): add iq-64-dev to dev matrix + brew node fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,13 @@ jobs:
               "github_env":"development",
               "deploy_env":"dev",
               "target_dir":"/opt/soma-work/dev"
+            },
+            {
+              "name":"iq-64-dev",
+              "runner_label":"iq-64",
+              "github_env":"development",
+              "deploy_env":"dev",
+              "target_dir":"/opt/soma-work/dev"
             }
           ]}
           EOF
@@ -179,6 +186,15 @@ jobs:
               if [[ -n "$NVM_BIN" ]]; then
                 export PATH="$NVM_BIN:$PATH"
               fi
+            fi
+            # Homebrew fallback (iq-64 uses brew-installed node, no nvm).
+            if ! command -v node >/dev/null 2>&1; then
+              for BREW_PREFIX in /opt/homebrew /usr/local; do
+                if [[ -x "$BREW_PREFIX/bin/node" ]]; then
+                  export PATH="$BREW_PREFIX/bin:$PATH"
+                  break
+                fi
+              done
             fi
           fi
           command -v node >/dev/null 2>&1 || {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,7 +187,8 @@ jobs:
                 export PATH="$NVM_BIN:$PATH"
               fi
             fi
-            # Homebrew fallback (iq-64 uses brew-installed node, no nvm).
+            # Fallback for runners where node is installed via Homebrew
+            # rather than nvm. Apple Silicon: /opt/homebrew, Intel/Linux: /usr/local.
             if ! command -v node >/dev/null 2>&1; then
               for BREW_PREFIX in /opt/homebrew /usr/local; do
                 if [[ -x "$BREW_PREFIX/bin/node" ]]; then
@@ -198,11 +199,11 @@ jobs:
             fi
           fi
           command -v node >/dev/null 2>&1 || {
-            echo "::error::node not found on PATH after nvm sourcing — cannot deploy."
+            echo "::error::node not found on PATH after nvm/brew fallbacks — cannot deploy."
             exit 1
           }
           command -v npm >/dev/null 2>&1 || {
-            echo "::error::npm not found on PATH after nvm sourcing — cannot deploy."
+            echo "::error::npm not found on PATH after nvm/brew fallbacks — cannot deploy."
             exit 1
           }
           echo "Using node: $(node -v) at $(command -v node)"


### PR DESCRIPTION
## Summary

- Dev 배포 매트릭스에 **`iq-64-dev`** 타겟 추가 (runner_label `iq-64`, target_dir `/opt/soma-work/dev`)
- node 탐색 fallback에 **Homebrew prefix(`/opt/homebrew`, `/usr/local`)** 추가 — iq-64는 brew 설치 node 사용 (nvm 없음)
- 결과: `git push origin main:deploy/dev` 시 mac-mini-dev / oudwood-dev / **iq-64-dev** 3개 호스트에 fan-out (`fail-fast: false`)

기존 `mac-mini-dev` / `oudwood-dev`엔 영향 없음 — nvm fallback이 먼저 시도되고, brew는 그 후에만 동작.

## iq-64 사전 셋업 상태

- [x] Self-hosted runner online (label `iq-64`)
- [x] `/opt/soma-work/dev/` synced from mac-mini-dev (config + bundles, `data/`·`logs/` 제외)
- [x] `.env`에 새 Slack BOT/APP token + signing secret 적용 (mac-mini와 분리 — 메시지 중복 방지)
- [x] `node v25.9.0`, `npm 11.12.1` 설치 (brew, mac-mini와 동일 버전)
- [ ] LaunchDaemon plist 미설치 → 첫 deploy 시 `service.sh dev install`이 설치 (sudo 권한 필요할 수 있음)

## Test plan

- [ ] PR merge → `git push origin main:deploy/dev`로 트리거
- [ ] `prepare` job (oudwood-512) bundle 빌드 성공
- [ ] 3개 deploy matrix job 전부 성공: `mac-mini-dev`, `oudwood-dev`, `iq-64-dev`
- [ ] iq-64 service 확인: \`ssh iq-64 'launchctl list | grep ai.2lab.soma-work'\`
- [ ] Slack bot 연결 확인 (iq-64 인스턴스가 별도 bot user로 응답, mac-mini와 메시지 중복 없음)

## Notes

- **YAML/config-only change** — application logic 미변경. 로컬 \`tsc --noEmit\` 통과 (의존성은 \`npm ci\`로 복구). vitest는 CI가 검증.
- iq-64에 launchd-managed runner가 떠 있어, deploy step에서 \`service.sh dev install\`이 plist 설치 시도. 만약 sudoers 미구성으로 막히면 첫 1회만 수동 install 필요.
- 이번 PR이 머지되면 dev에 새 머신이 추가되는 것이지 prod 영향은 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)