### PR TITLE
deploy(dev): 2026-05-07 release — iq-64 target + dashboard kanban + cct cooldown propagation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,24 @@ BASE_DIRECTORY=/Users/username/Code/
 # CONVERSATION_VIEWER_PORT=3000
 # CONVERSATION_VIEWER_HOST=127.0.0.1
 
+# Multi-instance dashboard aggregation (#814)
+# When two soma-work instances run on the same host (e.g.
+# `:33000` + `:33001`), each writes a heartbeat to ~/.soma/instances/<port>.json
+# and the dashboard fans out to siblings to merge their kanban boards.
+#
+# - INSTANCE_NAME: operator-supplied label for the env badge on cards.
+#   Falls back to `${hostname}:${port}` when unset, but a human-readable
+#   label (oudwood-dev, mac-mini-dev, ...) is what the badge displays.
+# - CONVERSATION_VIEWER_TOKEN: cross-port aggregation auth. MUST be the
+#   SAME value on every instance that should aggregate together.
+#   When unset on either side, that instance silently falls back to
+#   self-only with a one-shot warn log.
+# - SOMA_INSTANCE_DIR (rare): override the heartbeat directory for tests
+#   or non-default deploys. Default: ~/.soma/instances.
+#
+# INSTANCE_NAME=oudwood-dev
+# SOMA_INSTANCE_DIR=/var/lib/soma/instances
+
 # Dashboard OAuth (Optional — enables Google/Microsoft sign-in on the dashboard)
 # Requires CONVERSATION_VIEWER_URL to be set for OAuth callback URLs
 #

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,13 @@ jobs:
               "github_env":"development",
               "deploy_env":"dev",
               "target_dir":"/opt/soma-work/dev"
+            },
+            {
+              "name":"iq-64-dev",
+              "runner_label":"iq-64",
+              "github_env":"development",
+              "deploy_env":"dev",
+              "target_dir":"/opt/soma-work/dev"
             }
           ]}
           EOF
@@ -179,6 +186,15 @@ jobs:
               if [[ -n "$NVM_BIN" ]]; then
                 export PATH="$NVM_BIN:$PATH"
               fi
+            fi
+            # Homebrew fallback (iq-64 uses brew-installed node, no nvm).
+            if ! command -v node >/dev/null 2>&1; then
+              for BREW_PREFIX in /opt/homebrew /usr/local; do
+                if [[ -x "$BREW_PREFIX/bin/node" ]]; then
+                  export PATH="$BREW_PREFIX/bin:$PATH"
+                  break
+                fi
+              done
             fi
           fi
           command -v node >/dev/null 2>&1 || {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,7 +187,8 @@ jobs:
                 export PATH="$NVM_BIN:$PATH"
               fi
             fi
-            # Homebrew fallback (iq-64 uses brew-installed node, no nvm).
+            # Fallback for runners where node is installed via Homebrew
+            # rather than nvm. Apple Silicon: /opt/homebrew, Intel/Linux: /usr/local.
             if ! command -v node >/dev/null 2>&1; then
               for BREW_PREFIX in /opt/homebrew /usr/local; do
                 if [[ -x "$BREW_PREFIX/bin/node" ]]; then
@@ -198,11 +199,11 @@ jobs:
             fi
           fi
           command -v node >/dev/null 2>&1 || {
-            echo "::error::node not found on PATH after nvm sourcing — cannot deploy."
+            echo "::error::node not found on PATH after nvm/brew fallbacks — cannot deploy."
             exit 1
           }
           command -v npm >/dev/null 2>&1 || {
-            echo "::error::npm not found on PATH after nvm sourcing — cannot deploy."
+            echo "::error::npm not found on PATH after nvm/brew fallbacks — cannot deploy."
             exit 1
           }
           echo "Using node: $(node -v) at $(command -v node)"

--- a/docs/cct-shared-bucket-cooldown-propagation/spec.md
+++ b/docs/cct-shared-bucket-cooldown-propagation/spec.md
@@ -1,0 +1,170 @@
+# CCT Shared-Bucket Cooldown Propagation — Spec
+
+> STV Spec | Created: 2026-04-30
+
+## 1. Overview
+
+### Proposal
+- **Why**: Operators register multiple separate Claude Max OAuth subscriptions as CCT slots expecting N× quota, but Anthropic enforces a cross-account rate-limit bucket (almost certainly IP/machine-based) so all slots 429 in cascade with the same parsed reset wall-clock. Each cascade step burns a real `claude` CLI subprocess + 429 round-trip before being marked, then we rotate to the next slot which immediately repeats. With N=6 slots, the user pays N-1 wasted spawn/parse/error cycles before the rotation pool is exhausted.
+- **What Changes**: When a rate-limit hits, after marking the active slot's `cooldownUntil`, we scan eligible-class sibling slots' existing cooldownUntil values. If at least one match within ±W ms is found (the *second* observation of the same wall-clock reset, **with both observations originating from a parsed wall-clock — not the 60-minute fallback — and from a direct-evidence source `'error_string' | 'response_header'`**), we propagate that cooldownUntil to all eligible OAuth-attached CCT siblings. The first 429 in any window is recorded normally — we never blind-propagate.
+- **Capabilities**: New `RateLimitSource` arm `'inferred_shared'` distinguishes propagation marks from real 429s in logs and UI. The slack `/cct` card surfaces this as `via inferred shared bucket` so operators can tell apart "this slot itself was rate-limited" from "we inferred this slot is in the same bucket as a recently-limited slot".
+- **Impact**: Additive type union extension (no schema migration). One new private helper in `TokenManager`. One UI label arm. One caller-side flag added by `stream-executor` (`knownReset: parsedCooldown !== null`) — keeps the trigger gated on real wall-clock evidence. Behavior change is *limited to the active 429 path* (`stream-executor` → `tryRotateToken` → `rotateOnRateLimit`) — passive header-driven `recordRateLimitHint` is untouched. `parseCooldownTime` is untouched. Existing tests must still pass; cascade-related flows now collapse two cycles instead of N.
+
+The mechanism is the second-cascade-step heuristic with three guards:
+
+1. **Trigger guard** — propagation only activates when the *current* call's source is direct-evidence (`'error_string' | 'response_header'`) AND `opts.knownReset === true` (the caller actually parsed a wall-clock, not the 60-minute fallback). Otherwise the helper is a no-op.
+2. **Match guard** — the matched sibling must itself be in the eligible-set (CCT + `oauthAttachment` + not tombstoned + not `disableRotation`) AND its `rateLimitSource` must be direct-evidence (`'error_string' | 'response_header'`). Sibling sources `'manual'` and `'inferred_shared'` cannot anchor a match — they don't represent direct upstream signal.
+3. **Window guard** — match radius ±W ms (default 90 000 = 90 s, env `CCT_SHARED_BUCKET_WINDOW_MS`). Wide enough to absorb minute-rounding from `parseCooldownTime`, narrow enough that two coincidental independent 429s 5+ minutes apart don't chain.
+
+Together these guards eliminate the dominant false-positive vectors: (a) two independent saturations falling on the 60-minute default fallback within window, (b) cascading propagation through `'inferred_shared'` re-anchoring, (c) `'manual'` operator-set cooldowns being treated as direct evidence, (d) ineligible-set slots (api_key, no-attachment, tombstoned, disableRotation) participating as match anchors or propagation targets.
+
+## 2. User Stories
+- **Operator with 6 keys** — As an operator who registered 6 separate Claude Max accounts, when one slot saturates the upstream's cross-account bucket I want the remaining slots marked immediately so my next user message doesn't sit through 4 more 429s before getting a "no slots available" answer.
+- **Operator inspecting `/cct`** — As an operator looking at the card, I want to distinguish "this slot itself 429d" from "this slot was inferred-cooled because a sibling 429d at the same wall-clock", so I know whether the cooldown is independent or shared.
+- **Operator running independent keys** — As an operator whose keys are *not* in a shared bucket (e.g. across multiple machines), I want my isolated 429s to NOT propagate, so a one-off rate-limit on slot A doesn't take down B/C/D.
+
+## 3. Acceptance Criteria
+- [ ] **AC-1**: First 429 in a rotation cycle marks only the active slot. `state[other].cooldownUntil` remains unchanged for every other slot.
+- [ ] **AC-2**: Second 429 whose new `cooldownUntil` is within ±W ms of *any* eligible sibling's existing future `cooldownUntil` (sibling source ∈ {`error_string`, `response_header`}) propagates the new `cooldownUntil` to every eligible OAuth-attached CCT sibling that is not already in a future cooldown. Propagated marks carry `rateLimitSource: 'inferred_shared'`, `rateLimitedAt: now`.
+- [ ] **AC-3**: Second 429 whose new `cooldownUntil` is *outside* ±W ms of every sibling's existing cooldownUntil does NOT propagate (independent bucket).
+- [ ] **AC-4**: Siblings already in a future cooldown are never overwritten by propagation.
+- [ ] **AC-5**: `kind: 'api_key'` slots, `kind: 'cct'` slots without `oauthAttachment`, tombstoned slots, and slots with `disableRotation: true` are skipped by propagation **and excluded from the match-anchor scan**.
+- [ ] **AC-6**: `process.env.CCT_SHARED_BUCKET_WINDOW_MS` overrides the default 90 000 ms window. Invalid (`NaN` / `≤0`) values fall back to default with a warning logged.
+- [ ] **AC-7**: `/cct` card renders the new `'inferred_shared'` source as `via inferred shared bucket` in `buildRateLimitedSegment`.
+- [ ] **AC-8**: Existing `token-manager`, `stream-executor`, `builder` test suites continue to pass without modification (additive only).
+- [ ] **AC-9**: Cascade scenario test counts exactly two `rotateOnRateLimit` invocations before all healthy siblings are marked (not N).
+- [ ] **AC-10**: Trigger requires `opts.knownReset === true` AND `opts.source ∈ {'error_string', 'response_header'}`. When `knownReset === false` (caller's `parseCooldownTime` returned `null`, fallback to 60-minute default), propagation is a no-op even if a within-window match exists. Prevents two independent fallback-60m cooldowns from chaining.
+- [ ] **AC-11**: Sibling whose `rateLimitSource ∈ {'manual', 'inferred_shared'}` cannot anchor a match. Only direct-evidence siblings (`error_string` / `response_header`) qualify. Prevents `inferred_shared` from chaining itself.
+- [ ] **AC-12**: stream-executor's `tryRotateToken` (`src/slack/pipeline/stream-executor.ts:2023`) passes `knownReset: parsedCooldown !== null` to `rotateOnRateLimit`. The default-60m branch (`!parsedCooldown`) sets `knownReset: false`.
+
+## 4. Scope
+
+### In-Scope
+- Extend `RateLimitSource` union in `src/cct-store/types.ts` with `'inferred_shared'`.
+- Extend `RotateOnRateLimitOptions` in `src/token-manager.ts` with `knownReset?: boolean` (default `false` when omitted — preserves backward compat for any non-stream-executor caller).
+- Modify `TokenManager.rotateOnRateLimit` (`src/token-manager.ts:732`) to perform the match-and-propagate step inside the existing `store.mutate` transaction, gated by `knownReset && source ∈ {error_string, response_header}`.
+- Add private helper `propagateInferredSharedCooldownIfMatched(snap, anchorCooldownUntilMs, nowIso, windowMs, currentId)` to keep the mutate body readable. The helper iterates `snap.registry.slots` (NOT raw `snap.state`) so the eligibility checks are slot-shape-aware.
+- Resolve window from `process.env.CCT_SHARED_BUCKET_WINDOW_MS` once per call (parseInt, fallback 90 000 on NaN / ≤0). Module-private resolver.
+- Modify `tryRotateToken` (`src/slack/pipeline/stream-executor.ts:2023`) to pass `knownReset: parsedCooldown !== null` alongside the existing `cooldownMinutes` arg.
+- UI: extend `buildRateLimitedSegment` source-label switch (`src/slack/cct/builder.ts`) for `'inferred_shared'`.
+- New unit tests in `src/__tests__/token-manager.test.ts` covering AC-1..AC-6, AC-9..AC-11.
+- New stream-executor test in `src/slack/pipeline/__tests__/stream-executor.test.ts` covering AC-12 (the `knownReset` flag is plumbed correctly for both parsed and fallback paths).
+- New UI test in `src/slack/cct/__tests__/builder.test.ts` covering AC-7.
+- Brief docs note appended to `docs/cct/scheduling-strategy.md` summarizing the propagation rule.
+
+### Out-of-Scope
+- Auto-detecting organization grouping via `accountUuid` or email domain.
+- Manual `slotGroup` config field on slot definitions.
+- UX-only banner without behavior change.
+- Disabling auto-rotate-on-429.
+- Touching `recordRateLimitHint` (header-driven passive path).
+- Touching `parseCooldownTime` (wall-clock parser is correct).
+- `applyTokenIfActiveMatches` and the auto-rotate selection logic in `src/oauth/auto-rotate.ts` (read-only consumer of cooldown state — no change needed; cooled siblings simply become ineligible by the existing `isEligible` gate).
+
+## 5. Architecture
+
+### 5.1 Layer Structure (unchanged + new helper)
+```
+slack/pipeline/stream-executor.ts
+  └─ tryRotateToken(error, activeSlotAtQueryStart)
+       └─ parseCooldownTime(errorText)               // returns Date | null
+       └─ knownReset = parsedCooldown !== null        // NEW flag
+       └─ cooldownMinutes = knownReset ? round(...) : 60
+       └─ TokenManager.rotateOnRateLimit(reason, {source:'error_string', cooldownMinutes, knownReset})
+            └─ [MUTATE TXN]
+                 ├─ snap.state[currentId].cooldownUntil = X
+                 ├─ snap.state[currentId].rateLimitedAt = now
+                 ├─ snap.state[currentId].rateLimitSource = 'error_string'
+                 ├─ if (opts.knownReset && opts.source ∈ {error_string, response_header}):
+                 │     NEW: propagateInferredSharedCooldownIfMatched(snap, Xms, nowIso, W, currentId)
+                 │       └─ for each slot K in snap.registry.slots, K !== currentId:
+                 │            ELIGIBLE_FILTER:
+                 │              skip if K.kind === 'api_key'
+                 │              skip if K.kind === 'cct' && K.oauthAttachment === undefined
+                 │              skip if K.disableRotation === true
+                 │              skip if state[K].tombstoned === true
+                 │            MATCH_ANCHOR_SCAN:
+                 │              candidate is K iff state[K].cooldownUntil exists,
+                 │              its parsed ms is finite AND > nowMs (future),
+                 │              AND state[K].rateLimitSource ∈ {error_string, response_header}
+                 │              AND |parsed_ms - Xms| <= W
+                 │              → if any K satisfies match → matched = true
+                 │            (loop1 collects match)
+                 │       └─ if matched:
+                 │            for each slot K' in snap.registry.slots, K' !== currentId,
+                 │            passing ELIGIBLE_FILTER, with NO future cooldownUntil:
+                 │              snap.state[K'].cooldownUntil  = cooldownUntilIso
+                 │              snap.state[K'].rateLimitedAt  = nowIso
+                 │              snap.state[K'].rateLimitSource = 'inferred_shared'
+                 └─ rotate activeKeyId to next eligible (now likely none → returns null)
+```
+
+The match-anchor scan and the propagation loop both walk `snap.registry.slots` (not raw `snap.state` keys) so orphan state rows (a known historical artifact when a slot is removed without state cleanup) cannot anchor or receive propagation.
+
+The propagation step lives **inside** the same `store.mutate` callback as the original currentId mutation. This is critical: both the `currentId` mark and the propagation must be atomic relative to other transactions to preserve the existing CAS-safe semantics. If the mutate transaction is retried due to optimistic-lock conflict, the propagation re-evaluates against the fresh snapshot and naturally converges.
+
+### 5.2 API Endpoints
+None. This is a pure runtime behavior change. No new HTTP/Slack/IPC surface.
+
+### 5.3 DB Schema
+No schema change. The persisted shape in `data/cct-store.json` is unchanged — `rateLimitSource` is already a free-form string from the `RateLimitSource` union; adding `'inferred_shared'` is read-tolerant by existing parse code (no enum gate at read time).
+
+For backward compat: a v2-format snapshot written by this PR can be read by an older soma-work binary that doesn't know `'inferred_shared'`. The older binary will still surface `state.cooldownUntil` correctly via the picker (`isEligible` doesn't switch on source). UI rendering on older binaries would fall through to a default Cooldown label — graceful degradation.
+
+### 5.4 Integration Points
+- **stream-executor `tryRotateToken`** — caller; today passes `{source: 'error_string', cooldownMinutes}`. **This PR adds `knownReset: parsedCooldown !== null`** so the propagation gate can distinguish parsed wall-clock from the 60-minute fallback. No other behavior change in this caller.
+- **auto-rotate `evaluateAndMaybeRotate`** — read-only consumer; cooled siblings are ineligible via existing `isEligible(slot, state, now)` which already checks `state.cooldownUntil > now`.
+- **slack/cct builder `buildRateLimitedSegment`** — UI label switch extended for `'inferred_shared'` → `via inferred shared bucket`. `computeUsageCooldown` `source: 'manual'` arm covers rendering of the bare `Cooldown <dur>` badge for inferred-shared cooled slots, since their `usage.sevenDay` / `usage.fiveHour` are not at 100% (the badge is utilization-driven; the rate-limited line is source-driven).
+- **logger** — `rotateOnRateLimit` already emits a single info log per call. Add a separate info log when propagation triggers, naming the matched sibling and the count of propagated targets.
+
+### 5.5 Failure Modes
+| Scenario | Expected behavior |
+|----------|-------------------|
+| Window env var malformed | Log warning, fall back to default 90 000 ms. Spec test covers this. |
+| Caller's `parseCooldownTime` returned `null` (60-min fallback) | `knownReset === false` ⇒ trigger guard rejects propagation. Two coincidental 60m fallbacks within window cannot chain. |
+| Sibling cooldownUntil is in the past (stale) | Excluded from match-anchor scan — `cooldownUntilMs > nowMs` is the sibling-recency gate. |
+| Sibling source is `'manual'` (operator-set) | Excluded from match-anchor scan — only direct-evidence sources (`error_string` / `response_header`) anchor. |
+| Sibling source is `'inferred_shared'` (already propagated) | Excluded from match-anchor scan — prevents inferred chains from re-propagating. |
+| Sibling has cooldownUntil but no rateLimitedAt | Still propagation-target eligible (`cooldownUntil` is the SSOT for "is in cooldown"); but as a match anchor the source check still applies. |
+| New cooldown is in the past after cooldownMinutes=1 floor | Same as today — `state.cooldownUntil = nowMs + cooldownMs`, rounded; propagation operates on the same `Xms`. |
+| Slot has `authState='refresh_failed'`/`'revoked'` | Already excluded from runtime picker. Marked by propagation for diagnostic clarity (cheap, harmless — slot was ineligible already). |
+| Tombstoned sibling | Skipped both as match anchor and as propagation target. |
+| `disableRotation: true` sibling | Skipped both as match anchor and as propagation target (operator opt-out preserved end-to-end). |
+| `api_key` sibling | Skipped both as match anchor and as propagation target (different rate-limit bucket — Anthropic commercial API quota). |
+| CCT slot without `oauthAttachment` (setup-only) | Skipped — same bucket signal does not apply to a slot that hasn't authenticated to OAuth. |
+| Orphan state row (no matching slot in registry) | Untouched — iteration walks `registry.slots` not state keys. |
+
+## 6. Non-Functional Requirements
+- **Performance**: Propagation is O(n_slots) inside a single `store.mutate`. n_slots is bounded by config (typically ≤16). Each iteration is field reads + 3 field writes. Negligible vs the lock acquisition cost already paid by `mutate`.
+- **Concurrency**: Existing CAS retry semantics in `CctStore.mutate` carry over. If a competing transaction lands between snapshot read and persist, the mutate is retried with a fresh snapshot — propagation is recomputed deterministically against the fresh state.
+- **Observability**: New log line `rotateOnRateLimit: inferred_shared propagation matched=<sibling-keyId> propagated=<count> windowMs=<W>`. Lets ops see propagation events in production logs without enabling debug.
+- **Configurability**: Single env var `CCT_SHARED_BUCKET_WINDOW_MS`. Default 90 000 ms is conservative — wall-clock `parseCooldownTime` rounds to the minute, so two cascade hits within the same minute boundary will be ≤ 60 000 ms apart at the source; 90 000 ms gives a 30 s slack for network jitter and clock skew.
+- **Security**: No new external surface; no PII handling; no token exposure. Logs name keyIds (already an opaque ULID, not a token).
+
+## 7. Auto-Decisions
+
+| Decision | Tier | Rationale |
+|----------|------|-----------|
+| Place propagation inside the same `store.mutate` callback | small | Existing CAS pattern; alternative (separate mutate) would race with the currentId write. |
+| Default window W = 90 000 ms | small | parseCooldownTime rounds to minute → max 60 s skew; +30 s for jitter. Easy to tune via env. |
+| Trigger on second observation (existing sibling cooldownUntil match) rather than first | small | Required to avoid blind fan-out false-positives on isolated rate-limits — directly responsive to user's "don't break independent keys" constraint. |
+| Skip api_key + no-attachment + tombstoned + disableRotation siblings (both as match anchor and as propagation target) | small | Mirrors existing `isEligible` exclusions; keeps propagation set aligned with runtime selection set. Operator-opt-out (`disableRotation`) must remain authoritative end-to-end. |
+| Match-anchor source must be `'error_string' \| 'response_header'` | small | Direct upstream evidence only. `'manual'` is operator-set bookkeeping; `'inferred_shared'` is already propagated. Prevents a single inference from chaining across the whole pool. |
+| Trigger gate: `opts.knownReset === true` AND source ∈ direct-evidence set | small | Two coincidental 60-minute fallback cooldowns must NOT chain into a phantom "shared bucket". `knownReset` is `parsedCooldown !== null` at the caller. |
+| Iterate `snap.registry.slots` (not raw `snap.state` keys) | small | Slot-shape-aware filtering requires the slot record. Also incidentally shields against orphan state rows. |
+| New `RateLimitSource` arm `'inferred_shared'` rather than overloading `'error_string'` | small | Preserves debugging: in `data/cct-store.json` we can still tell which marks were direct vs inferred. UI distinction useful for operator trust. |
+| UI label `via inferred shared bucket` on the rate-limited line; the badge label remains `Cooldown <dur>` (source='manual' arm in `computeUsageCooldown`) since utilization is not at 100% | small | Keeps the badge utilization-driven (its existing invariant) and surfaces the inference signal where it belongs (the rate-limited diagnostic line). |
+| Window env override parses with `parseInt(_, 10)`, falls back to default on NaN or ≤0 | small | Existing pattern in the codebase; avoid letting bad config silently set a 0 ms window. |
+
+All listed decisions have switching cost ≤ small (≤ 20 lines or following an existing pattern). Per Decision Gate: autonomous decision + record. No user ask required.
+
+## 8. Open Questions
+None remaining for the spec phase. Implementation phase will need to choose:
+- Exact log message format for the propagation event (matches the existing `rotateOnRateLimit` log style — small switching cost, autonomous).
+- Whether to emit a metric counter (`rotateOnRateLimit_inferred_shared_count`). Punted to follow-up if the codebase exposes a metrics pipe; otherwise log-only is fine.
+
+## 9. Spec Changelog
+- 2026-04-30: Initial creation.
+
+## 10. Next Step
+→ Proceed with vertical trace via `stv:trace docs/cct-shared-bucket-cooldown-propagation/spec.md`.

--- a/docs/cct-shared-bucket-cooldown-propagation/trace.md
+++ b/docs/cct-shared-bucket-cooldown-propagation/trace.md
@@ -1,0 +1,433 @@
+# CCT Shared-Bucket Cooldown Propagation — Vertical Trace
+
+> STV Trace | Created: 2026-04-30
+> Spec: docs/cct-shared-bucket-cooldown-propagation/spec.md
+
+This feature has no HTTP surface. The "API Entry" rows describe the runtime function entry that callers reach; the rest of the 7-section format applies as written.
+
+## Table of Contents
+1. [Scenario 1 — First 429: only active slot marked](#scenario-1)
+2. [Scenario 2 — Second 429 within window: propagate to siblings](#scenario-2)
+3. [Scenario 3 — Second 429 outside window: no propagation](#scenario-3)
+4. [Scenario 4 — Sibling already in future cooldown: no overwrite](#scenario-4)
+5. [Scenario 5 — Ineligible siblings (api_key / no-attachment / tombstoned / disableRotation): skipped](#scenario-5)
+6. [Scenario 6 — Window env override (`CCT_SHARED_BUCKET_WINDOW_MS`)](#scenario-6)
+7. [Scenario 7 — UI label `via inferred shared bucket`](#scenario-7)
+8. [Scenario 8 — Cascade end-to-end: exactly 2 calls before all marked](#scenario-8)
+9. [Scenario 9 — `knownReset === false` (60-min fallback) does NOT trigger propagation](#scenario-9)
+10. [Scenario 10 — Sibling source `'manual'` / `'inferred_shared'` cannot anchor a match](#scenario-10)
+11. [Scenario 11 — `disableRotation: true` sibling skipped both as anchor and target](#scenario-11)
+12. [Scenario 12 — `tryRotateToken` plumbs `knownReset` correctly](#scenario-12)
+
+---
+
+## Scenario 1 — First 429: only active slot marked
+
+### 1. API Entry
+- Runtime function: `TokenManager.rotateOnRateLimit(reason, opts)`
+- Caller: `src/slack/pipeline/stream-executor.ts:2023 tryRotateToken`
+- Auth: N/A (internal)
+
+### 2. Input
+- `reason: string` (e.g., `"stream-executor rate-limit on slot=ai2"`)
+- `opts: { source: 'error_string', cooldownMinutes: number, knownReset: true }`
+- Snapshot precondition: `snap.registry.activeKeyId = currentId`. **No sibling has a future `cooldownUntil`.**
+
+### 3. Layer Flow
+#### 3a. Entry — `rotateOnRateLimit` (`src/token-manager.ts:732`)
+- `nowMs = Date.now()`, `nowIso = new Date(nowMs).toISOString()`
+- `cooldownMs = (opts.cooldownMinutes ?? DEFAULT_COOLDOWN_MS/60000) * 60000`
+- `cooldownUntilIso = new Date(nowMs + cooldownMs).toISOString()`
+- `windowMs = resolveSharedBucketWindowMs(process.env.CCT_SHARED_BUCKET_WINDOW_MS)`
+
+#### 3b. Mutate transaction (`store.mutate(snap => …)`)
+- `currentId = snap.registry.activeKeyId`
+- Mutate `snap.state[currentId]` exactly as today: `rateLimitedAt`, `rateLimitSource = 'error_string'`, `cooldownUntil = cooldownUntilIso`.
+- **Trigger gate**: only call propagation helper when `opts.knownReset === true` AND `opts.source ∈ {'error_string', 'response_header'}`. Otherwise skip directly to rotation.
+- **NEW**: when gate passes — call `propagateInferredSharedCooldownIfMatched(snap, anchorMs = nowMs + cooldownMs, nowIso, windowMs, currentId)`.
+  - Inside helper, iterate `snap.registry.slots` (NOT raw `snap.state`):
+    - Skip slot K if `K.kind === 'api_key'`.
+    - Skip slot K if `K.kind === 'cct'` and `K.oauthAttachment === undefined`.
+    - Skip slot K if `K.disableRotation === true`.
+    - Skip slot K if `K.keyId === currentId`.
+    - Resolve `stateK = snap.state[K.keyId]`. If absent (orphan), use synthesized default `{authState:'healthy', activeLeases:[]}` (mirrors existing rotateOnRateLimit pattern), but a propagation target with absent state is unusual — still allowed.
+    - Skip slot K if `stateK.tombstoned === true`.
+  - **Match-anchor scan** (subset of iteration above):
+    - Candidate is K iff `stateK.cooldownUntil` exists, `existingMs = new Date(stateK.cooldownUntil).getTime()` finite AND `> nowMs` (future), AND `stateK.rateLimitSource ∈ {'error_string', 'response_header'}` AND `|existingMs - anchorMs| <= windowMs`.
+    - If at least one K matches → `matched = true`.
+  - **Pristine state in this scenario**: no sibling has any cooldownUntil → no candidate matches → `matched === false` → helper returns without mutation.
+- Continue with existing rotation: pick next eligible slot via the existing for-loop.
+
+#### 3c. Persist (`store.mutate` commit)
+- CAS write: only `snap.state[currentId]` changed. No sibling touched.
+
+Transformation arrows:
+```
+opts.cooldownMinutes → cooldownMs → cooldownUntilIso → snap.state[currentId].cooldownUntil
+opts.source ('error_string') → snap.state[currentId].rateLimitSource
+nowIso → snap.state[currentId].rateLimitedAt
+```
+
+### 4. Side Effects
+- DB-equivalent (cct-store JSON file): UPDATE `state[currentId]` row only.
+- Log: `rotateOnRateLimit: <reason> source=error_string rotated=<next|none>` (existing).
+
+### 5. Error Paths
+| Condition | Behavior |
+|-----------|----------|
+| `snap.registry.activeKeyId` undefined | Existing early return — no mutation. |
+| Existing throw inside mutate | CAS retry per `CctStore.mutate` semantics. |
+
+### 6. Output
+- Returns `{ keyId, name } | null` for the rotated-to slot (existing return shape, unchanged).
+
+### 7. Observability
+- Existing single info log line. No additional log emitted in this scenario (no propagation triggered).
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-1: first 429 in pristine state marks only active slot` | Happy Path |
+
+---
+
+## Scenario 2 — Second 429 within window: propagate to siblings
+
+### 1. API Entry
+- Runtime: `TokenManager.rotateOnRateLimit(reason, opts)`
+
+### 2. Input
+- Same shape as Scenario 1; `opts.knownReset === true`.
+- Snapshot precondition: at least one sibling slot `M` (CCT + `oauthAttachment` + not tombstoned + not `disableRotation`) has `state[M].cooldownUntil = Y` where `|Y_ms - anchorMs| <= windowMs` AND `state[M].rateLimitSource ∈ {'error_string', 'response_header'}`.
+
+### 3. Layer Flow
+#### 3a. Entry
+- Identical to Scenario 1 (compute `anchorMs`, `nowIso`, `windowMs`). Trigger gate passes (knownReset + direct-evidence source).
+
+#### 3b. Mutate transaction
+- Mark `state[currentId]` as in Scenario 1.
+- `propagateInferredSharedCooldownIfMatched` finds match on sibling `M`.
+- For each *other* slot `K` in `snap.registry.slots` (excluding `currentId`):
+  - Skip if `K.kind === 'api_key'`.
+  - Skip if `K.kind === 'cct'` and `K.oauthAttachment === undefined`.
+  - Skip if `K.disableRotation === true`.
+  - Resolve `stateK = snap.state[K.keyId] ?? <healthy default>`.
+  - Skip if `stateK.tombstoned === true`.
+  - Skip if `stateK.cooldownUntil` exists and `new Date(stateK.cooldownUntil).getTime() > nowMs` (already future-cooled — Scenario 4 rule).
+  - Otherwise: `stateK.cooldownUntil = cooldownUntilIso`, `stateK.rateLimitedAt = nowIso`, `stateK.rateLimitSource = 'inferred_shared'`. Persist back to `snap.state[K.keyId]`.
+
+Transformation arrows:
+```
+anchorMs (= currentId's new cooldownUntilMs) → matched against every state[*].cooldownUntilMs within ±windowMs
+On match: cooldownUntilIso → snap.state[K].cooldownUntil
+          nowIso          → snap.state[K].rateLimitedAt
+          'inferred_shared' → snap.state[K].rateLimitSource
+```
+
+#### 3c. Persist
+- CAS write: `currentId` row plus N propagated rows.
+
+### 4. Side Effects
+- UPDATE `state[currentId]` AND `state[K1..Kn]` rows.
+- Log: existing `rotateOnRateLimit: …` line PLUS new line `rotateOnRateLimit inferred_shared: matchedSibling=<keyId> propagated=<count> windowMs=<W>`.
+
+### 5. Error Paths
+| Condition | Behavior |
+|-----------|----------|
+| `state[K]` is missing entirely (untouched slot) | Helper synthesizes `{ authState:'healthy', activeLeases:[] }` then writes — matches existing default-value pattern in `rotateOnRateLimit`. |
+| Slot `K` has `authState !== 'healthy'` | Marked anyway. Already runtime-ineligible; no harm. (See spec §5.5.) |
+
+### 6. Output
+- Same return shape as Scenario 1 (`{ keyId, name } | null`). After propagation, the rotation loop typically returns `null` (no eligible siblings remain) — that's the desired observable: stop rotating into a known-bad bucket.
+
+### 7. Observability
+- New log line shows propagation occurred. Useful for ops to confirm the heuristic fired and to count its rate.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-2: second 429 within window propagates to all eligible siblings with source=inferred_shared` | Happy Path |
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-2: propagated rateLimitedAt equals nowIso (per-call)` | Contract |
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-2: rotation returns null when all siblings just propagated` | Side-Effect |
+
+---
+
+## Scenario 3 — Second 429 outside window: no propagation
+
+### 1. API Entry
+- Runtime: `TokenManager.rotateOnRateLimit(reason, opts)`
+
+### 2. Input
+- Sibling `M` exists with `state[M].cooldownUntil = Y` where `|Y_ms - anchorMs| > windowMs`.
+
+### 3. Layer Flow
+- Match scan finds no entry within window → `propagateInferredSharedCooldownIfMatched` returns without mutating siblings.
+
+### 4. Side Effects
+- UPDATE `state[currentId]` only (same as Scenario 1).
+
+### 5. Error Paths
+- N/A.
+
+### 6. Output
+- Same as Scenario 1.
+
+### 7. Observability
+- No propagation log line emitted.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-3: second 429 outside window does NOT propagate (independent buckets)` | Sad Path |
+
+---
+
+## Scenario 4 — Sibling already in future cooldown: no overwrite
+
+### 1. Input
+- Match found on sibling `M`. Sibling `K` has its own `state[K].cooldownUntil > nowMs`.
+
+### 3. Layer Flow
+- During iteration, `K` is skipped because `existingFutureK > nowMs`. `state[K]` is left untouched.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-4: sibling already in future cooldown is not overwritten by propagation` | Side-Effect |
+
+---
+
+## Scenario 5 — Ineligible siblings (api_key / no-attachment / tombstoned / disableRotation): skipped
+
+### 1. Input
+- Match found. Slots present: `K_apikey` (`kind==='api_key'`), `K_setupOnly` (`kind==='cct'`, no `oauthAttachment`), `K_tombstone` (`state.tombstoned===true`), `K_disabled` (`disableRotation===true`), `K_eligible` (cct + attachment + healthy + rotation enabled).
+
+### 3. Layer Flow
+- Helper iterates `snap.registry.slots` excluding `currentId`. Filters apply both during the match-anchor scan and the propagation loop:
+  - `K_apikey` → skip on `kind === 'api_key'`.
+  - `K_setupOnly` → skip on `oauthAttachment === undefined`.
+  - `K_tombstone` → skip on `state.tombstoned`.
+  - `K_disabled` → skip on `disableRotation === true`.
+  - `K_eligible` → propagated.
+- Crucially: even if `K_apikey` / `K_setupOnly` / `K_tombstone` / `K_disabled` happens to carry a future `cooldownUntil` matching the new value, they are NOT counted as match anchors. Match must come from a fully-eligible CCT sibling.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-5a: api_key, no-attachment, tombstoned, disableRotation siblings are skipped as propagation targets` | Sad Path |
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-5b: ineligible siblings cannot serve as match anchors even with cooldownUntil within window` | Sad Path |
+
+---
+
+## Scenario 6 — Window env override
+
+### 1. Entry
+- `process.env.CCT_SHARED_BUCKET_WINDOW_MS = "300000"` (or invalid).
+
+### 3. Layer Flow
+- `resolveSharedBucketWindowMs(envValue)`:
+  - `parseInt(envValue, 10)` → `n`.
+  - If `Number.isFinite(n) && n > 0` → `windowMs = n` (300_000).
+  - Else log warning `'CCT_SHARED_BUCKET_WINDOW_MS invalid, falling back to 90000'`, `windowMs = 90_000`.
+- Helper uses resolved `windowMs` when matching siblings.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-6a: env CCT_SHARED_BUCKET_WINDOW_MS=300000 widens the match window` | Contract |
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-6b: invalid env value falls back to default 90000 with warning logged` | Sad Path |
+
+---
+
+## Scenario 7 — UI label for `inferred_shared` source
+
+### 1. API Entry
+- Runtime: `buildRateLimitedSegment(state, userTz, nowMs)` (`src/slack/cct/builder.ts:540`).
+
+### 2. Input
+- `state.rateLimitedAt = "2026-04-30T03:48:00.000Z"`, `state.rateLimitSource = 'inferred_shared'`.
+
+### 3. Layer Flow
+- `formatRateLimitedAt` formats timestamp as today.
+- Source label switch returns `' via inferred shared bucket'` for `'inferred_shared'`.
+- Returns concatenated `rate-limited <ts> via inferred shared bucket`.
+
+Transformation arrows:
+```
+state.rateLimitSource ('inferred_shared') → ' via inferred shared bucket'
+```
+
+### 4. Side Effects
+- None (pure render).
+
+### 6. Output
+- String fragment placed on the slot's secondary diagnostic line in the `/cct` Slack card.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/slack/cct/__tests__/builder.test.ts` | `buildRateLimitedSegment > rateLimitSource label` | `AC-7: rateLimitSource='inferred_shared' renders 'via inferred shared bucket'` | Happy Path |
+
+---
+
+## Scenario 8 — Cascade end-to-end: exactly 2 calls before all marked
+
+### 1. Setup
+- 6 CCT-with-attachment slots (`A..F`), all healthy, no cooldown.
+- Active = A.
+
+### 3. Layer Flow (sequence)
+1. CLI 429 #1 → `rotateOnRateLimit` for A:
+   - `state[A]` marked. No sibling match (pristine). No propagation. Rotate to B.
+2. CLI 429 #2 → `rotateOnRateLimit` for B:
+   - `state[B]` marked. Match found against `state[A].cooldownUntil` (within window because Anthropic returned same wall-clock). Propagate to `C, D, E, F`. Rotate to next eligible → none → return `null`.
+3. Subsequent calls (without `rotateOnRateLimit` re-entry from caller) — caller surfaces "no eligible slot, retry in <dur>" using the propagated cooldownUntil.
+
+### 4. Side Effects
+- After call #2: every slot `A..F` has `cooldownUntil` set. `A`/`B` source = `'error_string'`; `C..F` source = `'inferred_shared'`.
+
+### 6. Output
+- Call #1 returns `{ keyId: B.keyId, name: B.name }`.
+- Call #2 returns `null` (no eligible after propagation).
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-9: 6-slot cascade collapses after 2 rotateOnRateLimit calls; remaining 4 marked inferred_shared` | Side-Effect |
+
+---
+
+## Scenario 9 — `knownReset === false` (60-min fallback) does NOT trigger propagation
+
+### 1. Input
+- `opts: { source: 'error_string', cooldownMinutes: 60, knownReset: false }`
+- Snapshot precondition: a sibling has a future cooldownUntil within ±W ms whose own source ∈ direct-evidence.
+
+### 3. Layer Flow
+- `state[currentId]` marked normally (cooldownUntil = now + 60min).
+- Trigger gate: `opts.knownReset === false` → propagation helper is NOT invoked. Mutate falls straight through to rotation.
+
+### 4. Side Effects
+- Only `state[currentId]` updated. No log line for inferred_shared. Sibling state unchanged.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-10: knownReset=false suppresses propagation even when a within-window match exists (prevents two coincidental 60m fallbacks chaining)` | Sad Path |
+
+---
+
+## Scenario 10 — Sibling source `'manual'` / `'inferred_shared'` cannot anchor a match
+
+### 1. Input — Variant A (manual sibling)
+- `opts.knownReset === true`.
+- Sibling `M` has `state[M].cooldownUntil` within ±W ms of new value, but `state[M].rateLimitSource === 'manual'`.
+
+### 1. Input — Variant B (inferred_shared sibling)
+- Same as A but `state[M].rateLimitSource === 'inferred_shared'`.
+
+### 3. Layer Flow
+- Helper iteration reaches `M`.
+- Match-anchor scan rejects `M` because its source is not in `{'error_string', 'response_header'}`.
+- No other sibling matches → `matched === false` → no propagation.
+
+### 4. Side Effects
+- Only `state[currentId]` mutated. Sibling state unchanged.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-11a: sibling rateLimitSource='manual' cannot anchor a match` | Sad Path |
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-11b: sibling rateLimitSource='inferred_shared' cannot anchor a match (no chaining)` | Sad Path |
+
+---
+
+## Scenario 11 — `disableRotation: true` sibling skipped both as anchor and target
+
+### 1. Input
+- Slot `K_disabled` has `disableRotation: true`. Has `state[K_disabled].cooldownUntil` within window with source `error_string`.
+- Slot `K_other` is fully eligible, no cooldownUntil.
+
+### 3. Layer Flow
+- Match-anchor scan iterates slots. `K_disabled` is filtered out before the source/window checks → does not anchor a match.
+- Propagation loop iterates slots. `K_disabled` is filtered out → not assigned `inferred_shared` cooldown.
+- `K_other` is not anchored against (because the only candidate was filtered out) → no propagation occurs.
+
+### 4. Side Effects
+- Only `state[currentId]` mutated. `K_disabled` and `K_other` unchanged.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/__tests__/token-manager.test.ts` | `rotateOnRateLimit > inferred-shared propagation` | `AC-5c: disableRotation sibling cannot anchor a match nor be a propagation target` | Sad Path |
+
+---
+
+## Scenario 12 — `tryRotateToken` plumbs `knownReset` correctly
+
+### 1. API Entry
+- Runtime: `StreamExecutor.tryRotateToken(error, activeSlotAtQueryStart)` (`src/slack/pipeline/stream-executor.ts:2023`).
+
+### 2. Input — Variant A (parsed)
+- `error.message` contains `"resets 7pm"` → `parseCooldownTime` returns a `Date`.
+
+### 2. Input — Variant B (unparsed)
+- `error.message` is opaque (just `"rate limit exceeded"`) → `parseCooldownTime` returns `null`.
+
+### 3. Layer Flow
+```
+parsedCooldown = parseCooldownTime(errorText)
+knownReset     = parsedCooldown !== null
+cooldownMinutes = knownReset ? max(1, round((parsed - now) / 60_000)) : 60
+rotateOnRateLimit(reason, { source: 'error_string', cooldownMinutes, knownReset })
+```
+
+Transformation arrows:
+```
+parseCooldownTime(errorText) → parsedCooldown : Date | null
+parsedCooldown !== null      → knownReset : boolean
+{ ..., knownReset }          → opts.knownReset (consumed by rotateOnRateLimit's trigger gate)
+```
+
+### 4. Side Effects
+- Variant A: `rotateOnRateLimit` receives `knownReset: true` → propagation helper may run (depending on snapshot match state).
+- Variant B: `rotateOnRateLimit` receives `knownReset: false` → propagation helper is short-circuited.
+
+### Contract Tests (RED)
+| File | describe | it | Category |
+|------|----------|----|----------|
+| `src/slack/pipeline/__tests__/stream-executor.test.ts` | `tryRotateToken > knownReset plumbing` | `AC-12a: parsed cooldown text → rotateOnRateLimit called with knownReset:true` | Contract |
+| `src/slack/pipeline/__tests__/stream-executor.test.ts` | `tryRotateToken > knownReset plumbing` | `AC-12b: unparseable error → rotateOnRateLimit called with knownReset:false and cooldownMinutes:60` | Contract |
+
+---
+
+## Auto-Decisions
+
+| Decision | Tier | Rationale |
+|----------|------|-----------|
+| Combine all token-manager test cases under a single `describe('inferred-shared propagation')` block | tiny | Keeps the new contract co-located; mirrors the existing nested `describe` pattern (`describe('rotateOnRateLimit', () => {...})`). |
+| Use snapshot fixture builder pattern already present in `token-manager.test.ts` | tiny | `tm` factory already exists per existing tests. No new infrastructure. |
+| `formatRateLimitedAt` mock not needed — feed real timestamp + tz | tiny | Existing builder test fixtures use the same approach. |
+| `resolveSharedBucketWindowMs` is module-private, tested via behavior (window override observed through propagation match outcome) rather than direct export | tiny | Don't widen public surface for a test affordance; observe via integration. |
+
+## Implementation Status
+| Scenario | Trace | Tests (RED) | Status |
+|----------|-------|-------------|--------|
+| 1. First 429 — only active marked | done | RED | Ready for stv:work |
+| 2. Second 429 within window — propagate | done | RED | Ready for stv:work |
+| 3. Second 429 outside window — no propagation | done | RED | Ready for stv:work |
+| 4. Sibling already cooled — no overwrite | done | RED | Ready for stv:work |
+| 5. Ineligible siblings (api_key/no-attachment/tombstoned/disableRotation) skipped — both as anchor and target | done | RED | Ready for stv:work |
+| 6. Window env override | done | RED | Ready for stv:work |
+| 7. UI label rendering | done | RED | Ready for stv:work |
+| 8. Cascade end-to-end | done | RED | Ready for stv:work |
+| 9. knownReset=false suppresses propagation | done | RED | Ready for stv:work |
+| 10. Sibling source 'manual' / 'inferred_shared' cannot anchor | done | RED | Ready for stv:work |
+| 11. disableRotation sibling end-to-end skip | done | RED | Ready for stv:work |
+| 12. tryRotateToken plumbs knownReset correctly | done | RED | Ready for stv:work |
+
+## Changelog
+- 2026-04-30: Initial creation.
+
+## Next Step
+→ Proceed with implementation + Trace Verify via `stv:work docs/cct-shared-bucket-cooldown-propagation/trace.md`.

--- a/docs/dashboard-multi-instance.md
+++ b/docs/dashboard-multi-instance.md
@@ -1,0 +1,100 @@
+# Dashboard Multi-Instance Aggregation (#814)
+
+When two or more soma-work instances run on the **same host** (e.g.
+`oudwood-dev:33000` + `mac-mini-dev:33001`), each instance now publishes a
+heartbeat file under `~/.soma/instances/<port>.json` and the dashboard at
+`:33000/dashboard` automatically fans out to its siblings, merges their
+kanban boards, and tags every card with an environment badge.
+
+## Operator setup
+
+1. Set `INSTANCE_NAME` on **every** instance (e.g.
+   `INSTANCE_NAME=oudwood-dev`). Without it the heartbeat record falls
+   back to `${hostname}:${port}` — still functional, just less readable.
+2. Set the **same** `CONVERSATION_VIEWER_TOKEN` on every instance that
+   should aggregate together. The aggregator authenticates cross-port
+   GETs with `Authorization: Bearer ${CONVERSATION_VIEWER_TOKEN}` against
+   each sibling. Mismatched / missing tokens cause the dashboard to fall
+   back to self-only with a one-shot warn log.
+3. (rare) Set `SOMA_INSTANCE_DIR` to relocate the heartbeat directory.
+   Default: `~/.soma/instances`.
+
+That's it. No restart-ordering requirements, no leader election. Each
+instance writes its own heartbeat and discovers others independently.
+
+## What you see in the UI
+
+- Each card gets a colored `env-badge` in the meta row identifying the
+  owning instance. Hovering shows `<instanceName> (<host>:<port>)`.
+- The topbar **token usage** stat is the sum across instances. Hovering
+  the value reveals an env-grouped breakdown:
+  `oudwood-dev: 12K · mac-mini-dev: 8K · Total: 20K`. On touch
+  devices, tap the value to toggle.
+- Single-env case (one instance running, or `INSTANCE_NAME` unset) keeps
+  the topbar quiet — no tooltip, no badge — so single-instance deploys
+  are visually unchanged.
+
+## Failure modes (intentionally graceful)
+
+| Condition                                | Behaviour                                                   |
+| ---------------------------------------- | ----------------------------------------------------------- |
+| Sibling instance crashed (no heartbeat refresh for 30s) | Excluded from aggregation; treated as gone               |
+| Sibling instance returns 5xx / timeout / parse error    | Silently skipped; one `Sibling dashboard fetch failed` warn per `(port, failure-class)` per 60 s — distinct ports and distinct causes are independently surfaced so a flapping port doesn't silence a brand-new failure on another port |
+| `CONVERSATION_VIEWER_TOKEN` empty (this instance) | Self-only fallback; `…not set` warn fires once per process  |
+| `CONVERSATION_VIEWER_TOKEN` mismatch with sibling   | Sibling 401s; treated like any other sibling failure (per-port warn) |
+| Aggregator throws unexpectedly (e.g. mergeBoards bug) | `/api/dashboard/sessions` falls back to self-only and **errors** (with stack) so the bug is visible — endpoint never 500s |
+
+## Architecture
+
+Three modules:
+
+1. **`src/conversation/instance-registry.ts`** — heartbeat read/write.
+   Atomic write (`tmp + rename`) with `0600` perms. Stale records
+   (`lastSeen > 30s`) are filtered out by readers. The owner process
+   refreshes every 5s.
+
+2. **`src/conversation/aggregator.ts`** — sibling fan-out. Discovers via
+   `readAllInstances`, filters out self by both port AND pid (defends
+   against port reuse after a crash), fetches each sibling's
+   `/api/dashboard/sessions?selfOnly=true` (the `selfOnly=true` is the
+   recursion guard — siblings must not re-aggregate). Stamps each
+   sibling card's `environment` and rewrites the wire-format key as
+   `${instanceName}::${originalKey}` to avoid client-cache collisions.
+
+3. **`src/conversation/dashboard.ts`** — calls `fetchSiblingBoards` from
+   the existing `/api/dashboard/sessions` handler and merges the
+   results. Self cards get the local env stamp + composite key on the
+   way out via `sessionToKanban`. Action endpoints (`/stop`, `/close`,
+   ...) strip the `${selfInstance}::` prefix before resolving against
+   the local session map.
+
+## Lifecycle
+
+- `web-server.ts` calls `startHeartbeatLoop` immediately after
+  `server.listen` succeeds (so `activePort` is final), and
+  `removeHeartbeat` + `clearInterval` from `stopWebServer` so SIGTERM /
+  SIGINT cleans up registry entries before we tear down listeners.
+
+## Out of scope (for #814)
+
+- Cross-host network discovery (only same-machine multi-instance).
+- WebSocket merging — `ws://...` is still per-instance; the kanban
+  board polls every 30s and that's where sibling data refreshes.
+- Cross-instance action routing — clicking Stop on a sibling card from
+  `:33000` will fail because the action endpoint hits `:33000`'s
+  session map (which doesn't own the sibling session). Workaround:
+  open the sibling's dashboard directly. Tracked separately.
+
+## Testing
+
+- `src/conversation/__tests__/instance-registry.test.ts` — atomic write,
+  stale filter, 0600 perms, glob, lifecycle.
+- `src/conversation/__tests__/aggregator.test.ts` — self exclusion
+  (port+pid), `selfOnly=true` enforcement, 5xx / timeout / parse-error
+  resilience, token-missing fallback, board merge with env stamping.
+- `src/conversation/__tests__/dashboard-multi-instance.test.ts` —
+  end-to-end through the Fastify route; verifies composite keys, env
+  stamping on self/sibling, action-endpoint prefix stripping, and the
+  `selfOnly=true` short-circuit.
+- `src/conversation/__tests__/dashboard-multi-instance-frontend.test.ts`
+  — static structural assertions on the inline JS/CSS bundle.

--- a/src/__tests__/token-manager.test.ts
+++ b/src/__tests__/token-manager.test.ts
@@ -2860,4 +2860,500 @@ describe('TokenManager (AuthKey v2, keyId-keyed)', () => {
       expect(true).toBe(true);
     });
   });
+
+  // ── #801 — inferred-shared cooldown propagation ─────────
+  //
+  // Cross-account shared-bucket heuristic: when two CCT slots cool down on
+  // the same wall-clock reset within ±W ms (with both observations sourced
+  // from a parsed wall-clock — `error_string` / `response_header`, NOT the
+  // 60-minute fallback), propagate the cooldown to the rest of the eligible
+  // CCT-with-attachment pool. Eliminates N-1 wasted CLI spawns under a
+  // shared-bucket cascade. See `docs/cct-shared-bucket-cooldown-propagation/`.
+  describe('rotateOnRateLimit > inferred-shared propagation (#801)', () => {
+    async function addOauthSlot(
+      tm: import('../token-manager').TokenManager,
+      name: string,
+      accessTokenSeed: string,
+    ): Promise<{ keyId: string; name: string }> {
+      return await tm.addSlot({
+        name,
+        kind: 'oauth_credentials',
+        credentials: makeOAuthCreds({ accessToken: accessTokenSeed }),
+        acknowledgedConsumerTosRisk: true,
+      });
+    }
+
+    async function addSixOauthSlots(
+      tm: import('../token-manager').TokenManager,
+    ): Promise<Array<{ keyId: string; name: string }>> {
+      const out: Array<{ keyId: string; name: string }> = [];
+      for (const n of ['A', 'B', 'C', 'D', 'E', 'F']) {
+        out.push(await addOauthSlot(tm, n, `sk-ant-oat01-${n}`));
+      }
+      return out;
+    }
+
+    it('AC-1: first 429 in pristine state marks only active slot', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [a, b, c] = await addSixOauthSlots(tm);
+      // First call: A is active. No sibling has cooldownUntil → no match → no propagation.
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const snap = await store.load();
+      // A — marked normally as the active slot.
+      expect(snap.state[a.keyId].rateLimitSource).toBe('error_string');
+      expect(snap.state[a.keyId].cooldownUntil).toBeDefined();
+      // B, C — pristine.
+      expect(snap.state[b.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[b.keyId].cooldownUntil).toBeUndefined();
+      expect(snap.state[c.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[c.keyId].cooldownUntil).toBeUndefined();
+    });
+
+    it('AC-2a: second 429 within window propagates to all eligible siblings with source=inferred_shared', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [a, b, c, d, e, f] = await addSixOauthSlots(tm);
+      // 1st: marks A. Active rotates to B.
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      // 2nd: marks B. cooldownUntil_B is within ±90s of cooldownUntil_A → match → propagate to C,D,E,F.
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const snap = await store.load();
+      expect(snap.state[a.keyId].rateLimitSource).toBe('error_string');
+      expect(snap.state[b.keyId].rateLimitSource).toBe('error_string');
+      for (const sib of [c, d, e, f]) {
+        expect(snap.state[sib.keyId].rateLimitSource).toBe('inferred_shared');
+        expect(snap.state[sib.keyId].cooldownUntil).toBeDefined();
+      }
+    });
+
+    it('AC-2b: propagated rateLimitedAt and cooldownUntil equal the call values (per-call now)', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [, b, c] = await addSixOauthSlots(tm);
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const beforeMs = Date.now();
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const afterMs = Date.now();
+      const snap = await store.load();
+      // Propagated rateLimitedAt should be ~now of the 2nd call (between beforeMs and afterMs + slack).
+      const cAt = new Date(snap.state[c.keyId].rateLimitedAt as string).getTime();
+      expect(cAt).toBeGreaterThanOrEqual(beforeMs - 50);
+      expect(cAt).toBeLessThanOrEqual(afterMs + 50);
+      // Propagated cooldownUntil should equal B's cooldownUntil (the new anchor).
+      expect(snap.state[c.keyId].cooldownUntil).toBe(snap.state[b.keyId].cooldownUntil);
+      // SAME `nowIso` must be stamped on every propagation target — the spec
+      // (§5.1) computes it once per call. A regression that minted a fresh
+      // `new Date().toISOString()` per target would produce ms-level drift
+      // that `cAt ∈ [beforeMs-50, afterMs+50]` would silently tolerate.
+      expect(snap.state[c.keyId].rateLimitedAt).toBe(snap.state[b.keyId].rateLimitedAt);
+    });
+
+    it('AC-2d: |Δ| just outside window (5 min apart) does NOT propagate', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [a, , c] = await addSixOauthSlots(tm);
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      // Push A's cooldown 5 minutes earlier — well past the 90 s window.
+      await store.mutate((snap) => {
+        const aMs = new Date(snap.state[a.keyId].cooldownUntil as string).getTime();
+        snap.state[a.keyId].cooldownUntil = new Date(aMs - 5 * 60_000).toISOString();
+      });
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const snap = await store.load();
+      expect(snap.state[c.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[c.keyId].cooldownUntil).toBeUndefined();
+    });
+
+    it('AC-2f: missing state row on a sibling — synthesized default still receives propagation', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [, , c] = await addSixOauthSlots(tm);
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      // Simulate registry/state desync: drop C's state row entirely.
+      await store.mutate((snap) => {
+        delete snap.state[c.keyId];
+      });
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const snap = await store.load();
+      // Helper synthesizes `{ authState:'healthy', activeLeases:[] }` and writes propagation.
+      expect(snap.state[c.keyId]).toBeDefined();
+      expect(snap.state[c.keyId].rateLimitSource).toBe('inferred_shared');
+      expect(snap.state[c.keyId].cooldownUntil).toBeDefined();
+    });
+
+    it('AC-6c: env "90s" silently parsed as 90 ms is rejected — strict-integer guard', async () => {
+      // `Number.parseInt("90s", 10) === 90`. Without the strict-integer guard
+      // this would silently set a 90 ms window; with it, the value is rejected
+      // and the default 90_000 ms applies.
+      process.env.CCT_SHARED_BUCKET_WINDOW_MS = '90s';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const { mod, storeMod } = await importSut();
+        const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+        const tm = new mod.TokenManager(store);
+        await tm.init();
+        const [, , c] = await addSixOauthSlots(tm);
+        // Two consecutive calls — within the default 90 000 ms window propagation should
+        // fire. If the guard is missing the runtime window collapses to 90 ms and even
+        // back-to-back calls (a few ms apart) won't reliably satisfy `<= W`. We also
+        // assert the warning surfaced.
+        await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+        await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+        const snap = await store.load();
+        expect(snap.state[c.keyId].rateLimitSource).toBe('inferred_shared');
+        const allCalls = [
+          ...warnSpy.mock.calls.map((c) => c.join(' ')),
+          ...errorSpy.mock.calls.map((c) => c.join(' ')),
+        ].join('\n');
+        expect(allCalls).toMatch(/CCT_SHARED_BUCKET_WINDOW_MS invalid \(90s\)/);
+      } finally {
+        delete process.env.CCT_SHARED_BUCKET_WINDOW_MS;
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('AC-2c: rotation returns null when all siblings just propagated', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      await addSixOauthSlots(tm);
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const second = await tm.rotateOnRateLimit('second', {
+        source: 'error_string',
+        cooldownMinutes: 60,
+        knownReset: true,
+      });
+      // After call #2 every sibling A..F has a future cooldownUntil → no eligible left.
+      expect(second).toBeNull();
+    });
+
+    it('AC-3: second 429 outside window does NOT propagate (independent buckets)', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [a, b, c, d] = await addSixOauthSlots(tm);
+      // Mark A first.
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      // Push A's cooldown far away (outside any reasonable window).
+      await store.mutate((snap) => {
+        snap.state[a.keyId].cooldownUntil = new Date(Date.now() + 10 * 60 * 60 * 1000).toISOString();
+      });
+      // Active is now B. Call rotate on B with cooldownMinutes:60 — B's cooldown
+      // is ~60min from now; A's is ~10h from now → outside ±W ms.
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const snap = await store.load();
+      expect(snap.state[b.keyId].rateLimitSource).toBe('error_string');
+      // C, D pristine — no propagation.
+      expect(snap.state[c.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[c.keyId].cooldownUntil).toBeUndefined();
+      expect(snap.state[d.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[d.keyId].cooldownUntil).toBeUndefined();
+    });
+
+    it('AC-4: sibling already in future cooldown is not overwritten by propagation', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [, , c] = await addSixOauthSlots(tm);
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      // Pre-seed C with its OWN future cooldown distinct from the anchor.
+      const preExistingC = new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
+      await store.mutate((snap) => {
+        snap.state[c.keyId].cooldownUntil = preExistingC;
+        snap.state[c.keyId].rateLimitSource = 'manual';
+        snap.state[c.keyId].rateLimitedAt = new Date().toISOString();
+      });
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const snap = await store.load();
+      // C must remain unchanged — its own cooldownUntil is intact.
+      expect(snap.state[c.keyId].cooldownUntil).toBe(preExistingC);
+      expect(snap.state[c.keyId].rateLimitSource).toBe('manual');
+    });
+
+    it('AC-5a: api_key + no-attachment + tombstoned siblings are skipped as propagation targets', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      // Two OAuth-attached slots (a active, b sibling that will be 2nd-cycle).
+      const a = await addOauthSlot(tm, 'a', 'sk-ant-oat01-a');
+      const b = await addOauthSlot(tm, 'b', 'sk-ant-oat01-b');
+      // Ineligible siblings:
+      const apiKey = await tm.addSlot({ name: 'api', kind: 'api_key', value: 'sk-ant-api03-xxxxxxxxxxx' });
+      const setupOnly = await tm.addSlot({ name: 'setup', kind: 'setup_token', value: 'sk-ant-oat01-setuponly' });
+      const tomb = await addOauthSlot(tm, 'tomb', 'sk-ant-oat01-tomb');
+      await store.mutate((snap) => {
+        snap.state[tomb.keyId].tombstoned = true;
+      });
+      // One eligible target so we can verify propagation actually fired.
+      const target = await addOauthSlot(tm, 'target', 'sk-ant-oat01-target');
+
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+
+      const snap = await store.load();
+      // a and b — direct marks.
+      expect(snap.state[a.keyId].rateLimitSource).toBe('error_string');
+      expect(snap.state[b.keyId].rateLimitSource).toBe('error_string');
+      // target — propagated.
+      expect(snap.state[target.keyId].rateLimitSource).toBe('inferred_shared');
+      // ineligible siblings: untouched.
+      expect(snap.state[apiKey.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[apiKey.keyId].cooldownUntil).toBeUndefined();
+      expect(snap.state[setupOnly.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[setupOnly.keyId].cooldownUntil).toBeUndefined();
+      // tomb has tombstoned=true — must NOT receive propagation cooldown either.
+      expect(snap.state[tomb.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[tomb.keyId].cooldownUntil).toBeUndefined();
+    });
+
+    it('AC-5b: ineligible siblings cannot serve as match anchors even with cooldownUntil within window', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      // Active will be `active`. Sibling `target` is fully eligible.
+      // Sibling `setupOnly` (CCT no attachment) carries a cooldownUntil that
+      // would match within window — but is ineligible to anchor.
+      const active = await addOauthSlot(tm, 'active', 'sk-ant-oat01-active');
+      const setupOnly = await tm.addSlot({ name: 'setup', kind: 'setup_token', value: 'sk-ant-oat01-only' });
+      const target = await addOauthSlot(tm, 'target', 'sk-ant-oat01-target');
+
+      // Seed setupOnly with a cooldownUntil that would otherwise be within window
+      // of a 60-min cooldown (set to ~60min from now, source=error_string).
+      const fakeAnchor = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      await store.mutate((snap) => {
+        snap.state[setupOnly.keyId].cooldownUntil = fakeAnchor;
+        snap.state[setupOnly.keyId].rateLimitSource = 'error_string';
+        snap.state[setupOnly.keyId].rateLimitedAt = new Date().toISOString();
+      });
+
+      // active is currently active (first added). Call rotate with knownReset.
+      await tm.rotateOnRateLimit('hit', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+
+      const snap = await store.load();
+      // active marked normally.
+      expect(snap.state[active.keyId].rateLimitSource).toBe('error_string');
+      // target NOT propagated — setupOnly cannot anchor (no oauthAttachment).
+      expect(snap.state[target.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[target.keyId].cooldownUntil).toBeUndefined();
+      // setupOnly's pre-seeded state untouched by us in this code path.
+      expect(snap.state[setupOnly.keyId].cooldownUntil).toBe(fakeAnchor);
+    });
+
+    it('AC-5c: disableRotation sibling cannot anchor a match nor be a propagation target', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const active = await addOauthSlot(tm, 'active', 'sk-ant-oat01-active');
+      const disabled = await addOauthSlot(tm, 'disabled', 'sk-ant-oat01-disabled');
+      const target = await addOauthSlot(tm, 'target', 'sk-ant-oat01-target');
+      // Mark `disabled` as disableRotation=true with a within-window cooldownUntil
+      // that would otherwise anchor a match.
+      const fakeAnchor = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      await store.mutate((snap) => {
+        const d = snap.registry.slots.find((s) => s.keyId === disabled.keyId);
+        if (!d) throw new Error('disabled slot missing');
+        d.disableRotation = true;
+        snap.state[disabled.keyId].cooldownUntil = fakeAnchor;
+        snap.state[disabled.keyId].rateLimitSource = 'error_string';
+        snap.state[disabled.keyId].rateLimitedAt = new Date().toISOString();
+      });
+
+      await tm.rotateOnRateLimit('hit', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+
+      const snap = await store.load();
+      // active marked normally.
+      expect(snap.state[active.keyId].rateLimitSource).toBe('error_string');
+      // target NOT propagated (no eligible anchor).
+      expect(snap.state[target.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[target.keyId].cooldownUntil).toBeUndefined();
+      // disabled untouched (operator-opt-out preserved end-to-end).
+      expect(snap.state[disabled.keyId].cooldownUntil).toBe(fakeAnchor);
+    });
+
+    it('AC-6a: env CCT_SHARED_BUCKET_WINDOW_MS=300000 widens the match window', async () => {
+      process.env.CCT_SHARED_BUCKET_WINDOW_MS = '300000'; // 5 min
+      try {
+        const { mod, storeMod } = await importSut();
+        const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+        const tm = new mod.TokenManager(store);
+        await tm.init();
+        const [a, , c] = await addSixOauthSlots(tm);
+        // Mark A normally.
+        await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+        // Shift A's cooldown 4 minutes (240 000 ms) earlier — outside the
+        // default 90 s window but within the widened 5-min window.
+        await store.mutate((snap) => {
+          const aMs = new Date(snap.state[a.keyId].cooldownUntil as string).getTime();
+          snap.state[a.keyId].cooldownUntil = new Date(aMs - 240_000).toISOString();
+        });
+        // Active is B now. Call rotate.
+        await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+        const snap = await store.load();
+        // C must be propagated (within widened 300 000 ms window).
+        expect(snap.state[c.keyId].rateLimitSource).toBe('inferred_shared');
+        expect(snap.state[c.keyId].cooldownUntil).toBeDefined();
+      } finally {
+        delete process.env.CCT_SHARED_BUCKET_WINDOW_MS;
+      }
+    });
+
+    it('AC-6b: invalid env value falls back to default 90000 with warning logged', async () => {
+      process.env.CCT_SHARED_BUCKET_WINDOW_MS = 'not-a-number';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const { mod, storeMod } = await importSut();
+        const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+        const tm = new mod.TokenManager(store);
+        await tm.init();
+        const [a, , c] = await addSixOauthSlots(tm);
+        await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+        // Shift A's cooldown 4 minutes earlier — outside default 90 s.
+        await store.mutate((snap) => {
+          const aMs = new Date(snap.state[a.keyId].cooldownUntil as string).getTime();
+          snap.state[a.keyId].cooldownUntil = new Date(aMs - 240_000).toISOString();
+        });
+        await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+        const snap = await store.load();
+        // C must NOT be propagated (env was invalid → fallback to 90s window → outside).
+        expect(snap.state[c.keyId].rateLimitSource).toBeUndefined();
+        expect(snap.state[c.keyId].cooldownUntil).toBeUndefined();
+        // Warning surfaced to console (the project's Logger funnels through console).
+        const allCalls = [
+          ...warnSpy.mock.calls.map((c) => c.join(' ')),
+          ...errorSpy.mock.calls.map((c) => c.join(' ')),
+        ].join('\n');
+        expect(allCalls).toMatch(/CCT_SHARED_BUCKET_WINDOW_MS/);
+      } finally {
+        delete process.env.CCT_SHARED_BUCKET_WINDOW_MS;
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('AC-9: 6-slot cascade collapses after exactly 2 rotateOnRateLimit calls; 3rd is no-op', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const all = await addSixOauthSlots(tm);
+      // Two cascade calls.
+      const r1 = await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const r2 = await tm.rotateOnRateLimit('second', {
+        source: 'error_string',
+        cooldownMinutes: 60,
+        knownReset: true,
+      });
+      expect(r1).not.toBeNull();
+      // After call #2 the pool is exhausted — exactly 2 calls is the AC-9 invariant.
+      // (A regression that propagated on the FIRST call would also leave r2 === null
+      // but the snapshot would show all 6 slots already cooled before r2 fires; the
+      // r1 !== null assertion above pins that the FIRST call still rotated to a sibling.)
+      expect(r2).toBeNull();
+      const snap2 = await store.load();
+      const cooled2 = Object.values(snap2.state).filter((s) => s.cooldownUntil).length;
+      expect(cooled2).toBe(6);
+      // 3rd call must be a true no-op for the propagation pool — every healthy
+      // sibling already carries a future cooldown, so AC-4 forbids overwrites.
+      // (The active slot's own cooldownUntil is re-stamped by the direct-mark
+      // path on every call — that's pre-#801 behavior; the AC-9 invariant is
+      // about the propagated siblings, not the active slot.)
+      const r3 = await tm.rotateOnRateLimit('third', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      expect(r3).toBeNull();
+      const snap3 = await store.load();
+      // Sources: first two stay error_string, last four stay inferred_shared
+      // (NOT promoted to error_string by the 3rd call).
+      expect(snap3.state[all[0].keyId].rateLimitSource).toBe('error_string');
+      expect(snap3.state[all[1].keyId].rateLimitSource).toBe('error_string');
+      for (let i = 2; i < 6; i++) {
+        expect(snap3.state[all[i].keyId].rateLimitSource).toBe('inferred_shared');
+        expect(snap3.state[all[i].keyId].cooldownUntil).toBeDefined();
+      }
+      // AC-4: propagation siblings (i ∈ 2..5) are NOT overwritten by call #3.
+      // Slot all[1] is the active slot at call #3 (pinned by call #1 → no eligible
+      // rotation in #2 → activeKeyId stays on all[1]) so its cooldownUntil gets
+      // re-stamped by the direct-mark path; we explicitly exclude it.
+      for (let i = 2; i < 6; i++) {
+        expect(snap3.state[all[i].keyId].cooldownUntil).toBe(snap2.state[all[i].keyId].cooldownUntil);
+      }
+      // Slot all[0] was the active slot at call #1; after call #1 active rotated
+      // to all[1] → all[0] is a sibling for calls #2 and #3. Its cooldownUntil
+      // was last set by call #1's direct-mark and NOT overwritten by call #2's
+      // propagation (AC-4) nor by call #3 (still in future).
+      expect(snap3.state[all[0].keyId].cooldownUntil).toBe(snap2.state[all[0].keyId].cooldownUntil);
+    });
+
+    it('AC-10: knownReset=false suppresses propagation even when a within-window match exists', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [, b, c] = await addSixOauthSlots(tm);
+      // First call seeds A's cooldown (knownReset:true, source=error_string).
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      // Second call has knownReset:false (caller's parseCooldownTime returned null).
+      // A's cooldownUntil is within window but trigger gate must reject.
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: false });
+      const snap = await store.load();
+      // B marked normally, but no propagation to C.
+      expect(snap.state[b.keyId].rateLimitSource).toBe('error_string');
+      expect(snap.state[c.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[c.keyId].cooldownUntil).toBeUndefined();
+    });
+
+    it('AC-11a: sibling rateLimitSource=manual cannot anchor a match', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [a, , c] = await addSixOauthSlots(tm);
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      // Re-stamp A as manual.
+      await store.mutate((snap) => {
+        snap.state[a.keyId].rateLimitSource = 'manual';
+      });
+      // 2nd call: A has cooldownUntil within window but its source is 'manual' → cannot anchor.
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const snap = await store.load();
+      expect(snap.state[c.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[c.keyId].cooldownUntil).toBeUndefined();
+    });
+
+    it('AC-11b: sibling rateLimitSource=inferred_shared cannot anchor a match (no chaining)', async () => {
+      const { mod, storeMod } = await importSut();
+      const store = new storeMod.CctStore(path.join(tmp, 'cct-store.json'));
+      const tm = new mod.TokenManager(store);
+      await tm.init();
+      const [a, , c] = await addSixOauthSlots(tm);
+      await tm.rotateOnRateLimit('first', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      // Re-stamp A as inferred_shared.
+      await store.mutate((snap) => {
+        snap.state[a.keyId].rateLimitSource = 'inferred_shared';
+      });
+      // 2nd call: A's cooldownUntil within window but source 'inferred_shared' cannot anchor.
+      await tm.rotateOnRateLimit('second', { source: 'error_string', cooldownMinutes: 60, knownReset: true });
+      const snap = await store.load();
+      expect(snap.state[c.keyId].rateLimitSource).toBeUndefined();
+      expect(snap.state[c.keyId].cooldownUntil).toBeUndefined();
+    });
+  });
 });

--- a/src/cct-store/types.ts
+++ b/src/cct-store/types.ts
@@ -25,7 +25,22 @@ import type { AuthKey } from '../auth/auth-key';
 
 export type AuthState = 'healthy' | 'refresh_failed' | 'revoked';
 
-export type RateLimitSource = 'response_header' | 'error_string' | 'manual';
+/**
+ * Where the rate-limit signal came from.
+ *
+ * - `response_header` — direct upstream evidence (parsed from rate-limit headers).
+ * - `error_string`    — direct upstream evidence (parsed from a 429 error body).
+ * - `manual`          — operator-set bookkeeping (no upstream signal).
+ * - `inferred_shared` — propagated from a sibling slot that was directly
+ *                      rate-limited at the same wall-clock reset (the
+ *                      cross-account shared-bucket heuristic; see
+ *                      `docs/cct-shared-bucket-cooldown-propagation/`).
+ *
+ * Only the two "direct evidence" arms can anchor a shared-bucket match —
+ * `manual` and `inferred_shared` are deliberately excluded so a single
+ * inference cannot chain across the whole pool.
+ */
+export type RateLimitSource = 'response_header' | 'error_string' | 'manual' | 'inferred_shared';
 
 export interface Lease {
   leaseId: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -177,6 +177,15 @@ export const config = {
     viewerPort: process.env.CONVERSATION_VIEWER_PORT ? parseInt(process.env.CONVERSATION_VIEWER_PORT, 10) : 0,
     viewerUrl: process.env.CONVERSATION_VIEWER_URL || '',
     viewerToken: process.env.CONVERSATION_VIEWER_TOKEN || '',
+    /**
+     * Operator-supplied label for this instance — surfaced as the
+     * environment badge on dashboard cards (#814) and used as the
+     * key prefix for cross-instance session aggregation. Empty
+     * string is the "not configured" sentinel; `web-server.ts`
+     * falls back to `${hostname}:${port}` at startup so every
+     * heartbeat record has a non-empty `instanceName`.
+     */
+    instanceName: process.env.INSTANCE_NAME || '',
   },
   oauth: {
     google: {

--- a/src/conversation/__tests__/aggregator.test.ts
+++ b/src/conversation/__tests__/aggregator.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ──
+
+const mockConfig = {
+  conversation: {
+    viewerToken: 'shared-token',
+    instanceName: 'self-instance',
+  },
+};
+
+vi.mock('../../config', () => ({ config: mockConfig }));
+
+const mockReadAllInstances = vi.fn();
+
+vi.mock('../instance-registry', () => ({
+  readAllInstances: () => mockReadAllInstances(),
+}));
+
+// ── Module under test ──
+
+let aggregator: typeof import('../aggregator');
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockConfig.conversation.viewerToken = 'shared-token';
+  mockConfig.conversation.instanceName = 'self-instance';
+  mockReadAllInstances.mockReset();
+  aggregator = await import('../aggregator');
+  // Reset the one-shot warn flag between tests so each case gets a fresh
+  // observation of "would this warn?" behaviour.
+  if (typeof (aggregator as any).__resetWarnFlagForTests === 'function') {
+    (aggregator as any).__resetWarnFlagForTests();
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Helper: create a fetch stub that responds per-URL
+function makeFetchStub(handlers: Record<string, () => Promise<Response> | Response>) {
+  return vi.fn(async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (url.includes(pattern)) {
+        return handler();
+      }
+    }
+    throw new Error('No handler for URL: ' + url);
+  });
+}
+
+// ── Tests ──
+
+describe('aggregator: shouldAggregate', () => {
+  it('returns false when selfOnly query flag is set', () => {
+    expect(aggregator.shouldAggregate({ selfOnly: true, viewerToken: 't', siblingCount: 1 })).toBe(false);
+  });
+
+  it('returns false when no siblings are present', () => {
+    expect(aggregator.shouldAggregate({ selfOnly: false, viewerToken: 't', siblingCount: 0 })).toBe(false);
+  });
+
+  it('returns false when viewerToken is unset (no shared auth)', () => {
+    expect(aggregator.shouldAggregate({ selfOnly: false, viewerToken: '', siblingCount: 1 })).toBe(false);
+  });
+
+  it('returns true when sibling exists, viewerToken is set, and selfOnly is off', () => {
+    expect(aggregator.shouldAggregate({ selfOnly: false, viewerToken: 't', siblingCount: 1 })).toBe(true);
+  });
+});
+
+describe('aggregator: fetchSiblingBoards — self exclusion', () => {
+  it('excludes the entry whose port matches self', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33000, instanceName: 'self', host: '127.0.0.1', pid: 999, lastSeen: Date.now() },
+      { port: 33001, instanceName: 'mac-mini-dev', host: '127.0.0.1', pid: 1001, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () =>
+        new Response(JSON.stringify({ board: { working: [], waiting: [], idle: [], closed: [] } }), { status: 200 }),
+    });
+
+    const result = await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub).toHaveBeenCalledWith(expect.stringContaining(':33001'), expect.any(Object));
+    expect(result).toHaveLength(1);
+  });
+
+  it('excludes the entry whose pid matches self even on a different port', async () => {
+    // Defensive case: the heartbeat for our previous port is still on disk
+    // because shutdown didn't run — the port was reused for another sibling
+    // process, but our pid still appears. We must not call ourselves.
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33000, instanceName: 'self', host: '127.0.0.1', pid: 999, lastSeen: Date.now() },
+      { port: 33002, instanceName: 'leftover-self', host: '127.0.0.1', pid: 999, lastSeen: Date.now() },
+      { port: 33001, instanceName: 'mac-mini-dev', host: '127.0.0.1', pid: 1001, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () =>
+        new Response(JSON.stringify({ board: { working: [], waiting: [], idle: [], closed: [] } }), { status: 200 }),
+    });
+
+    await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub).toHaveBeenCalledWith(expect.stringContaining(':33001'), expect.any(Object));
+  });
+});
+
+describe('aggregator: fetchSiblingBoards — selfOnly enforcement (fan-out prevention)', () => {
+  it('always appends ?selfOnly=true to sibling URLs to prevent recursive fan-out', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'sib', host: '127.0.0.1', pid: 1001, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () =>
+        new Response(JSON.stringify({ board: { working: [], waiting: [], idle: [], closed: [] } }), { status: 200 }),
+    });
+
+    await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    const call = fetchStub.mock.calls[0];
+    const calledUrl: string = call[0];
+    expect(calledUrl).toMatch(/[?&]selfOnly=true(?:&|$)/);
+  });
+
+  it('passes the viewerToken via Authorization: Bearer', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'sib', host: '127.0.0.1', pid: 1001, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () =>
+        new Response(JSON.stringify({ board: { working: [], waiting: [], idle: [], closed: [] } }), { status: 200 }),
+    });
+
+    await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    const call = fetchStub.mock.calls[0] as any[];
+    const init = (call[1] || {}) as any;
+    const headers = init.headers || {};
+    const authHeader = headers.Authorization || headers.authorization;
+    expect(authHeader).toBe('Bearer shared-token');
+  });
+});
+
+describe('aggregator: fetchSiblingBoards — failure modes', () => {
+  it('skips siblings that return non-200 (silently)', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'good', host: '127.0.0.1', pid: 1, lastSeen: Date.now() },
+      { port: 33002, instanceName: 'bad', host: '127.0.0.1', pid: 2, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () =>
+        new Response(JSON.stringify({ board: { working: [{ key: 'k1' }], waiting: [], idle: [], closed: [] } }), {
+          status: 200,
+        }),
+      ':33002': () => new Response('boom', { status: 500 }),
+    });
+
+    const result = await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].instanceName).toBe('good');
+  });
+
+  it('skips siblings whose fetch rejects (timeout / network error)', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'good', host: '127.0.0.1', pid: 1, lastSeen: Date.now() },
+      { port: 33002, instanceName: 'dead', host: '127.0.0.1', pid: 2, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () =>
+        new Response(JSON.stringify({ board: { working: [], waiting: [], idle: [], closed: [] } }), { status: 200 }),
+      ':33002': () => Promise.reject(new Error('ECONNREFUSED')),
+    });
+
+    const result = await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].instanceName).toBe('good');
+  });
+
+  it('skips siblings whose body fails JSON parse', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'malformed', host: '127.0.0.1', pid: 1, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () => new Response('not-json', { status: 200 }),
+    });
+
+    const result = await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('aggregator: fetchSiblingBoards — empty / disabled cases', () => {
+  it('returns [] without any fetch when there are no siblings to call', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33000, instanceName: 'self', host: '127.0.0.1', pid: 999, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = vi.fn();
+
+    const result = await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] without fetching when viewerToken is empty (graceful fallback)', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'sib', host: '127.0.0.1', pid: 1, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = vi.fn();
+
+    const result = await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: '',
+      fetchImpl: fetchStub as any,
+    });
+
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('aggregator: per-(port, class) warn throttling (PR #815 review)', () => {
+  it('logs distinct sibling failures with different ports independently', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // We can't easily intercept the logger directly without leaking
+    // through module mocks; instead, observe by invoking fetch twice on
+    // distinct ports and asserting both produce a warn-emitting result
+    // (graceful — both return null). The actual rate-limit semantics are
+    // unit-tested via the same flag logic in __resetWarnFlagForTests.
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'a', host: '127.0.0.1', pid: 1, lastSeen: Date.now() },
+      { port: 33002, instanceName: 'b', host: '127.0.0.1', pid: 2, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () => new Response('boom', { status: 500 }),
+      ':33002': () => Promise.reject(new Error('ECONNREFUSED')),
+    });
+
+    const result = await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+
+    // Both siblings failed with distinct classes (http_status vs network_error).
+    // The throttle key is `${port}:${class}`, so each one is independently logged.
+    expect(result).toEqual([]);
+    warnSpy.mockRestore();
+  });
+
+  it('warn flag reset (test hook) lets a previously-throttled key warn again', async () => {
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'a', host: '127.0.0.1', pid: 1, lastSeen: Date.now() },
+    ]);
+
+    const fetchStub = makeFetchStub({
+      ':33001': () => new Response('boom', { status: 500 }),
+    });
+
+    // First call — warn fires (and is throttled for next 60s).
+    await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+    // Second call within same test — same key, throttled, no extra warn.
+    await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+    // After reset, the next call emits again.
+    (aggregator as any).__resetWarnFlagForTests();
+    const result3 = await aggregator.fetchSiblingBoards({
+      selfPort: 33000,
+      selfPid: 999,
+      viewerToken: 'shared-token',
+      fetchImpl: fetchStub as any,
+    });
+    // Sanity: still graceful (no throw).
+    expect(result3).toEqual([]);
+  });
+});
+
+describe('aggregator: mergeBoards', () => {
+  it('preserves self board first, then concatenates each sibling column', () => {
+    const self = {
+      board: {
+        working: [{ key: 'a' }],
+        waiting: [],
+        idle: [],
+        closed: [],
+      },
+    };
+    const siblingBoards = [
+      {
+        instanceName: 's1',
+        port: 33001,
+        host: '127.0.0.1',
+        board: { working: [{ key: 'b' }], waiting: [{ key: 'c' }], idle: [], closed: [] },
+      },
+    ];
+    const merged = aggregator.mergeBoards({
+      selfBoard: self.board,
+      selfEnv: { instanceName: 'self', port: 33000, host: '127.0.0.1' },
+      siblings: siblingBoards as any,
+    });
+    expect(merged.working.map((s: any) => s.key)).toEqual(['a', 's1::b']);
+    expect(merged.waiting.map((s: any) => s.key)).toEqual(['s1::c']);
+  });
+
+  it('stamps environment metadata on sibling sessions during merge', () => {
+    const self = {
+      board: { working: [], waiting: [], idle: [], closed: [] },
+    };
+    const siblingBoards = [
+      {
+        instanceName: 'mac-mini-dev',
+        port: 33001,
+        host: 'mac-mini.local',
+        board: {
+          working: [{ key: 'orig-key', title: 't' }],
+          waiting: [],
+          idle: [],
+          closed: [],
+        },
+      },
+    ];
+
+    const merged = aggregator.mergeBoards({
+      selfBoard: self.board,
+      selfEnv: { instanceName: 'self', port: 33000, host: '127.0.0.1' },
+      siblings: siblingBoards as any,
+    });
+
+    const card = merged.working[0] as any;
+    expect(card.environment).toEqual({
+      instanceName: 'mac-mini-dev',
+      port: 33001,
+      host: 'mac-mini.local',
+    });
+  });
+
+  it('uses composite key for sibling sessions (instance::originalKey) so collisions are impossible', () => {
+    const self = {
+      board: { working: [{ key: 'self::C1:t1' }], waiting: [], idle: [], closed: [] },
+    };
+    const siblings = [
+      {
+        instanceName: 'mac-mini-dev',
+        port: 33001,
+        host: '127.0.0.1',
+        board: {
+          working: [{ key: 'C1:t1' }], // raw key from sibling, same channel:thread coincidentally
+          waiting: [],
+          idle: [],
+          closed: [],
+        },
+      },
+    ];
+
+    const merged = aggregator.mergeBoards({
+      selfBoard: self.board,
+      selfEnv: { instanceName: 'self', port: 33000, host: '127.0.0.1' },
+      siblings: siblings as any,
+    });
+
+    const keys = merged.working.map((s: any) => s.key);
+    expect(keys).toContain('self::C1:t1');
+    expect(keys).toContain('mac-mini-dev::C1:t1');
+    expect(new Set(keys).size).toBe(keys.length); // no duplicates
+  });
+});

--- a/src/conversation/__tests__/dashboard-multi-instance-frontend.test.ts
+++ b/src/conversation/__tests__/dashboard-multi-instance-frontend.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Static structure tests for #814 — multi-instance dashboard frontend.
+ *
+ * Same pattern as `dashboard-topbar-mobile.test.ts` (read the rendered
+ * dashboard source, assert structural invariants). Cheap to run and
+ * catches regressions where someone refactors the inline JS/CSS bundle
+ * and accidentally drops a piece the multi-instance UI depends on.
+ *
+ * The actual DOM behaviour (badge colour, tooltip suppression on
+ * single-env, tap-toggle on touch) is exercised by Playwright dashboard
+ * tests; these tests only verify the bundle ships the bits.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const DASHBOARD_TS = readFileSync(join(__dirname, '..', 'dashboard.ts'), 'utf-8');
+
+describe('Dashboard multi-instance frontend (#814)', () => {
+  it('ships the 4-color env badge palette', () => {
+    expect(DASHBOARD_TS).toContain('#5DADE2');
+    expect(DASHBOARD_TS).toContain('#48C9B0');
+    expect(DASHBOARD_TS).toContain('#F4D03F');
+    expect(DASHBOARD_TS).toContain('#EC7063');
+  });
+
+  it('exposes getEnvBadgeColor for renderCard', () => {
+    expect(DASHBOARD_TS).toContain('function getEnvBadgeColor');
+  });
+
+  it('renderCard suppresses the env badge when only one env is in the cache', () => {
+    // The condition `_envCount() > 1` is the gate. Drop it and a
+    // single-instance deploy gets a meaningless badge on every card.
+    expect(DASHBOARD_TS).toContain('_envCount() > 1');
+  });
+
+  it('exposes a topbar tokens tooltip wrap with breakdown attribute', () => {
+    expect(DASHBOARD_TS).toContain('id="stat-tokens-wrap"');
+    expect(DASHBOARD_TS).toContain('id="stat-tokens-tooltip"');
+    expect(DASHBOARD_TS).toContain('data-has-breakdown');
+  });
+
+  it('mobile tap-toggle uses (hover: none) media query', () => {
+    expect(DASHBOARD_TS).toContain('@media (hover: none)');
+    expect(DASHBOARD_TS).toContain("matchMedia('(hover: none)')");
+  });
+
+  it('updateTokenStats suppresses the tooltip when fewer than 2 envs are present', () => {
+    expect(DASHBOARD_TS).toContain('envNames.length < 2');
+  });
+
+  it('CSS `.env-badge` rule is present in the inline style block', () => {
+    expect(DASHBOARD_TS).toContain('.card .card-meta .env-badge');
+  });
+
+  // PR #815 review #1 — sibling cards must not invite action clicks.
+  it('renderCard suppresses action buttons on sibling cards (env mismatch)', () => {
+    // The bundle must declare SELF_INSTANCE_NAME and the isSibling check.
+    expect(DASHBOARD_TS).toContain('SELF_INSTANCE_NAME');
+    expect(DASHBOARD_TS).toContain('s.environment.instanceName !== SELF_INSTANCE_NAME');
+    // The disabled placeholder uses the redirect arrow (\u2192) so the
+    // user sees `Stop -> mac-mini-dev` instead of a live button.
+    expect(DASHBOARD_TS).toContain('\\u2192');
+  });
+
+  it('renderDashboardPage injects SELF_INSTANCE_NAME from server config', () => {
+    // Source-line check that the constant comes from initSelfInstance,
+    // not a hardcoded null. Catches regressions where someone simplifies
+    // the template and drops the dynamic injection.
+    expect(DASHBOARD_TS).toContain('SELF_INSTANCE_NAME = ${initSelfInstance}');
+    expect(DASHBOARD_TS).toContain('initSelfInstance =');
+  });
+});

--- a/src/conversation/__tests__/dashboard-multi-instance.test.ts
+++ b/src/conversation/__tests__/dashboard-multi-instance.test.ts
@@ -1,0 +1,608 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ──
+
+const mockConfig = {
+  conversation: {
+    summaryModel: 'claude-haiku-4-20250414',
+    viewerHost: '127.0.0.1',
+    viewerPort: 0,
+    viewerUrl: '',
+    viewerToken: 'test-token',
+    instanceName: 'self-host',
+  },
+  oauth: {
+    google: { clientId: '', clientSecret: '' },
+    microsoft: { clientId: '', clientSecret: '' },
+    jwtSecret: '',
+    jwtExpiresIn: 604800,
+  },
+};
+
+vi.mock('../../config', () => ({ config: mockConfig }));
+vi.mock('../../env-paths', () => ({ IS_DEV: true, DATA_DIR: '/tmp/test-data' }));
+vi.mock('../recorder', () => ({
+  listConversations: vi.fn().mockResolvedValue([]),
+  getConversation: vi.fn().mockResolvedValue(null),
+  getTurnRawContent: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../viewer', () => ({
+  renderConversationListPage: vi.fn().mockReturnValue('<html></html>'),
+  renderConversationViewPage: vi.fn().mockReturnValue('<html></html>'),
+}));
+vi.mock('../../session-archive', () => ({
+  getArchiveStore: () => ({ listRecent: () => [] }),
+}));
+
+// Aggregator mock — we drive `fetchSiblingBoards` directly so each test
+// pins the cross-instance behaviour without a network shim.
+const mockFetchSiblingBoards = vi.fn();
+vi.mock('../aggregator', async () => {
+  const actual = await vi.importActual<typeof import('../aggregator')>('../aggregator');
+  return {
+    ...actual,
+    fetchSiblingBoards: (...args: any[]) => mockFetchSiblingBoards(...args),
+  };
+});
+
+// Instance registry mock — `/api/dashboard/sessions` pre-discovers siblings
+// (PR #815 review) before fetching, so each test must seed the registry to
+// match the sibling count it expects fetchSiblingBoards to be called for.
+const mockReadAllInstances = vi.fn();
+vi.mock('../instance-registry', async () => {
+  const actual = await vi.importActual<typeof import('../instance-registry')>('../instance-registry');
+  return {
+    ...actual,
+    readAllInstances: (...args: any[]) => mockReadAllInstances(...args),
+  };
+});
+
+const AUTH_HEADER = { Authorization: 'Bearer test-token' };
+
+describe('Dashboard multi-instance aggregation (#814)', () => {
+  let startWebServer: any;
+  let stopWebServer: any;
+  let injectWebServer: any;
+  let setDashboardSessionAccessor: any;
+  let setSelfInstanceEnv: any;
+  let __resetSelfInstanceEnvForTests: any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockFetchSiblingBoards.mockReset();
+    mockReadAllInstances.mockReset();
+    // Default: no siblings discovered — tests that exercise aggregation
+    // override per-case below.
+    mockReadAllInstances.mockResolvedValue([]);
+    mockConfig.conversation.viewerToken = 'test-token';
+    mockConfig.conversation.instanceName = 'self-host';
+
+    const webServer = await import('../web-server');
+    startWebServer = webServer.startWebServer;
+    stopWebServer = webServer.stopWebServer;
+    injectWebServer = webServer.injectWebServer;
+
+    const dashboard = await import('../dashboard');
+    setDashboardSessionAccessor = dashboard.setDashboardSessionAccessor;
+    setSelfInstanceEnv = dashboard.setSelfInstanceEnv;
+    __resetSelfInstanceEnvForTests = dashboard.__resetSelfInstanceEnvForTests;
+
+    await startWebServer({ listen: false });
+  });
+
+  afterEach(async () => {
+    if (__resetSelfInstanceEnvForTests) __resetSelfInstanceEnvForTests();
+    await stopWebServer();
+  });
+
+  it('composes session.key as `${instanceName}::${rawKey}` once self env is wired', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    const sessions = new Map<string, any>();
+    sessions.set('C1:t1', {
+      sessionId: 'sid1',
+      title: 'Working session',
+      ownerId: 'U1',
+      ownerName: 'Alice',
+      channelId: 'C1',
+      threadTs: 't1',
+      activityState: 'working',
+      state: 'MAIN',
+      lastActivity: new Date('2026-04-01T10:00:00Z'),
+    });
+    setDashboardSessionAccessor(() => sessions);
+
+    const res = await injectWebServer({
+      method: 'GET',
+      url: '/api/dashboard/sessions?selfOnly=true',
+      headers: AUTH_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.board.working).toHaveLength(1);
+    expect(body.board.working[0].key).toBe('self-host::C1:t1');
+  });
+
+  it('stamps environment metadata on self cards when env is wired', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    const sessions = new Map<string, any>();
+    sessions.set('C1:t1', {
+      sessionId: 'sid1',
+      ownerId: 'U1',
+      channelId: 'C1',
+      threadTs: 't1',
+      activityState: 'working',
+      state: 'MAIN',
+      lastActivity: new Date('2026-04-01T10:00:00Z'),
+    });
+    setDashboardSessionAccessor(() => sessions);
+
+    const res = await injectWebServer({
+      method: 'GET',
+      url: '/api/dashboard/sessions?selfOnly=true',
+      headers: AUTH_HEADER,
+    });
+
+    const body = JSON.parse(res.body);
+    expect(body.board.working[0].environment).toEqual({
+      instanceName: 'self-host',
+      port: 33000,
+      host: '127.0.0.1',
+    });
+  });
+
+  it('selfOnly=true bypasses the aggregator (no fan-out)', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    setDashboardSessionAccessor(() => new Map());
+
+    const res = await injectWebServer({
+      method: 'GET',
+      url: '/api/dashboard/sessions?selfOnly=true',
+      headers: AUTH_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockFetchSiblingBoards).not.toHaveBeenCalled();
+  });
+
+  it('aggregates sibling boards into self board when env is wired and siblings exist', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    const sessions = new Map<string, any>();
+    sessions.set('C1:t1', {
+      sessionId: 'sid1',
+      ownerId: 'U1',
+      channelId: 'C1',
+      threadTs: 't1',
+      activityState: 'working',
+      state: 'MAIN',
+      lastActivity: new Date('2026-04-01T10:00:00Z'),
+    });
+    setDashboardSessionAccessor(() => sessions);
+
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'mac-mini-dev', host: '127.0.0.1', pid: 1001, lastSeen: Date.now() },
+    ]);
+    mockFetchSiblingBoards.mockResolvedValue([
+      {
+        instanceName: 'mac-mini-dev',
+        port: 33001,
+        host: '127.0.0.1',
+        board: {
+          working: [
+            {
+              key: 'C9:t9',
+              title: 'Sibling working',
+              ownerId: 'U2',
+              channelId: 'C9',
+              activityState: 'working',
+              lastActivity: '2026-04-01T09:30:00Z',
+            },
+          ],
+          waiting: [],
+          idle: [],
+          closed: [],
+        },
+      },
+    ]);
+
+    const res = await injectWebServer({
+      method: 'GET',
+      url: '/api/dashboard/sessions',
+      headers: AUTH_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.board.working).toHaveLength(2);
+    // Self card preserved (composite key) first.
+    expect(body.board.working[0].key).toBe('self-host::C1:t1');
+    expect(body.board.working[0].environment.instanceName).toBe('self-host');
+    // Sibling card stamped with sibling env and composite key.
+    expect(body.board.working[1].key).toBe('mac-mini-dev::C9:t9');
+    expect(body.board.working[1].environment).toEqual({
+      instanceName: 'mac-mini-dev',
+      port: 33001,
+      host: '127.0.0.1',
+    });
+  });
+
+  it('falls back to self-only board when aggregator throws', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    const sessions = new Map<string, any>();
+    sessions.set('C1:t1', {
+      sessionId: 'sid1',
+      ownerId: 'U1',
+      channelId: 'C1',
+      threadTs: 't1',
+      activityState: 'working',
+      state: 'MAIN',
+      lastActivity: new Date('2026-04-01T10:00:00Z'),
+    });
+    setDashboardSessionAccessor(() => sessions);
+
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'mac-mini-dev', host: '127.0.0.1', pid: 1001, lastSeen: Date.now() },
+    ]);
+    mockFetchSiblingBoards.mockRejectedValue(new Error('boom'));
+
+    const res = await injectWebServer({
+      method: 'GET',
+      url: '/api/dashboard/sessions',
+      headers: AUTH_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.board.working).toHaveLength(1);
+    expect(body.board.working[0].key).toBe('self-host::C1:t1');
+  });
+
+  it('sibling-instance card with same channelId:threadTs as self does not collide on key', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    const sessions = new Map<string, any>();
+    sessions.set('C1:t1', {
+      sessionId: 'sid1',
+      ownerId: 'U1',
+      channelId: 'C1',
+      threadTs: 't1',
+      activityState: 'working',
+      state: 'MAIN',
+      lastActivity: new Date('2026-04-01T10:00:00Z'),
+    });
+    setDashboardSessionAccessor(() => sessions);
+
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'mac-mini-dev', host: '127.0.0.1', pid: 1001, lastSeen: Date.now() },
+    ]);
+    mockFetchSiblingBoards.mockResolvedValue([
+      {
+        instanceName: 'mac-mini-dev',
+        port: 33001,
+        host: '127.0.0.1',
+        board: {
+          working: [
+            {
+              key: 'C1:t1', // identical raw key on the sibling
+              title: 'Sibling collision attempt',
+              ownerId: 'U2',
+              channelId: 'C1',
+              activityState: 'working',
+              lastActivity: '2026-04-01T09:30:00Z',
+            },
+          ],
+          waiting: [],
+          idle: [],
+          closed: [],
+        },
+      },
+    ]);
+
+    const res = await injectWebServer({
+      method: 'GET',
+      url: '/api/dashboard/sessions',
+      headers: AUTH_HEADER,
+    });
+
+    const body = JSON.parse(res.body);
+    const keys = body.board.working.map((s: any) => s.key).sort();
+    expect(keys).toEqual(['mac-mini-dev::C1:t1', 'self-host::C1:t1']);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('action endpoint /stop strips the self-instance prefix and looks up the raw key', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    const sessions = new Map<string, any>();
+    sessions.set('C1:t1', {
+      sessionId: 'sid1',
+      ownerId: 'U1',
+      channelId: 'C1',
+      threadTs: 't1',
+      activityState: 'working',
+      state: 'MAIN',
+      lastActivity: new Date(),
+    });
+    setDashboardSessionAccessor(() => sessions);
+
+    const stopHandler = vi.fn().mockResolvedValue(undefined);
+    const dashboard = await import('../dashboard');
+    dashboard.setDashboardStopHandler(stopHandler);
+
+    const res = await injectWebServer({
+      method: 'POST',
+      url: '/api/dashboard/session/' + encodeURIComponent('self-host::C1:t1') + '/stop',
+      headers: AUTH_HEADER,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(stopHandler).toHaveBeenCalledWith('C1:t1');
+  });
+
+  // PR #815 review #2 — every action endpoint that takes :key must strip the
+  // self-instance prefix AND reject foreign prefixes with 409. Missing the
+  // strip on any one endpoint silently degraded a sibling-routed action;
+  // missing the foreign-prefix reject silently 4xxed (or worse, 200/no-op).
+  describe('action endpoint prefix handling — all 7 endpoints', () => {
+    type EndpointSpec = {
+      verb: string;
+      path: string;
+      bodyForOk?: any;
+      handler: 'stop' | 'close' | 'trash' | 'command' | 'choice' | 'multi' | 'submit';
+    };
+    const endpoints: EndpointSpec[] = [
+      { verb: 'POST', path: 'stop', handler: 'stop' },
+      { verb: 'POST', path: 'close', handler: 'close' },
+      { verb: 'POST', path: 'trash', handler: 'trash' },
+      { verb: 'POST', path: 'command', bodyForOk: { message: 'hi' }, handler: 'command' },
+      {
+        verb: 'POST',
+        path: 'answer-choice',
+        bodyForOk: { choiceId: 'a', label: 'A', question: 'q?' },
+        handler: 'choice',
+      },
+      {
+        verb: 'POST',
+        path: 'answer-multi-choice',
+        bodyForOk: { selections: { q1: { choiceId: 'a', label: 'A' } } },
+        handler: 'multi',
+      },
+      { verb: 'POST', path: 'submit-recommended', handler: 'submit' },
+    ];
+
+    for (const ep of endpoints) {
+      it(`${ep.path}: strips self-instance prefix and routes to local handler`, async () => {
+        setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+        const sessions = new Map<string, any>();
+        sessions.set('C1:t1', {
+          sessionId: 'sid1',
+          ownerId: 'U1',
+          channelId: 'C1',
+          threadTs: 't1',
+          activityState: 'waiting',
+          state: 'MAIN',
+          lastActivity: new Date(),
+        });
+        setDashboardSessionAccessor(() => sessions);
+
+        const dashboard = await import('../dashboard');
+        const handler = vi.fn().mockResolvedValue(undefined);
+        switch (ep.handler) {
+          case 'stop':
+            dashboard.setDashboardStopHandler(handler);
+            break;
+          case 'close':
+            dashboard.setDashboardCloseHandler(handler);
+            break;
+          case 'trash':
+            dashboard.setDashboardTrashHandler(handler);
+            break;
+          case 'command':
+            dashboard.setDashboardCommandHandler(handler);
+            break;
+          case 'choice':
+            dashboard.setDashboardChoiceAnswerHandler(handler);
+            break;
+          case 'multi':
+            dashboard.setDashboardMultiChoiceAnswerHandler(handler);
+            break;
+          case 'submit':
+            dashboard.setDashboardSubmitRecommendedHandler(handler);
+            break;
+        }
+
+        const res = await injectWebServer({
+          method: ep.verb,
+          url: `/api/dashboard/session/${encodeURIComponent('self-host::C1:t1')}/${ep.path}`,
+          headers: AUTH_HEADER,
+          payload: ep.bodyForOk,
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(handler).toHaveBeenCalled();
+        // First arg is always the resolved local key.
+        expect(handler.mock.calls[0][0]).toBe('C1:t1');
+      });
+
+      it(`${ep.path}: returns 409 for a foreign-instance prefix (no silent passthrough)`, async () => {
+        setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+        const sessions = new Map<string, any>();
+        sessions.set('C1:t1', {
+          sessionId: 'sid1',
+          ownerId: 'U1',
+          channelId: 'C1',
+          threadTs: 't1',
+          activityState: 'waiting',
+          state: 'MAIN',
+          lastActivity: new Date(),
+        });
+        setDashboardSessionAccessor(() => sessions);
+
+        const dashboard = await import('../dashboard');
+        const handler = vi.fn().mockResolvedValue(undefined);
+        switch (ep.handler) {
+          case 'stop':
+            dashboard.setDashboardStopHandler(handler);
+            break;
+          case 'close':
+            dashboard.setDashboardCloseHandler(handler);
+            break;
+          case 'trash':
+            dashboard.setDashboardTrashHandler(handler);
+            break;
+          case 'command':
+            dashboard.setDashboardCommandHandler(handler);
+            break;
+          case 'choice':
+            dashboard.setDashboardChoiceAnswerHandler(handler);
+            break;
+          case 'multi':
+            dashboard.setDashboardMultiChoiceAnswerHandler(handler);
+            break;
+          case 'submit':
+            dashboard.setDashboardSubmitRecommendedHandler(handler);
+            break;
+        }
+
+        const res = await injectWebServer({
+          method: ep.verb,
+          url: `/api/dashboard/session/${encodeURIComponent('mac-mini-dev::C1:t1')}/${ep.path}`,
+          headers: AUTH_HEADER,
+          payload: ep.bodyForOk,
+        });
+
+        expect(res.statusCode).toBe(409);
+        const body = JSON.parse(res.body);
+        expect(body.error).toMatch(/Cross-instance/i);
+        expect(body.wireKey).toBe('mac-mini-dev::C1:t1');
+        // Critical: handler must NOT have been invoked for a foreign prefix.
+        expect(handler).not.toHaveBeenCalled();
+      });
+    }
+  });
+
+  it('archivedToKanban composite key path — strip works and resolves to raw archive key', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    setDashboardSessionAccessor(() => new Map());
+
+    // Seed the archive store with a closed session.
+    const archives = await import('../../session-archive');
+    const archivedAt = 1700000000000;
+    (archives.getArchiveStore as any) = () => ({
+      listRecent: () => [
+        {
+          sessionId: 'sid1',
+          sessionKey: 'C1:t1',
+          archivedAt,
+          ownerId: 'U1',
+          channelId: 'C1',
+          threadTs: 't1',
+          conversationId: 'conv1',
+          summaryTitle: 'archived',
+          archiveReason: 'sleep_expired',
+          lastActivity: new Date(archivedAt).toISOString(),
+        },
+      ],
+    });
+
+    // The full archive store mock is heavy; instead, just verify the prefix
+    // resolution rule directly via a /trash request with the composite
+    // archive key shape. The resolveSelfActionKey logic is the unit under
+    // test; the archive-listing path is covered by existing tests.
+    const trashKey = `archived_C1:t1_${archivedAt}`;
+    const wireKey = `self-host::${trashKey}`;
+
+    const dashboard = await import('../dashboard');
+    const trashHandler = vi.fn().mockResolvedValue(undefined);
+    dashboard.setDashboardTrashHandler(trashHandler);
+
+    const res = await injectWebServer({
+      method: 'POST',
+      url: `/api/dashboard/session/${encodeURIComponent(wireKey)}/trash`,
+      headers: AUTH_HEADER,
+    });
+
+    // Owner check uses the local session map which doesn't contain
+    // archive keys — trash will get 403. The point of this test is to
+    // assert the strip path produced the raw archive key, not 409 the
+    // foreign-prefix reject. So we accept either 200 (handler called) or
+    // 403 (owner reject) — but NEVER 409 (foreign prefix mistake).
+    expect(res.statusCode).not.toBe(409);
+  });
+
+  it('renders sibling cards with disabled action buttons and instance label', async () => {
+    setSelfInstanceEnv({ instanceName: 'self-host', port: 33000, host: '127.0.0.1' });
+    setDashboardSessionAccessor(() => new Map());
+
+    mockReadAllInstances.mockResolvedValue([
+      { port: 33001, instanceName: 'mac-mini-dev', host: '127.0.0.1', pid: 1001, lastSeen: Date.now() },
+    ]);
+    mockFetchSiblingBoards.mockResolvedValue([
+      {
+        instanceName: 'mac-mini-dev',
+        port: 33001,
+        host: '127.0.0.1',
+        board: {
+          working: [
+            {
+              key: 'C9:t9',
+              title: 'Sibling',
+              ownerId: 'U2',
+              channelId: 'C9',
+              activityState: 'working',
+              lastActivity: '2026-04-01T09:30:00Z',
+            },
+          ],
+          waiting: [],
+          idle: [],
+          closed: [],
+        },
+      },
+    ]);
+
+    const res = await injectWebServer({
+      method: 'GET',
+      url: '/api/dashboard/sessions',
+      headers: AUTH_HEADER,
+    });
+
+    const body = JSON.parse(res.body);
+    expect(body.board.working).toHaveLength(1);
+    const sibling = body.board.working[0];
+    expect(sibling.environment.instanceName).toBe('mac-mini-dev');
+    // Sibling card must carry env so the renderCard sibling-detection
+    // (env.instanceName !== SELF_INSTANCE_NAME) can match.
+    expect(sibling.key).toBe('mac-mini-dev::C9:t9');
+  });
+
+  it('stopWebServer removes the heartbeat file on shutdown', async () => {
+    // This test goes through the real instance-registry to verify the
+    // lifecycle wiring. Other tests mock readAllInstances at the module
+    // boundary, so we use a separate fresh import here.
+    const tmpDir = require('node:fs').mkdtempSync(
+      require('node:path').join(require('node:os').tmpdir(), 'soma-shutdown-'),
+    );
+    const oldDir = process.env.SOMA_INSTANCE_DIR;
+    process.env.SOMA_INSTANCE_DIR = tmpDir;
+    try {
+      // Re-import the registry (not the mocked one) to talk to the real fs.
+      vi.resetModules();
+      const real = await vi.importActual<typeof import('../instance-registry')>('../instance-registry');
+      await real.writeHeartbeat({
+        port: 33555,
+        instanceName: 'shutdown-test',
+        host: '127.0.0.1',
+        pid: process.pid,
+      });
+      expect(require('node:fs').existsSync(require('node:path').join(tmpDir, '33555.json'))).toBe(true);
+      await real.removeHeartbeat(33555);
+      expect(require('node:fs').existsSync(require('node:path').join(tmpDir, '33555.json'))).toBe(false);
+    } finally {
+      if (oldDir === undefined) delete process.env.SOMA_INSTANCE_DIR;
+      else process.env.SOMA_INSTANCE_DIR = oldDir;
+      try {
+        require('node:fs').rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+  });
+});

--- a/src/conversation/__tests__/instance-registry.test.ts
+++ b/src/conversation/__tests__/instance-registry.test.ts
@@ -1,0 +1,227 @@
+import { promises as fs, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  readAllInstances,
+  removeHeartbeat,
+  STALE_THRESHOLD_MS,
+  startHeartbeatLoop,
+  writeHeartbeat,
+} from '../instance-registry';
+
+// ── Test setup ──
+
+let tempDir: string;
+let originalEnv: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'soma-instance-registry-'));
+  originalEnv = process.env.SOMA_INSTANCE_DIR;
+  process.env.SOMA_INSTANCE_DIR = tempDir;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.SOMA_INSTANCE_DIR;
+  else process.env.SOMA_INSTANCE_DIR = originalEnv;
+  try {
+    rmSync(tempDir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+});
+
+describe('instance-registry: writeHeartbeat', () => {
+  it('writes a JSON file at <dir>/<port>.json with required payload fields', async () => {
+    await writeHeartbeat({
+      port: 33000,
+      instanceName: 'oudwood-dev',
+      host: '127.0.0.1',
+      pid: 4242,
+    });
+
+    const files = readdirSync(tempDir);
+    expect(files).toContain('33000.json');
+
+    const raw = await fs.readFile(join(tempDir, '33000.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.port).toBe(33000);
+    expect(parsed.instanceName).toBe('oudwood-dev');
+    expect(parsed.host).toBe('127.0.0.1');
+    expect(parsed.pid).toBe(4242);
+    expect(typeof parsed.lastSeen).toBe('number');
+    expect(parsed.lastSeen).toBeGreaterThan(Date.now() - 5000);
+  });
+
+  it('uses 0600 file permissions (owner read/write only) on POSIX', async () => {
+    await writeHeartbeat({
+      port: 33001,
+      instanceName: 'mac-mini-dev',
+      host: '127.0.0.1',
+      pid: 1234,
+    });
+
+    if (process.platform === 'win32') {
+      // Windows POSIX permissions are not meaningful — skip the bit check
+      return;
+    }
+
+    const stat = statSync(join(tempDir, '33001.json'));
+    // Mask off file-type bits, keep only the permission bits
+    const perm = stat.mode & 0o777;
+    expect(perm).toBe(0o600);
+  });
+
+  it('atomic write: never leaves a partial file (uses tmp+rename)', async () => {
+    // The contract is "atomic write" — there must never be a partial JSON
+    // visible to readers during a write. Easiest invariant test: after
+    // many concurrent writes, every file we can read parses cleanly.
+    const writes = [];
+    for (let i = 0; i < 20; i++) {
+      writes.push(
+        writeHeartbeat({
+          port: 33000,
+          instanceName: 'oudwood-dev',
+          host: '127.0.0.1',
+          pid: 100 + i,
+        }),
+      );
+    }
+    await Promise.all(writes);
+
+    const raw = await fs.readFile(join(tempDir, '33000.json'), 'utf8');
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+
+  it('overwrites an existing file at the same port (idempotent for a refresh)', async () => {
+    await writeHeartbeat({ port: 33000, instanceName: 'a', host: '127.0.0.1', pid: 1 });
+    await writeHeartbeat({ port: 33000, instanceName: 'b', host: '127.0.0.1', pid: 2 });
+
+    const raw = await fs.readFile(join(tempDir, '33000.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.instanceName).toBe('b');
+    expect(parsed.pid).toBe(2);
+  });
+
+  it('creates the heartbeat directory if it does not exist', async () => {
+    const nested = join(tempDir, 'sub', 'nested');
+    process.env.SOMA_INSTANCE_DIR = nested;
+
+    await writeHeartbeat({
+      port: 33000,
+      instanceName: 'oudwood-dev',
+      host: '127.0.0.1',
+      pid: 99,
+    });
+
+    const files = readdirSync(nested);
+    expect(files).toContain('33000.json');
+  });
+});
+
+describe('instance-registry: readAllInstances', () => {
+  it('returns empty array when directory is empty', async () => {
+    const result = await readAllInstances();
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when directory does not exist', async () => {
+    process.env.SOMA_INSTANCE_DIR = join(tempDir, 'never-created');
+    const result = await readAllInstances();
+    expect(result).toEqual([]);
+  });
+
+  it('reads all .json files and returns parsed instance records', async () => {
+    await writeHeartbeat({ port: 33000, instanceName: 'a', host: '127.0.0.1', pid: 1 });
+    await writeHeartbeat({ port: 33001, instanceName: 'b', host: '127.0.0.1', pid: 2 });
+    await writeHeartbeat({ port: 33002, instanceName: 'c', host: '127.0.0.1', pid: 3 });
+
+    const result = await readAllInstances();
+    expect(result).toHaveLength(3);
+    const ports = result.map((r) => r.port).sort();
+    expect(ports).toEqual([33000, 33001, 33002]);
+  });
+
+  it('filters out stale instances (lastSeen older than STALE_THRESHOLD_MS)', async () => {
+    // Write a fresh heartbeat
+    await writeHeartbeat({ port: 33000, instanceName: 'fresh', host: '127.0.0.1', pid: 1 });
+
+    // Write a stale heartbeat by directly writing JSON with old lastSeen
+    const stalePayload = {
+      port: 33001,
+      instanceName: 'stale',
+      host: '127.0.0.1',
+      pid: 2,
+      lastSeen: Date.now() - (STALE_THRESHOLD_MS + 5000),
+    };
+    await fs.writeFile(join(tempDir, '33001.json'), JSON.stringify(stalePayload), { mode: 0o600 });
+
+    const result = await readAllInstances();
+    expect(result).toHaveLength(1);
+    expect(result[0].instanceName).toBe('fresh');
+  });
+
+  it('skips files that fail JSON parse (corrupt or partial)', async () => {
+    await writeHeartbeat({ port: 33000, instanceName: 'good', host: '127.0.0.1', pid: 1 });
+    await fs.writeFile(join(tempDir, '33999.json'), '{ not valid json', { mode: 0o600 });
+
+    const result = await readAllInstances();
+    expect(result).toHaveLength(1);
+    expect(result[0].instanceName).toBe('good');
+  });
+
+  it('ignores non-.json files in the directory', async () => {
+    await writeHeartbeat({ port: 33000, instanceName: 'good', host: '127.0.0.1', pid: 1 });
+    await fs.writeFile(join(tempDir, 'README.md'), '# notes', { mode: 0o600 });
+    await fs.writeFile(join(tempDir, '33000.json.tmp'), 'partial', { mode: 0o600 });
+
+    const result = await readAllInstances();
+    expect(result).toHaveLength(1);
+    expect(result[0].port).toBe(33000);
+  });
+});
+
+describe('instance-registry: removeHeartbeat', () => {
+  it('deletes the heartbeat file for the given port', async () => {
+    await writeHeartbeat({ port: 33000, instanceName: 'a', host: '127.0.0.1', pid: 1 });
+    await writeHeartbeat({ port: 33001, instanceName: 'b', host: '127.0.0.1', pid: 2 });
+
+    await removeHeartbeat(33000);
+
+    const files = readdirSync(tempDir);
+    expect(files).not.toContain('33000.json');
+    expect(files).toContain('33001.json');
+  });
+
+  it('does not throw if the heartbeat file does not exist', async () => {
+    await expect(removeHeartbeat(99999)).resolves.toBeUndefined();
+  });
+});
+
+describe('instance-registry: startHeartbeatLoop', () => {
+  it('immediately writes the heartbeat then refreshes on the interval', async () => {
+    const handle = startHeartbeatLoop({ port: 33000, instanceName: 'loopy', host: '127.0.0.1', pid: 9999 }, 50);
+
+    try {
+      // Wait for at least one immediate write to land
+      await new Promise((r) => setTimeout(r, 30));
+      const first = JSON.parse(await fs.readFile(join(tempDir, '33000.json'), 'utf8'));
+      const firstSeen = first.lastSeen;
+      expect(typeof firstSeen).toBe('number');
+
+      // Wait long enough for the interval to fire at least once more
+      await new Promise((r) => setTimeout(r, 120));
+      const second = JSON.parse(await fs.readFile(join(tempDir, '33000.json'), 'utf8'));
+      expect(second.lastSeen).toBeGreaterThanOrEqual(firstSeen);
+    } finally {
+      clearInterval(handle);
+    }
+  });
+
+  it('returns a Timeout handle that can be cleared with clearInterval', async () => {
+    const handle = startHeartbeatLoop({ port: 33000, instanceName: 'loopy', host: '127.0.0.1', pid: 9999 }, 50);
+    expect(handle).toBeTruthy();
+    clearInterval(handle);
+  });
+});

--- a/src/conversation/aggregator.ts
+++ b/src/conversation/aggregator.ts
@@ -1,0 +1,284 @@
+/**
+ * Cross-instance dashboard aggregator (#814).
+ *
+ * On a multi-instance host (e.g. `oudwood-dev:33000` + `mac-mini-dev:33001`)
+ * a user may open the dashboard on either port and expect to see *all*
+ * sessions on the host. This module is the glue between heartbeat
+ * discovery (`instance-registry`) and the `/api/dashboard/sessions`
+ * handler:
+ *
+ *   1. Discovery: read `~/.soma/instances/*.json` for sibling instances.
+ *   2. Filter:    drop entries whose port *or* pid match self (port reuse
+ *                 after a crash can leave a stale record pointing at the
+ *                 same pid on a different port).
+ *   3. Fan-out:   `GET http://<host>:<port>/api/dashboard/sessions?selfOnly=true`
+ *                 with `Authorization: Bearer ${viewerToken}`.
+ *                 The forced `selfOnly=true` is the recursion guard —
+ *                 siblings must not aggregate their own siblings.
+ *   4. Stamp:     each sibling card gets `environment={instanceName, port,
+ *                 host}` injected and a composite `key =
+ *                 ${instanceName}::${originalKey}` so the client cache is
+ *                 collision-proof when two instances coincidentally key on
+ *                 the same `channelId:threadTs`.
+ *   5. Merge:     concat per column (self first), preserving original
+ *                 sort order.
+ *
+ * Failure mode is graceful: a sibling that 5xxs, times out, or returns
+ * malformed JSON is silently skipped (with one warn-log per process so
+ * the operator notices but the page still renders self-only data).
+ *
+ */
+
+import { Logger } from '../logger';
+import { type InstanceRecord, readAllInstances } from './instance-registry';
+
+const logger = new Logger('Aggregator');
+
+/** Same column shape as `KanbanBoard` in `dashboard.ts`, redeclared here
+ * so the aggregator does not depend on the dashboard module (and so the
+ * dashboard module does not have to export the type just for tests). */
+export interface AggregatorBoard {
+  working: any[];
+  waiting: any[];
+  idle: any[];
+  closed: any[];
+}
+
+export interface InstanceEnvironment {
+  instanceName: string;
+  port: number;
+  host: string;
+}
+
+export interface SiblingBoardResult extends InstanceEnvironment {
+  /** Raw board returned by the sibling. Cards are *not* yet env-stamped. */
+  board: AggregatorBoard;
+}
+
+export interface FetchSiblingBoardsOptions {
+  selfPort: number;
+  selfPid: number;
+  /** Shared `CONVERSATION_VIEWER_TOKEN`; when empty, the call short-circuits. */
+  viewerToken: string;
+  /** Per-call timeout (ms). Default 1500. */
+  timeoutMs?: number;
+  /** Injected for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Override discovery (tests). */
+  discoverFn?: () => Promise<InstanceRecord[]>;
+}
+
+let _warnedAboutMissingToken = false;
+
+/**
+ * Per-(port, class) warn rate-limit. The map keys on `${port}:${cls}` so
+ * a flapping port doesn't silence a brand-new failure on a different
+ * port or with a different cause. 60 s TTL: a sibling failing every
+ * 30 s poll logs once per minute; a recovered-then-flapping sibling
+ * re-surfaces.
+ */
+const SIBLING_WARN_TTL_MS = 60_000;
+type SiblingFailureClass = 'http_status' | 'parse_failed' | 'board_missing' | 'timeout' | 'network_error';
+const _siblingWarnedAt = new Map<string, number>();
+
+/** Test hook — clears warn rate-limit state. Not used in production. */
+export function __resetWarnFlagForTests(): void {
+  _warnedAboutMissingToken = false;
+  _siblingWarnedAt.clear();
+}
+
+/**
+ * Pure decision: should `/api/dashboard/sessions` aggregate or stay self-only?
+ *
+ * Three inputs decide:
+ *   - `selfOnly` query flag from the request (set by the aggregator itself
+ *     when fanning out to siblings, or by clients that explicitly opt out)
+ *   - `viewerToken` — without it cross-port auth can't succeed
+ *   - `siblingCount` — when zero there's nothing to aggregate anyway
+ *
+ * The function is exported so the handler tests can pin behaviour without
+ * round-tripping through `fetchSiblingBoards`.
+ */
+export function shouldAggregate(args: { selfOnly: boolean; viewerToken: string; siblingCount: number }): boolean {
+  if (args.selfOnly) return false;
+  if (!args.viewerToken) return false;
+  if (args.siblingCount <= 0) return false;
+  return true;
+}
+
+/**
+ * Discover and fetch sibling boards.
+ *
+ * Returns an array of sibling results — siblings that error out are
+ * dropped silently (with one process-lifetime warn log). Callers that
+ * need the strict "self-only" path are expected to gate this call via
+ * {@link shouldAggregate} first; this function still defends in depth
+ * against an empty viewerToken.
+ */
+export async function fetchSiblingBoards(options: FetchSiblingBoardsOptions): Promise<SiblingBoardResult[]> {
+  const {
+    selfPort,
+    selfPid,
+    viewerToken,
+    timeoutMs = 1500,
+    fetchImpl = fetch,
+    discoverFn = readAllInstances,
+  } = options;
+
+  if (!viewerToken) {
+    if (!_warnedAboutMissingToken) {
+      logger.warn(
+        'CONVERSATION_VIEWER_TOKEN not set — dashboard cannot fan out to sibling instances. Falling back to self-only.',
+      );
+      _warnedAboutMissingToken = true;
+    }
+    return [];
+  }
+
+  const all = await discoverFn();
+  const siblings = all.filter((r) => r.port !== selfPort && r.pid !== selfPid);
+  if (siblings.length === 0) return [];
+
+  const calls = siblings.map(async (sib) => {
+    const url = buildSiblingUrl(sib);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${viewerToken}` },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        warnSiblingFailure(sib.port, 'http_status', { status: res.status });
+        return null;
+      }
+      const text = await res.text();
+      let parsed: any;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        warnSiblingFailure(sib.port, 'parse_failed', {});
+        return null;
+      }
+      const board = parsed?.board;
+      if (!board || typeof board !== 'object') {
+        warnSiblingFailure(sib.port, 'board_missing', {});
+        return null;
+      }
+      return {
+        instanceName: sib.instanceName,
+        port: sib.port,
+        host: sib.host,
+        board: {
+          working: Array.isArray(board.working) ? board.working : [],
+          waiting: Array.isArray(board.waiting) ? board.waiting : [],
+          idle: Array.isArray(board.idle) ? board.idle : [],
+          closed: Array.isArray(board.closed) ? board.closed : [],
+        },
+      } as SiblingBoardResult;
+    } catch (err) {
+      const e = err as Error;
+      const cls = e.name === 'AbortError' ? 'timeout' : 'network_error';
+      warnSiblingFailure(sib.port, cls, { msg: e.message });
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  const settled = await Promise.allSettled(calls);
+  const out: SiblingBoardResult[] = [];
+  for (const s of settled) {
+    if (s.status === 'fulfilled' && s.value) out.push(s.value);
+  }
+  return out;
+}
+
+/**
+ * Rate-limited warn for sibling fan-out failures. Distinct (port, cls)
+ * combinations each get their own throttle, so a flapping port-A doesn't
+ * silence a brand-new port-B failure for the lifetime of the process.
+ */
+function warnSiblingFailure(port: number, cls: SiblingFailureClass, extra: Record<string, unknown>): void {
+  const key = `${port}:${cls}`;
+  const now = Date.now();
+  const last = _siblingWarnedAt.get(key);
+  if (last !== undefined && now - last < SIBLING_WARN_TTL_MS) return;
+  _siblingWarnedAt.set(key, now);
+  logger.warn('Sibling dashboard fetch failed', { port, cls, ...extra });
+}
+
+function buildSiblingUrl(sib: { host: string; port: number }): string {
+  // selfOnly=true is the recursion guard — sibling must answer with its
+  // own data, not aggregate further. URL-encoded literally to keep it
+  // simple to grep for in logs.
+  return `http://${sib.host}:${sib.port}/api/dashboard/sessions?selfOnly=true`;
+}
+
+/**
+ * Merge self board + sibling boards into one columnar board, stamping
+ * env metadata and composite keys on sibling cards as they go past.
+ *
+ * Self cards are inserted first (matching the spec — "자기 카드 먼저,
+ * sibling 다음"). Self cards are *not* re-stamped here; the dashboard
+ * `sessionToKanban` already attached the env when constructing the self
+ * board, and altering its key now would break the action endpoints.
+ */
+export function mergeBoards(args: {
+  selfBoard: AggregatorBoard;
+  selfEnv: InstanceEnvironment;
+  siblings: SiblingBoardResult[];
+}): AggregatorBoard {
+  const out: AggregatorBoard = {
+    working: args.selfBoard.working.slice(),
+    waiting: args.selfBoard.waiting.slice(),
+    idle: args.selfBoard.idle.slice(),
+    closed: args.selfBoard.closed.slice(),
+  };
+
+  for (const sib of args.siblings) {
+    const env: InstanceEnvironment = {
+      instanceName: sib.instanceName,
+      port: sib.port,
+      host: sib.host,
+    };
+    pushStamped(out.working, sib.board.working, env);
+    pushStamped(out.waiting, sib.board.waiting, env);
+    pushStamped(out.idle, sib.board.idle, env);
+    pushStamped(out.closed, sib.board.closed, env);
+  }
+
+  return out;
+}
+
+function pushStamped(target: any[], source: any[], env: InstanceEnvironment): void {
+  for (const card of source) {
+    target.push(stampEnvAndKey(card, env));
+  }
+}
+
+/**
+ * Stamp the env metadata onto a card and rewrite its key into the
+ * composite form `${instanceName}::${originalKey}`. Idempotent: a card
+ * whose key is already composite (already has `::`) is left alone.
+ */
+export function stampEnvAndKey<T extends { key?: string; environment?: InstanceEnvironment }>(
+  card: T,
+  env: InstanceEnvironment,
+): T {
+  const originalKey = typeof card.key === 'string' ? card.key : '';
+  // If the sibling already returned a composite key (e.g. it itself is
+  // the front-of-house instance and has stamped its own cards), trust
+  // its prefix — but the recursion guard means we never receive that
+  // shape from a properly-running sibling.
+  const composite =
+    originalKey && !originalKey.startsWith(`${env.instanceName}::`)
+      ? `${env.instanceName}::${originalKey}`
+      : originalKey;
+  return {
+    ...card,
+    key: composite,
+    environment: env,
+  };
+}

--- a/src/conversation/dashboard.ts
+++ b/src/conversation/dashboard.ts
@@ -19,6 +19,7 @@
  */
 
 import type { FastifyInstance } from 'fastify';
+import { config } from '../config';
 import { displayTitle } from '../format/display-title';
 import { Logger } from '../logger';
 import { MetricsEventStore } from '../metrics/event-store';
@@ -27,6 +28,8 @@ import { AggregatedMetrics, type MetricsEvent } from '../metrics/types';
 import { type ArchivedSession, getArchiveStore } from '../session-archive';
 import { buildThreadPermalink } from '../turn-notifier';
 import { coerceEffort, type EffortLevel, userSettingsStore } from '../user-settings-store';
+import { fetchSiblingBoards, type InstanceEnvironment, mergeBoards, shouldAggregate } from './aggregator';
+import { readAllInstances } from './instance-registry';
 import { getConversation, resummarizeTurn, updateConversationTitleSub } from './recorder';
 import { generateTitle } from './title-generator';
 
@@ -106,6 +109,21 @@ export interface KanbanSession {
   issueShortRef?: string;
   /** GitHub PR short ref like "PR-123" derived from prUrl */
   prShortRef?: string;
+  /**
+   * #814 — environment metadata identifying which soma-work instance owns
+   * this card. Self cards get the local instance's env; sibling cards
+   * get their owner's env after the aggregator stamps them on the merge
+   * path. The frontend renders an env badge from this and groups token
+   * stats by `instanceName`. Always present once `setSelfInstanceEnv()`
+   * has been called from `startWebServer` — defensive `?` because tests
+   * exercise paths that don't initialize the env (and the badge is
+   * suppressed when missing).
+   */
+  environment?: {
+    instanceName: string;
+    port: number;
+    host: string;
+  };
   /** Pending user choice question (present when activityState === 'waiting' and a question was asked) */
   pendingQuestion?: {
     type: 'user_choice' | 'user_choices';
@@ -164,6 +182,132 @@ export interface UserStats {
     mergeLinesDeleted: number;
     workflowCounts: Record<string, number>;
   };
+}
+
+// ── Self-instance environment (#814) ───────────────────────────────
+
+/**
+ * The local instance's environment metadata, set once by `web-server.ts`
+ * after `activePort` is finalized. Used to stamp self-owned cards with
+ * `environment` and to compose `${instanceName}::${originalKey}` keys
+ * so the client cache and the cross-instance aggregator can distinguish
+ * cards from sibling instances.
+ *
+ * Null until set — code paths that build cards before
+ * `setSelfInstanceEnv` runs (e.g. tests that exercise the dashboard
+ * without booting the server) emit raw keys and no environment, which
+ * keeps backward compat with the existing dashboard.test.ts snapshots
+ * that assert `key === 'C1:t1'` directly.
+ */
+let _selfInstanceEnv: InstanceEnvironment | null = null;
+
+/** Wire the local instance's env. Called by `startWebServer`. */
+export function setSelfInstanceEnv(env: InstanceEnvironment): void {
+  _selfInstanceEnv = env;
+}
+
+/** Test helper — clear the self env between cases. */
+export function __resetSelfInstanceEnvForTests(): void {
+  _selfInstanceEnv = null;
+  _aggregatorCacheClear();
+}
+
+// #814 — Per-process TTL cache for sibling fan-out. Collapses concurrent
+// /api/dashboard/sessions polls (multiple browser tabs) into one fan-out;
+// 1500 ms < 30 s poll cadence so a sibling that just came up surfaces on
+// the next tick.
+const AGGREGATOR_CACHE_TTL_MS = 1_500;
+type SiblingBoards = Awaited<ReturnType<typeof fetchSiblingBoards>>;
+let _aggregatorCache: { value: SiblingBoards; stamp: number } | null = null;
+function _aggregatorCacheGet(): SiblingBoards | null {
+  if (_aggregatorCache === null) return null;
+  if (Date.now() - _aggregatorCache.stamp > AGGREGATOR_CACHE_TTL_MS) return null;
+  return _aggregatorCache.value;
+}
+function _aggregatorCacheSet(siblings: SiblingBoards): void {
+  _aggregatorCache = { value: siblings, stamp: Date.now() };
+}
+function _aggregatorCacheClear(): void {
+  _aggregatorCache = null;
+}
+
+/**
+ * Build the wire-format key for a session. When the local env is wired
+ * (production), keys are `${instanceName}::${originalKey}` — collision-
+ * proof against sibling instances. When it's not wired (legacy tests),
+ * we return the original key untouched.
+ */
+function composeSessionKey(originalKey: string): string {
+  if (!_selfInstanceEnv) return originalKey;
+  if (originalKey.startsWith(`${_selfInstanceEnv.instanceName}::`)) return originalKey;
+  return `${_selfInstanceEnv.instanceName}::${originalKey}`;
+}
+
+/**
+ * Inverse of {@link composeSessionKey}: strip the `${selfInstance}::`
+ * prefix from an action endpoint's `:key` param.
+ *
+ * Three outcomes (#814 silent-failure-hunter audit):
+ *   - **No env wired** (legacy / single-instance): return `wireKey` unchanged.
+ *   - **No `::` separator**: return `wireKey` unchanged (legacy clients
+ *     that haven't seen a composite key yet, e.g. immediately after upgrade).
+ *   - **`foreign-instance::raw`**: return `null` — the action targets a
+ *     sibling instance that this server does not own. Callers must surface a
+ *     409 with a redirect hint, not silently pass through and 403/no-op.
+ *   - **`self::raw`**: strip and return `raw`.
+ */
+function stripSelfInstancePrefix(wireKey: string): string | null {
+  if (!_selfInstanceEnv) return wireKey;
+  // Only treat as composite when `::` is present — bare keys remain
+  // backward-compatible for clients that pre-date the composite wire format.
+  const sepIdx = wireKey.indexOf('::');
+  if (sepIdx < 0) return wireKey;
+  const prefix = wireKey.slice(0, sepIdx);
+  // The session storage layer uses `archived_<channel>:<thread>_<ts>` as a
+  // key shape — the prefix in that case is the literal string `archived_…`,
+  // not an instance name. We only treat the prefix as an instance routing
+  // hint when it matches the self instance; everything else is left alone.
+  if (prefix === _selfInstanceEnv.instanceName) {
+    return wireKey.slice(sepIdx + 2);
+  }
+  // Anything else with `::` is a foreign instance — refuse.
+  return null;
+}
+
+/**
+ * Helper for action endpoints — wrap `stripSelfInstancePrefix` and emit a
+ * uniform 409 reply when the wire key targets a sibling instance, so the
+ * caller's frontend can show "open this card on $sibling".
+ *
+ * Returns the resolved local key, or null if the request was rejected
+ * (in which case the reply has already been sent).
+ */
+function resolveSelfActionKey(wireKey: string, reply: any): string | null {
+  const local = stripSelfInstancePrefix(wireKey);
+  if (local === null) {
+    reply.status(409).send({
+      error:
+        'Cross-instance action not supported — this session belongs to another soma-work instance. Open that instance directly to act on it.',
+      wireKey,
+    });
+    return null;
+  }
+  return local;
+}
+
+/**
+ * Resolve the wire-format `:key` route param to a local session key AND
+ * gate on `requireSessionOwner` in one call. Centralizes the
+ * (cross-instance reject → owner gate) preamble that every action
+ * endpoint shares. Returns null if either check failed (the reply has
+ * already been sent).
+ */
+function resolveSelfActionKeyAndOwner(request: any, reply: any): { wireKey: string; originalKey: string } | null {
+  const wireKey: string = request.params?.key ?? '';
+  const originalKey = resolveSelfActionKey(wireKey, reply);
+  if (originalKey === null) return null;
+  if (!requireSessionOwner(request, reply, originalKey)) return null;
+  return { wireKey, originalKey };
 }
 
 // ── Session data accessor ──────────────────────────────────────────
@@ -380,7 +524,9 @@ function sessionToKanban(key: string, s: any): KanbanSession {
   const aggregate = computeThreadAggregate(s.channelId, s.threadTs, getAllSessions(), Date.now());
   const headline = displayTitle(s);
   return {
-    key,
+    // #814 Wire-format key includes the local instance prefix so sibling
+    // instances can never collide on the client cache.
+    key: composeSessionKey(key),
     title: headline,
     displayHeadline: headline,
     // Emit summaryTitle so initial board renders (and full-page refresh) match
@@ -438,6 +584,10 @@ function sessionToKanban(key: string, s: any): KanbanSession {
     threadSessionCount: aggregate.sessionCount,
     threadCompactionCount: aggregate.compactionCount,
     ...cardDerivedFields({ effort: s.effort, ownerId: s.ownerId, links: s.links, persistedEffort: true }),
+    // #814 Stamp self env (when wired) so the frontend renders the env
+    // badge for self cards too — siblings get their env from the
+    // aggregator's mergeBoards stamp.
+    environment: _selfInstanceEnv ? { ..._selfInstanceEnv } : undefined,
     pendingQuestion: s.actionPanel?.pendingQuestion
       ? s.actionPanel.pendingQuestion.type === 'user_choice'
         ? {
@@ -486,7 +636,10 @@ const DASHBOARD_ARCHIVE_MAX_AGE_MS = 48 * 60 * 60 * 1000;
 function archivedToKanban(archived: ArchivedSession): KanbanSession {
   const headline = displayTitle(archived);
   return {
-    key: `archived_${archived.sessionKey}_${archived.archivedAt}`,
+    // #814 Same composite-key scheme as live cards. The original archive
+    // key already contains underscores and timestamps; the instance
+    // prefix simply nests on top via `::`.
+    key: composeSessionKey(`archived_${archived.sessionKey}_${archived.archivedAt}`),
     title: headline,
     displayHeadline: headline,
     summaryTitle:
@@ -535,6 +688,7 @@ function archivedToKanban(archived: ArchivedSession): KanbanSession {
     threadSessionCount: 1,
     threadCompactionCount: archived.compactionCount || 0,
     ...cardDerivedFields({ ownerId: archived.ownerId, links: archived.links, persistedEffort: false }),
+    environment: _selfInstanceEnv ? { ..._selfInstanceEnv } : undefined,
   };
 }
 
@@ -770,7 +924,11 @@ export function broadcastTaskUpdate(
 ): void {
   if (wsClients.size === 0) return;
   try {
-    const payload = JSON.stringify({ type: 'task_update', sessionKey, tasks });
+    // #814 External callers (e.g. Slack handler) pass the raw session key.
+    // Compose the wire-format key here so the client cache (keyed by
+    // composite `${instanceName}::${rawKey}`) finds the card.
+    const wireKey = composeSessionKey(sessionKey);
+    const payload = JSON.stringify({ type: 'task_update', sessionKey: wireKey, tasks });
     for (const client of wsClients) {
       try {
         client.send(payload);
@@ -846,9 +1004,11 @@ export function broadcastSummaryTitleChanged(sessionKey: string, summaryTitle: s
       logger.warn('broadcastSummaryTitleChanged: session not found', { sessionKey });
       return;
     }
+    // #814 — clients key their cache by composite. See broadcastTaskUpdate.
+    const wireKey = composeSessionKey(sessionKey);
     const payload = JSON.stringify({
       type: 'summaryTitleChanged',
-      sessionKey,
+      sessionKey: wireKey,
       summaryTitle,
       displayHeadline: displayTitle(session),
     });
@@ -922,13 +1082,74 @@ export async function registerDashboardRoutes(
   // ── JSON API ──
 
   // Kanban sessions
-  server.get<{ Querystring: { userId?: string } }>(
+  server.get<{ Querystring: { userId?: string; selfOnly?: string } }>(
     '/api/dashboard/sessions',
     { preHandler: [authMiddleware] },
     async (request, reply) => {
       const userId = request.query.userId || undefined;
+      const selfOnly = request.query.selfOnly === 'true';
       const board = buildKanbanBoard(userId);
-      reply.send({ board });
+
+      // #814 — when not the recursion-guarded selfOnly path, ask the
+      // aggregator to fan out to sibling instances on the same host.
+      // Skip pre-listen / single-instance.
+      if (!_selfInstanceEnv) {
+        reply.send({ board });
+        return;
+      }
+      if (selfOnly) {
+        reply.send({ board });
+        return;
+      }
+
+      try {
+        // Pre-discover once and reuse the same records inside
+        // `fetchSiblingBoards` (via `discoverFn`) so the gate doesn't
+        // cost a second readdir+readFile sweep.
+        const all = await readAllInstances();
+        const selfPort = _selfInstanceEnv.port;
+        const siblingCount = all.filter((r) => r.port !== selfPort && r.pid !== process.pid).length;
+        if (
+          !shouldAggregate({
+            selfOnly,
+            viewerToken: config.conversation.viewerToken,
+            siblingCount,
+          })
+        ) {
+          reply.send({ board });
+          return;
+        }
+        // Per-poll TTL cache — multiple browser tabs polling /sessions
+        // every 30 s shouldn't independently fan out N×HTTP each time.
+        // 1.5 s collapses a burst of concurrent polls without going
+        // stale enough to mask a sibling that just came up.
+        const cached = _aggregatorCacheGet();
+        let siblings;
+        if (cached) {
+          siblings = cached;
+        } else {
+          siblings = await fetchSiblingBoards({
+            selfPort,
+            selfPid: process.pid,
+            viewerToken: config.conversation.viewerToken,
+            discoverFn: async () => all,
+          });
+          _aggregatorCacheSet(siblings);
+        }
+        const merged = mergeBoards({
+          selfBoard: board,
+          selfEnv: _selfInstanceEnv,
+          siblings,
+        });
+        reply.send({ board: merged });
+      } catch (err) {
+        // Hard failure of the aggregator must never surface a 500 —
+        // fall back to self-only. Log at error (with stack) so a
+        // genuine bug in mergeBoards / fetch wiring is visible, not
+        // confused with the warn-throttled per-sibling failures.
+        logger.error('Aggregator failed; serving self-only board', err);
+        reply.send({ board });
+      }
     },
   );
 
@@ -1199,12 +1420,14 @@ export async function registerDashboardRoutes(
     '/api/dashboard/session/:key/stop',
     { preHandler: [authMiddleware, ...(csrfMiddleware ? [csrfMiddleware] : [])] },
     async (request, reply) => {
-      const { key } = request.params;
-      if (!requireSessionOwner(request, reply, key)) return;
+      const resolved = resolveSelfActionKeyAndOwner(request, reply);
+      if (!resolved) return;
+      const { wireKey: key, originalKey } = resolved;
       try {
         if (_stopHandlerFn) {
-          await _stopHandlerFn(key);
+          await _stopHandlerFn(originalKey);
         }
+        // Broadcast uses wire-format so the client cache lookup matches.
         broadcastSessionAction(key, 'stop');
         broadcastSessionUpdate();
         reply.send({ ok: true });
@@ -1219,11 +1442,12 @@ export async function registerDashboardRoutes(
     '/api/dashboard/session/:key/close',
     { preHandler: [authMiddleware, ...(csrfMiddleware ? [csrfMiddleware] : [])] },
     async (request, reply) => {
-      const { key } = request.params;
-      if (!requireSessionOwner(request, reply, key)) return;
+      const resolved = resolveSelfActionKeyAndOwner(request, reply);
+      if (!resolved) return;
+      const { wireKey: key, originalKey } = resolved;
       try {
         if (_closeHandlerFn) {
-          await _closeHandlerFn(key);
+          await _closeHandlerFn(originalKey);
         }
         broadcastSessionAction(key, 'close');
         broadcastSessionUpdate();
@@ -1239,11 +1463,12 @@ export async function registerDashboardRoutes(
     '/api/dashboard/session/:key/trash',
     { preHandler: [authMiddleware, ...(csrfMiddleware ? [csrfMiddleware] : [])] },
     async (request, reply) => {
-      const { key } = request.params;
-      if (!requireSessionOwner(request, reply, key)) return;
+      const resolved = resolveSelfActionKeyAndOwner(request, reply);
+      if (!resolved) return;
+      const { wireKey: key, originalKey } = resolved;
       try {
         if (_trashHandlerFn) {
-          await _trashHandlerFn(key);
+          await _trashHandlerFn(originalKey);
         }
         broadcastSessionAction(key, 'trash');
         broadcastSessionUpdate();
@@ -1259,7 +1484,6 @@ export async function registerDashboardRoutes(
     '/api/dashboard/session/:key/command',
     { preHandler: [authMiddleware, ...(csrfMiddleware ? [csrfMiddleware] : [])] },
     async (request, reply) => {
-      const { key } = request.params;
       const { message } = request.body || {};
       if (!message || typeof message !== 'string') {
         reply.status(400).send({ error: 'message is required and must be a string' });
@@ -1269,10 +1493,12 @@ export async function registerDashboardRoutes(
         reply.status(400).send({ error: 'message exceeds max length (4000 chars)' });
         return;
       }
-      if (!requireSessionOwner(request, reply, key)) return;
+      const resolved = resolveSelfActionKeyAndOwner(request, reply);
+      if (!resolved) return;
+      const { originalKey } = resolved;
       try {
         if (_commandHandlerFn) {
-          await _commandHandlerFn(key, message);
+          await _commandHandlerFn(originalKey, message);
         }
         reply.send({ ok: true });
       } catch (error) {
@@ -1288,7 +1514,6 @@ export async function registerDashboardRoutes(
     '/api/dashboard/session/:key/answer-choice',
     { preHandler: [authMiddleware, ...(csrfMiddleware ? [csrfMiddleware] : [])] },
     async (request, reply) => {
-      const { key } = request.params;
       const { choiceId, label, question } = request.body || {};
       if (
         !choiceId ||
@@ -1305,10 +1530,12 @@ export async function registerDashboardRoutes(
         reply.status(400).send({ error: 'Field length exceeded' });
         return;
       }
-      if (!requireSessionOwner(request, reply, key)) return;
+      const resolved = resolveSelfActionKeyAndOwner(request, reply);
+      if (!resolved) return;
+      const { originalKey } = resolved;
       try {
         if (_choiceAnswerHandlerFn) {
-          await _choiceAnswerHandlerFn(key, choiceId, label, question);
+          await _choiceAnswerHandlerFn(originalKey, choiceId, label, question);
         } else {
           reply.status(501).send({ error: 'Choice answer handler not configured' });
           return;
@@ -1339,7 +1566,6 @@ export async function registerDashboardRoutes(
     '/api/dashboard/session/:key/answer-multi-choice',
     { preHandler: [authMiddleware, ...(csrfMiddleware ? [csrfMiddleware] : [])] },
     async (request, reply) => {
-      const { key } = request.params;
       const { selections } = request.body || {};
       if (
         !selections ||
@@ -1374,10 +1600,12 @@ export async function registerDashboardRoutes(
           return;
         }
       }
-      if (!requireSessionOwner(request, reply, key)) return;
+      const resolved = resolveSelfActionKeyAndOwner(request, reply);
+      if (!resolved) return;
+      const { originalKey } = resolved;
       try {
         if (_multiChoiceAnswerHandlerFn) {
-          await _multiChoiceAnswerHandlerFn(key, selections);
+          await _multiChoiceAnswerHandlerFn(originalKey, selections);
         } else {
           reply.status(501).send({ error: 'Multi-choice answer handler not configured' });
           return;
@@ -1409,14 +1637,15 @@ export async function registerDashboardRoutes(
     '/api/dashboard/session/:key/submit-recommended',
     { preHandler: [authMiddleware, ...(csrfMiddleware ? [csrfMiddleware] : [])] },
     async (request, reply) => {
-      const { key } = request.params;
-      if (!requireSessionOwner(request, reply, key)) return;
+      const resolved = resolveSelfActionKeyAndOwner(request, reply);
+      if (!resolved) return;
+      const { wireKey: key, originalKey } = resolved;
       try {
         if (!_submitRecommendedHandlerFn) {
           reply.status(501).send({ error: 'Submit-recommended handler not configured' });
           return;
         }
-        await _submitRecommendedHandlerFn(key);
+        await _submitRecommendedHandlerFn(originalKey);
         reply.send({ ok: true });
       } catch (error) {
         const errMsg = (error as Error).message || '';
@@ -1501,6 +1730,10 @@ export async function registerDashboardRoutes(
 
 function renderDashboardPage(userId?: string): string {
   const initUser = userId ? JSON.stringify(userId) : 'null';
+  // #814 — inject the local instance's name so the frontend can identify
+  // sibling cards (`environment.instanceName !== SELF_INSTANCE_NAME`) and
+  // hide actions that would silently 4xx if dispatched to the wrong port.
+  const initSelfInstance = _selfInstanceEnv ? JSON.stringify(_selfInstanceEnv.instanceName) : 'null';
   return `<!DOCTYPE html>
 <html lang="ko">
 <head>
@@ -1932,6 +2165,52 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
   color: var(--accent);
   font-weight: 700;
   text-transform: lowercase;
+}
+
+/* ── ENV BADGE — multi-instance origin tag (#814) ── */
+.card .card-meta .env-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-size: 0.78em;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.02em;
+  vertical-align: baseline;
+  /* color is set inline via getEnvBadgeColor() because we hash the
+     instanceName at render time; the CSS just owns layout. */
+}
+/* Topbar tooltip — env-grouped token breakdown (#814) */
+#stat-tokens-wrap {
+  position: relative;
+  display: inline-block;
+}
+#stat-tokens-tooltip {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 4px;
+  background: var(--surface, #222);
+  color: var(--text, #eee);
+  border: 1px solid var(--border, rgba(255,255,255,0.1));
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.78em;
+  font-weight: 400;
+  white-space: nowrap;
+  z-index: 50;
+  pointer-events: none;
+}
+#stat-tokens-wrap.tooltip-open #stat-tokens-tooltip,
+#stat-tokens-wrap:hover #stat-tokens-tooltip { display: block; }
+@media (hover: none) {
+  /* On touch devices :hover is sticky after a tap and never closes —
+     gate visibility entirely on the explicit tooltip-open class
+     toggled by the tap handler in updateTokenStats(). */
+  #stat-tokens-wrap:hover #stat-tokens-tooltip { display: none; }
+  #stat-tokens-wrap.tooltip-open #stat-tokens-tooltip { display: block; }
 }
 
 /* ── CONTEXT USAGE BAR ── */
@@ -2774,7 +3053,7 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
       <div class="stat-card"><div class="label">PR &#xC0DD;&#xC131;</div><div class="value" id="stat-prs">-</div></div>
       <div class="stat-card"><div class="label">PR &#xBA38;&#xC9C0;</div><div class="value" id="stat-merged">-</div></div>
       <div class="stat-card"><div class="label">&#xBA38;&#xC9C0; &#xCF54;&#xB4DC;</div><div class="value" id="stat-merge-lines">-</div></div>
-      <div class="stat-card"><div class="label">&#xD1A0;&#xD070; &#xC0AC;&#xC6A9;</div><div class="value" id="stat-tokens">-</div></div>
+      <div class="stat-card"><div class="label">&#xD1A0;&#xD070; &#xC0AC;&#xC6A9;</div><div class="value" id="stat-tokens-wrap"><span id="stat-tokens">-</span><span id="stat-tokens-tooltip" role="tooltip"></span></div></div>
       <div class="stat-card"><div class="label">&#xBE44;&#xC6A9; (USD)</div><div class="value" id="stat-cost">-</div></div>
       <div class="stat-card"><div class="label">&#xC6CC;&#xD06C;&#xD50C;&#xB85C;&#xC6B0;</div><div class="value" id="stat-workflows" style="font-size:0.85em">-</div></div>
     </div>
@@ -2858,6 +3137,11 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
 
 <script>
 const INIT_USER = ${initUser};
+// #814 — name of the dashboard's *home* instance (the one that served this
+// HTML). Used by renderCard() to detect sibling cards and suppress action
+// buttons that would post to the wrong instance. null when single-instance
+// (no env wired) or pre-listen tests; the suppression check tolerates null.
+const SELF_INSTANCE_NAME = ${initSelfInstance};
 let currentUserId = INIT_USER || '';
 // Displayed + placeholder copy when a non-owner views a session. Kept here so
 // wording edits only touch one place instead of four button sites + panel.
@@ -3361,9 +3645,98 @@ function setPeriod(period) {
 // ── Session cache ──
 let _sessionCache = {};
 
+// ── Env badge helpers (#814) ──
+// 4-color palette — kept in CSS-friendly order so the contrast against
+// dark/light themes is decent for any of the four. Index = hash of
+// instanceName mod 4. Two unrelated names hashing to the same slot is
+// noise we can live with on a 4-instance host (operators rarely run more
+// than 2-3 instances per box).
+var ENV_BADGE_PALETTE = ['#5DADE2', '#48C9B0', '#F4D03F', '#EC7063'];
+
+// _envIndex caches a deterministic palette-slot per instanceName so two
+// envs sharing a hash bucket fall back to a "first-come, first-coloured"
+// scheme based on the sorted set of envs in the current cache. Recomputed
+// any time the cache changes (cleared in renderBoard).
+var _envIndex = null;
+
+function _hashStr(s) {
+  // djb2 — small, deterministic, sufficient for a 4-bucket palette.
+  var h = 5381;
+  for (var i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+function _buildEnvIndex() {
+  var envs = {};
+  for (var k in _sessionCache) {
+    var c = _sessionCache[k];
+    if (c && c.environment && c.environment.instanceName) {
+      envs[c.environment.instanceName] = true;
+    }
+  }
+  var sorted = Object.keys(envs).sort();
+  var assigned = {};
+  // First pass — try the hash bucket. If taken, mark conflict.
+  var occupied = {};
+  for (var i = 0; i < sorted.length; i++) {
+    var name = sorted[i];
+    var slot = _hashStr(name) % ENV_BADGE_PALETTE.length;
+    if (!occupied[slot]) {
+      assigned[name] = slot;
+      occupied[slot] = name;
+    } else {
+      assigned[name] = -1; // mark for fallback pass
+    }
+  }
+  // Second pass — fallback: walk sorted-order names that hashed into a
+  // taken slot and assign the next free slot in palette order. This
+  // keeps the assignment stable across renders so a card doesn't change
+  // colour when an unrelated card is added.
+  var nextSlot = 0;
+  for (var j = 0; j < sorted.length; j++) {
+    var name2 = sorted[j];
+    if (assigned[name2] !== -1) continue;
+    while (occupied[nextSlot] && nextSlot < ENV_BADGE_PALETTE.length) nextSlot++;
+    if (nextSlot < ENV_BADGE_PALETTE.length) {
+      assigned[name2] = nextSlot;
+      occupied[nextSlot] = name2;
+      nextSlot++;
+    } else {
+      // More envs than palette slots — wrap. Operators on a 5+ instance
+      // host accept that two badges may collide on colour.
+      assigned[name2] = _hashStr(name2) % ENV_BADGE_PALETTE.length;
+    }
+  }
+  return assigned;
+}
+
+function getEnvBadgeColor(instanceName) {
+  if (!_envIndex) _envIndex = _buildEnvIndex();
+  var slot = _envIndex[instanceName];
+  if (typeof slot !== 'number' || slot < 0) {
+    slot = _hashStr(instanceName || '') % ENV_BADGE_PALETTE.length;
+  }
+  return ENV_BADGE_PALETTE[slot];
+}
+
+function _envCount() {
+  if (!_envIndex) _envIndex = _buildEnvIndex();
+  return Object.keys(_envIndex).length;
+}
+
 // ── Kanban rendering ──
 function renderBoard(board) {
   _sessionCache = {}; // Clear stale cache each render cycle
+  // Populate cache from the entire board first so the env-palette pass
+  // (which reads every card's environment) and per-column renderCard
+  // calls share one walk over the data.
+  for (var col0 of ['working', 'waiting', 'idle', 'closed']) {
+    var arr = board[col0] || [];
+    for (var i0 = 0; i0 < arr.length; i0++) {
+      _sessionCache[arr[i0].key] = arr[i0];
+    }
+  }
+  _envIndex = _buildEnvIndex();
   var emptyHints = { working: 'No active sessions', waiting: 'No sessions awaiting input', idle: 'No idle sessions' };
   for (const col of ['working', 'waiting', 'idle']) {
     const container = document.getElementById('cards-' + col);
@@ -3506,9 +3879,23 @@ function renderCard(s, col) {
 
   // Action buttons — disabled for non-owners (server RBAC still rejects, but UI
   // shouldn't invite the click in the first place).
+  // #814 — sibling cards (env.instanceName !== self) get a "open on sibling"
+  // hint instead of action buttons. Posting Stop/Close/Trash to the local
+  // instance for a sibling-owned key would fail server-side
+  // (stripSelfInstancePrefix rejects foreign prefixes); rendering a clearly-
+  // disabled button with a redirect title is honest UX.
+  const isSibling = !!(SELF_INSTANCE_NAME && s.environment && s.environment.instanceName && s.environment.instanceName !== SELF_INSTANCE_NAME);
+  const siblingTitle = isSibling
+    ? ' title="' + escAttr('Open ' + s.environment.instanceName + ' (' + (s.environment.host || '') + ':' + (s.environment.port || '') + ') to act on this session') + '"'
+    : '';
   const readOnlyTitle = isOwner ? '' : ' title="' + escAttr(READ_ONLY_MSG) + '"';
   let actionBtn = '';
-  if (col === 'working') {
+  if (isSibling) {
+    // Sibling card — emit a disabled placeholder so the layout is consistent
+    // with same-instance cards but the click is impossible.
+    var label = (col === 'working') ? 'Stop' : (col === 'closed' && s.terminated ? 'Trash' : 'Close');
+    actionBtn = '<button class="btn-action btn-stop" disabled' + siblingTitle + '>' + label + ' \u2192 ' + esc(s.environment.instanceName) + '</button>';
+  } else if (col === 'working') {
     actionBtn = '<button class="btn-action btn-stop"' + readOnlyAttrs + readOnlyTitle + ' onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'stop\\')">Stop</button>';
   } else if (col === 'waiting' || col === 'idle') {
     actionBtn = '<button class="btn-action btn-close"' + readOnlyAttrs + readOnlyTitle + ' onclick="event.stopPropagation();doAction(\\'' + escJs(s.key) + '\\',\\'close\\')">Close</button>';
@@ -3567,7 +3954,18 @@ function renderCard(s, col) {
   const effortHtml = s.effort
     ? '<span class="meta-effort" title="Power level">' + esc(s.effort) + '</span>'
     : '';
+  // #814 env badge — only shown when multiple distinct envs are present in
+  // the current cache. Single-env (sibling 0 + INSTANCE_NAME unset) suppresses
+  // the badge to keep the card chrome quiet for single-instance deploys.
+  var envHtml = '';
+  if (s.environment && s.environment.instanceName && _envCount() > 1) {
+    var instName = s.environment.instanceName;
+    var envColor = getEnvBadgeColor(instName);
+    var envHostPort = (s.environment.host || '') + ':' + (s.environment.port || '');
+    envHtml = '<span class="env-badge" style="background:' + envColor + '" title="' + escAttr(instName + ' (' + envHostPort + ')') + '">' + esc(instName) + '</span>';
+  }
   const metaHtml = '<div class="card-meta">'
+    + envHtml
     + '<span>' + esc(s.workflow) + '</span>'
     + '<span>' + modelShort + '</span>'
     + effortHtml
@@ -4241,17 +4639,62 @@ function connectWs() {
 
 // ── Token stats from session cache ──
 function updateTokenStats() {
+  // #814 — group token usage by environment.instanceName so the topbar
+  // tooltip can break down "oudwood-dev: 12K | mac-mini-dev: 8K | Total: 20K".
+  // Fallback bucket ('') is used for cards whose environment is missing
+  // (legacy WS payloads, tests). When all cards share one env we suppress
+  // the tooltip entirely — see _envCount() check below.
+  var byEnv = {};
   let totalTokens = 0, totalCost = 0;
   for (const key in _sessionCache) {
     const s = _sessionCache[key];
     if (currentUserId && s.ownerId !== currentUserId) continue;
-    if (s.tokenUsage) {
-      totalTokens += s.tokenUsage.totalInputTokens + s.tokenUsage.totalOutputTokens;
-      totalCost += s.tokenUsage.totalCostUsd;
-    }
+    if (!s.tokenUsage) continue;
+    var t = s.tokenUsage.totalInputTokens + s.tokenUsage.totalOutputTokens;
+    totalTokens += t;
+    totalCost += s.tokenUsage.totalCostUsd;
+    var envName = (s.environment && s.environment.instanceName) || '';
+    if (!byEnv[envName]) byEnv[envName] = { tokens: 0, cost: 0 };
+    byEnv[envName].tokens += t;
+    byEnv[envName].cost += s.tokenUsage.totalCostUsd;
   }
   document.getElementById('stat-tokens').textContent = formatTokens(totalTokens);
   document.getElementById('stat-cost').textContent = '$' + totalCost.toFixed(2);
+
+  // Tooltip: only show when there's actually a breakdown (≥2 envs in
+  // the cache). For the single-instance / empty-env case we leave the
+  // tooltip dark so the topbar stays the same shape it was before #814.
+  var tip = document.getElementById('stat-tokens-tooltip');
+  var wrap = document.getElementById('stat-tokens-wrap');
+  if (!tip || !wrap) return;
+  var envNames = Object.keys(byEnv).filter(function(n) { return n.length > 0; });
+  if (envNames.length < 2) {
+    tip.textContent = '';
+    wrap.classList.remove('tooltip-open');
+    wrap.removeAttribute('data-has-breakdown');
+    return;
+  }
+  // Stable order: sort so the same env always renders in the same position.
+  envNames.sort();
+  var parts = [];
+  for (var i = 0; i < envNames.length; i++) {
+    var n = envNames[i];
+    parts.push(esc(n) + ': ' + formatTokens(byEnv[n].tokens));
+  }
+  parts.push('Total: ' + formatTokens(totalTokens));
+  tip.innerHTML = parts.join(' &middot; ');
+  wrap.setAttribute('data-has-breakdown', 'true');
+  // Mobile (no-hover) tap-toggle wiring — attach once.
+  if (!wrap.hasAttribute('data-tap-bound')) {
+    wrap.setAttribute('data-tap-bound', 'true');
+    wrap.addEventListener('click', function() {
+      // Only toggle on touch-likely devices; on hover-capable devices the
+      // CSS :hover rule already handles it and a click adds noise.
+      if (window.matchMedia('(hover: none)').matches) {
+        wrap.classList.toggle('tooltip-open');
+      }
+    });
+  }
 }
 
 // ── Slide Panel ──

--- a/src/conversation/instance-registry.ts
+++ b/src/conversation/instance-registry.ts
@@ -1,0 +1,232 @@
+/**
+ * Instance heartbeat registry — discovery layer for multi-instance dashboard
+ * aggregation (#814).
+ *
+ * Each running soma-work instance writes a small JSON file
+ * `<HEARTBEAT_DIR>/<port>.json` and refreshes its `lastSeen` timestamp every
+ * few seconds. Other instances on the same machine can read the directory to
+ * find sibling instances and call their public API.
+ *
+ * The directory defaults to `~/.soma/instances` and can be overridden by the
+ * `SOMA_INSTANCE_DIR` environment variable (used by tests and by operators
+ * who want a non-default location).
+ *
+ * Stale records (lastSeen older than {@link STALE_THRESHOLD_MS}) are filtered
+ * out by {@link readAllInstances} — they're left on disk for the owner
+ * process (or the next start on the same port) to overwrite, so a crashed
+ * instance is harmless rather than fatal.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { Logger } from '../logger';
+
+const logger = new Logger('InstanceRegistry');
+
+/**
+ * Records older than this are treated as stale and excluded from
+ * {@link readAllInstances}. The 30 s window matches the spec in #814 and
+ * gives the heartbeat loop (5 s default) ~6 attempts before a sibling is
+ * considered dead.
+ */
+export const STALE_THRESHOLD_MS = 30_000;
+
+/** Default refresh cadence for {@link startHeartbeatLoop}. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 5_000;
+
+export interface HeartbeatPayload {
+  /** Listening port — also the filename stem (`<port>.json`). */
+  port: number;
+  /**
+   * Operator-supplied instance label (e.g. `oudwood-dev`). When empty the
+   * caller is expected to fall back to `${hostname}:${port}` upstream.
+   */
+  instanceName: string;
+  /** Resolvable hostname (or bind address) for the instance. */
+  host: string;
+  /** OS process id — used by the aggregator to defend against port reuse. */
+  pid: number;
+}
+
+export interface InstanceRecord extends HeartbeatPayload {
+  /** Epoch ms of the most recent heartbeat write. */
+  lastSeen: number;
+}
+
+/**
+ * Resolve the heartbeat directory.
+ *
+ * `SOMA_INSTANCE_DIR` wins so tests can pin to a temp dir and operators can
+ * relocate the registry without code changes. Otherwise we use
+ * `~/.soma/instances`, which lives alongside other soma state under the
+ * user's home directory.
+ *
+ * Resolution happens at call time, not at module load — tests mutate the
+ * env var between cases, so caching here would leak state across describes.
+ */
+function getHeartbeatDir(): string {
+  const override = process.env.SOMA_INSTANCE_DIR;
+  if (override && override.length > 0) return override;
+  return path.join(os.homedir(), '.soma', 'instances');
+}
+
+// Module-scoped guard — the heartbeat directory only needs to be created
+// once per process per resolved path. Avoids one mkdir syscall per 5 s
+// tick × instance over the lifetime of the server.
+let _ensuredDir: string | null = null;
+
+/**
+ * Atomically write `<dir>/<port>.json` with mode 0600.
+ *
+ * Atomicity: we write to a unique temp file in the same directory, then
+ * `rename()` over the target. POSIX rename is atomic within a filesystem,
+ * so a concurrent reader either sees the previous payload or the new one
+ * — never a half-written stream.
+ *
+ * The 0600 mode is requested on the temp file before rename. The
+ * effective bits are subject to the process umask (Node honours the
+ * caller's umask for `fs.writeFile`'s `mode`); operators with a
+ * non-default umask may see a tighter mode but never a looser one,
+ * which is the safe direction. The `instance-registry.test.ts` test
+ * pins the expected `0o600` on POSIX hosts and skips the assertion on
+ * Windows where POSIX permission bits are not meaningful.
+ */
+export async function writeHeartbeat(payload: HeartbeatPayload): Promise<void> {
+  const dir = getHeartbeatDir();
+  if (_ensuredDir !== dir) {
+    await fs.mkdir(dir, { recursive: true });
+    _ensuredDir = dir;
+  }
+
+  const target = path.join(dir, `${payload.port}.json`);
+  // Per-process random suffix keeps concurrent writers from clobbering each
+  // other's temp files. process.pid alone isn't enough — the heartbeat
+  // loop may overlap with itself if the disk is slow.
+  const tmp = path.join(dir, `${payload.port}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`);
+
+  const record: InstanceRecord = {
+    ...payload,
+    lastSeen: Date.now(),
+  };
+
+  try {
+    await fs.writeFile(tmp, JSON.stringify(record), { mode: 0o600 });
+    await fs.rename(tmp, target);
+  } catch (err) {
+    // Defensive cleanup: if rename failed, the tmp may linger.
+    try {
+      await fs.unlink(tmp);
+    } catch {
+      // ignore — tmp may already be gone
+    }
+    throw err;
+  }
+}
+
+/**
+ * Read all heartbeat files in the registry directory and return non-stale
+ * instance records. Bad / non-JSON files are skipped silently (with a
+ * warn log) — a corrupt file from a crashed write must not break sibling
+ * discovery for the rest of the registry.
+ */
+export async function readAllInstances(): Promise<InstanceRecord[]> {
+  const dir = getHeartbeatDir();
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return [];
+    logger.warn('Failed to read instance registry directory', { dir, err });
+    return [];
+  }
+
+  const now = Date.now();
+  const jsonFiles = entries.filter((n) => n.endsWith('.json'));
+  const records = await Promise.all(
+    jsonFiles.map(async (name) => {
+      const full = path.join(dir, name);
+      let raw: string;
+      try {
+        raw = await fs.readFile(full, 'utf8');
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        // ENOENT is benign (file vanished mid-readdir, heartbeat
+        // overwrite race). EACCES / EIO are real and surface so an
+        // operator can fix permissions instead of seeing silently
+        // empty sibling discovery.
+        if (code !== 'ENOENT') {
+          logger.warn('Heartbeat file read failed', { name, code });
+        }
+        return null;
+      }
+      let parsed: any;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        logger.warn('Skipping unparseable heartbeat file', { name });
+        return null;
+      }
+      if (!parsed || typeof parsed !== 'object') return null;
+      if (typeof parsed.port !== 'number') return null;
+      if (typeof parsed.lastSeen !== 'number') return null;
+      if (now - parsed.lastSeen > STALE_THRESHOLD_MS) return null;
+      return {
+        port: parsed.port,
+        instanceName: typeof parsed.instanceName === 'string' ? parsed.instanceName : '',
+        host: typeof parsed.host === 'string' ? parsed.host : '127.0.0.1',
+        pid: typeof parsed.pid === 'number' ? parsed.pid : 0,
+        lastSeen: parsed.lastSeen,
+      } satisfies InstanceRecord;
+    }),
+  );
+  return records.filter((r): r is InstanceRecord => r !== null);
+}
+
+/**
+ * Delete the heartbeat file for a given port. No-op if it doesn't exist
+ * (covers the case where shutdown runs twice or the file was never
+ * written successfully).
+ */
+export async function removeHeartbeat(port: number): Promise<void> {
+  const dir = getHeartbeatDir();
+  const target = path.join(dir, `${port}.json`);
+  try {
+    await fs.unlink(target);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return;
+    logger.warn('Failed to remove heartbeat file', { target, err });
+  }
+}
+
+/**
+ * Start a refresh loop that writes the heartbeat immediately and then again
+ * every `intervalMs` (default {@link DEFAULT_HEARTBEAT_INTERVAL_MS}). The
+ * returned handle can be passed to `clearInterval` for shutdown cleanup.
+ *
+ * The immediate write covers the dashboard-aggregator race where
+ * `:33000` boots and a user opens its page before the first interval
+ * tick has fired.
+ */
+export function startHeartbeatLoop(
+  payload: HeartbeatPayload,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): NodeJS.Timeout {
+  // Fire-and-forget the kick-off write — errors are logged but must not
+  // block the interval (otherwise a transient mkdir failure would silently
+  // disable discovery for the lifetime of the process).
+  void writeHeartbeat(payload).catch((err) => {
+    logger.warn('Initial heartbeat write failed', err);
+  });
+  const handle = setInterval(() => {
+    void writeHeartbeat(payload).catch((err) => {
+      logger.warn('Heartbeat refresh failed', err);
+    });
+  }, intervalMs);
+  // Allow the process to exit even if the interval is still scheduled.
+  if (typeof handle.unref === 'function') handle.unref();
+  return handle;
+}

--- a/src/conversation/web-server.ts
+++ b/src/conversation/web-server.ts
@@ -13,7 +13,8 @@ import { config } from '../config';
 import { IS_DEV } from '../env-paths';
 import { registerHookRoutes } from '../hooks';
 import { Logger } from '../logger';
-import { registerDashboardRoutes } from './dashboard';
+import { registerDashboardRoutes, setSelfInstanceEnv } from './dashboard';
+import { removeHeartbeat, startHeartbeatLoop } from './instance-registry';
 import {
   type AuthContext,
   generateCsrfToken,
@@ -301,6 +302,8 @@ export { requireWriteAccess };
 
 let server: FastifyInstance | null = null;
 let activePort: number | null = null;
+let heartbeatHandle: NodeJS.Timeout | null = null;
+let heartbeatPort: number | null = null;
 
 const DEFAULT_PORT_MAIN = 3000;
 const DEFAULT_PORT_DEV = 33000;
@@ -590,6 +593,34 @@ export async function startWebServer(options: StartWebServerOptions = {}): Promi
       } else {
         logger.warn('Authentication disabled (CONVERSATION_VIEWER_TOKEN not set)');
       }
+
+      // #814 Multi-instance discovery: write a heartbeat so other soma-work
+      // instances on this host can find us. Resolve `instanceName` here
+      // (after `activePort` is final) because the fallback shape is
+      // `${hostname}:${port}` and the operator-supplied
+      // `INSTANCE_NAME` (config.conversation.instanceName) wins. The host
+      // label uses the same resolver as the viewer URL so siblings can
+      // reach us — `127.0.0.1` is fine for same-machine aggregation.
+      const resolvedInstanceName =
+        config.conversation.instanceName?.trim() || `${os.hostname() || 'localhost'}:${port}`;
+      const heartbeatHost = host && host !== '0.0.0.0' ? host : '127.0.0.1';
+      // `startHeartbeatLoop` returns synchronously — it kicks off the
+      // first write as a fire-and-forget promise (logged-and-eaten in
+      // instance-registry on failure). No try/catch needed here; a
+      // permanent fs problem surfaces as a per-tick warn from the loop
+      // itself, and `setSelfInstanceEnv` runs unconditionally so the
+      // dashboard handler can still serve the self board.
+      heartbeatHandle = startHeartbeatLoop({
+        port,
+        instanceName: resolvedInstanceName,
+        host: heartbeatHost,
+        pid: process.pid,
+      });
+      heartbeatPort = port;
+      // Hand the resolved env to the dashboard so the aggregator can stamp
+      // self cards and the handler can fan out to siblings.
+      setSelfInstanceEnv({ instanceName: resolvedInstanceName, port, host: heartbeatHost });
+
       return;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'EADDRINUSE' && attempt < MAX_PORT_RETRIES - 1) {
@@ -613,6 +644,21 @@ export async function stopWebServer(): Promise<void> {
       hookState.flushSync();
     } catch {
       // Hook module may not be loaded
+    }
+    // #814 Stop the heartbeat loop and remove our registry entry before
+    // tearing down the server so siblings stop trying to fan out to us
+    // mid-shutdown.
+    if (heartbeatHandle) {
+      clearInterval(heartbeatHandle);
+      heartbeatHandle = null;
+    }
+    if (heartbeatPort != null) {
+      try {
+        await removeHeartbeat(heartbeatPort);
+      } catch (err) {
+        logger.warn('Failed to remove heartbeat on shutdown', err);
+      }
+      heartbeatPort = null;
     }
     await server.close();
     server = null;

--- a/src/slack/__tests__/mcp-status-tracker.test.ts
+++ b/src/slack/__tests__/mcp-status-tracker.test.ts
@@ -72,10 +72,12 @@ describe('McpStatusDisplay', () => {
       display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
       display.registerCall('session1', 'call2', mcpConfig('jira', 'search'), 'C123', '111.222');
 
-      // First tick should post a single consolidated message
-      await vi.advanceTimersByTimeAsync(10_000);
+      // Issue #794 — first registerCall fires an immediate enqueued tick;
+      // the second one joins the existing session and does NOT post again.
+      // Drain microtasks (no timer advance) so the immediate tick lands.
+      await vi.advanceTimersByTimeAsync(0);
 
-      // Only 1 postMessage (consolidated), not 2 separate ones
+      // Only 1 postMessage from the immediate render — second call joined.
       expect(mockSlackApi.postMessage).toHaveBeenCalledTimes(1);
     });
 
@@ -83,17 +85,21 @@ describe('McpStatusDisplay', () => {
       display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
       display.registerCall('session2', 'call2', mcpConfig('jira', 'search'), 'C456', '222.333');
 
-      await vi.advanceTimersByTimeAsync(10_000);
+      // Issue #794 — each session's first registerCall fires its own
+      // immediate render. Drain microtasks rather than waiting 10s.
+      await vi.advanceTimersByTimeAsync(0);
 
       // Each session gets its own message
       expect(mockSlackApi.postMessage).toHaveBeenCalledTimes(2);
     });
 
-    it('should post initial message on first tick', async () => {
+    it('should post initial message immediately on register (issue #794)', async () => {
       display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
 
-      await vi.advanceTimersByTimeAsync(10_000);
+      // Drain microtasks — no timer advance needed.
+      await vi.advanceTimersByTimeAsync(0);
 
+      expect(mockSlackApi.postMessage).toHaveBeenCalledTimes(1);
       expect(mockSlackApi.postMessage).toHaveBeenCalledWith('C123', expect.stringContaining('codex → search'), {
         threadTs: '111.222',
       });
@@ -102,13 +108,31 @@ describe('McpStatusDisplay', () => {
     it('should update message on subsequent ticks', async () => {
       display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
 
-      // First tick: post
-      await vi.advanceTimersByTimeAsync(10_000);
+      // First render is immediate (issue #794) — runs after microtasks drain.
+      await vi.advanceTimersByTimeAsync(0);
       expect(mockSlackApi.postMessage).toHaveBeenCalledTimes(1);
 
-      // Second tick: update
+      // Setinterval tick at +10s: update.
       await vi.advanceTimersByTimeAsync(10_000);
       expect(mockSlackApi.updateMessage).toHaveBeenCalled();
+    });
+
+    it('should NOT post twice when same session registers a second call (issue #794 S16)', async () => {
+      display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
+      // Allow the first immediate tick to land before the second register.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackApi.postMessage).toHaveBeenCalledTimes(1);
+
+      // Second register on same session — should join existing tick.
+      display.registerCall('session1', 'call2', mcpConfig('jira', 'search'), 'C123', '111.222');
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Still 1 post — the second register did NOT trigger an extra
+      // immediate render, it joined the live session.
+      expect(mockSlackApi.postMessage).toHaveBeenCalledTimes(1);
+      // updateMessage may or may not have fired depending on render
+      // ordering — what matters is no extra `postMessage` for the
+      // joined call.
     });
   });
 
@@ -154,18 +178,22 @@ describe('McpStatusDisplay', () => {
     it('should fall back to startTime-based elapsed when duration is null', async () => {
       display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
 
-      // 5s pass before completion (first tick is at 10s, so no tick fires yet)
+      // Issue #794 — first render is immediate (running state). Drain
+      // microtasks so the immediate tick lands, then sleep 5s before
+      // completion so the startTime-based fallback can resolve to 5s.
       await vi.advanceTimersByTimeAsync(5000);
 
       // Abort / untracked path: duration comes through as null
       display.completeCall('call1', null);
 
-      // Next tick renders the completed state
+      // setInterval fires at +10s → updateMessage with the completed state.
       await vi.advanceTimersByTimeAsync(10_000);
 
-      const postText = mockSlackApi.postMessage.mock.calls[0][1];
-      expect(postText).toContain('🟢');
-      expect(postText).toContain('5.0s');
+      // Final state lives on updateMessage (the immediate post showed
+      // the running state), so assert against the last update.
+      const updateText = mockSlackApi.updateMessage.mock.lastCall?.[2] ?? '';
+      expect(updateText).toContain('🟢');
+      expect(updateText).toContain('5.0s');
     });
 
     it('should preserve explicit duration=0 (do not fall back on 0)', async () => {
@@ -179,10 +207,11 @@ describe('McpStatusDisplay', () => {
 
       await vi.advanceTimersByTimeAsync(10_000);
 
-      const postText = mockSlackApi.postMessage.mock.calls[0][1];
-      // Expect 0ms-style formatting, not the 4s fallback.
-      expect(postText).toContain('0ms');
-      expect(postText).not.toContain('4.0s');
+      // Final completion render lands on updateMessage (issue #794:
+      // immediate first post already happened with the running state).
+      const updateText = mockSlackApi.updateMessage.mock.lastCall?.[2] ?? '';
+      expect(updateText).toContain('0ms');
+      expect(updateText).not.toContain('4.0s');
     });
 
     it('should show elapsed for every call in multi-call session even when one is null', async () => {
@@ -196,9 +225,11 @@ describe('McpStatusDisplay', () => {
 
       await vi.advanceTimersByTimeAsync(10_000);
 
-      const postText = mockSlackApi.postMessage.mock.calls[0][1];
-      expect(postText).toContain('3.0s'); // from startTime fallback
-      expect(postText).toContain('7.0s'); // from explicit duration
+      // Issue #794 — final completion text is on updateMessage (post #1
+      // was the immediate render at t=0).
+      const updateText = mockSlackApi.updateMessage.mock.lastCall?.[2] ?? '';
+      expect(updateText).toContain('3.0s'); // from startTime fallback
+      expect(updateText).toContain('7.0s'); // from explicit duration
     });
 
     it('should render mixed state (some complete, some running)', async () => {
@@ -220,6 +251,10 @@ describe('McpStatusDisplay', () => {
     it('should remove all calls and stop tick for a session', async () => {
       display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
       display.registerCall('session1', 'call2', mcpConfig('jira', 'search'), 'C123', '111.222');
+
+      // Drain immediate-tick microtasks first (issue #794 — first
+      // render is enqueued on registerCall).
+      await vi.advanceTimersByTimeAsync(0);
 
       display.cleanupSession('session1');
 
@@ -250,13 +285,16 @@ describe('McpStatusDisplay', () => {
       mockMcpCallTracker.getElapsedTime.mockReturnValue(30_000); // 30s
       display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
 
-      // First tick at 10s
+      // Immediate render is the first post (issue #794). setInterval
+      // ticks at +10s/+20s issue updates.
       await vi.advanceTimersByTimeAsync(10_000);
       expect(mockSlackApi.postMessage).toHaveBeenCalledTimes(1);
-
-      // Second tick at 20s
-      await vi.advanceTimersByTimeAsync(10_000);
       expect(mockSlackApi.updateMessage).toHaveBeenCalledTimes(1);
+
+      // Second setInterval tick at +20s — another update.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(mockSlackApi.postMessage).toHaveBeenCalledTimes(1);
+      expect(mockSlackApi.updateMessage).toHaveBeenCalledTimes(2);
     });
 
     it('should use 30s interval for calls 1-10 minutes old', async () => {
@@ -460,6 +498,78 @@ describe('McpStatusDisplay', () => {
       // Canonical multi-line "실행 중" header from buildRunningText must
       // still appear for plain MCP
       expect(postText).toContain('실행 중:');
+    });
+  });
+
+  /**
+   * Issue #794 — `flushSession` is the awaitable final-render fence
+   * called by `ToolEventProcessor.cleanup`. Caller-side contract:
+   *   1. Mark every active callId as completed
+   *      (`completeCall(id, null)`) BEFORE invoking flushSession.
+   *   2. `await flushSession(sessionKey)` — drains the render chain
+   *      (so any in-flight tick lands first), enqueues a final tick,
+   *      tears the session down only when no `running` entries remain.
+   */
+  describe('flushSession (issue #794)', () => {
+    it('S17: flushSession after completeCall renders final state and tears session down', async () => {
+      display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
+      // Allow the immediate render to land before we mark completed.
+      await vi.advanceTimersByTimeAsync(0);
+      const postCallsBefore = mockSlackApi.postMessage.mock.calls.length;
+
+      display.completeCall('call1', 4321);
+      await display.flushSession('session1');
+
+      // After flushSession the active count is 0 — entries cleared.
+      expect(display.getActiveCount()).toBe(0);
+
+      // Final render must mention the completion marker. It lands on
+      // either postMessage (if the immediate render was the very first
+      // call) or updateMessage (subsequent flush). Combine both surfaces
+      // and check the last text reflects the completion.
+      const lastUpdate = mockSlackApi.updateMessage.mock.lastCall?.[2] ?? '';
+      const lastPost = mockSlackApi.postMessage.mock.calls[postCallsBefore]?.[1] ?? '';
+      const lastText = lastUpdate || lastPost;
+      expect(lastText).toContain('🟢');
+
+      // Session tick is gone — no further ticks after we advance time.
+      mockSlackApi.postMessage.mockClear();
+      mockSlackApi.updateMessage.mockClear();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(mockSlackApi.postMessage).not.toHaveBeenCalled();
+      expect(mockSlackApi.updateMessage).not.toHaveBeenCalled();
+    });
+
+    it('S12: flushSession is idempotent — second call is a no-op', async () => {
+      display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
+      await vi.advanceTimersByTimeAsync(0);
+      display.completeCall('call1', 1000);
+
+      await display.flushSession('session1');
+      // Second flush — must not throw, must not re-post.
+      mockSlackApi.postMessage.mockClear();
+      mockSlackApi.updateMessage.mockClear();
+      await display.flushSession('session1');
+      expect(mockSlackApi.postMessage).not.toHaveBeenCalled();
+      expect(mockSlackApi.updateMessage).not.toHaveBeenCalled();
+    });
+
+    it('flushSession on unknown session is a no-op', async () => {
+      await expect(display.flushSession('does-not-exist')).resolves.toBeUndefined();
+      expect(mockSlackApi.postMessage).not.toHaveBeenCalled();
+      expect(mockSlackApi.updateMessage).not.toHaveBeenCalled();
+    });
+
+    it('flushSession leaves tick alive when running calls remain (turn-replacement guard)', async () => {
+      display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Caller forgot to completeCall — flushSession should NOT tear the
+      // tick down because a running call remains. The next setInterval
+      // tick (or a later flush) cleans up.
+      await display.flushSession('session1');
+
+      expect(display.getActiveCount()).toBe(1);
     });
   });
 

--- a/src/slack/__tests__/mcp-status-tracker.test.ts
+++ b/src/slack/__tests__/mcp-status-tracker.test.ts
@@ -134,6 +134,93 @@ describe('McpStatusDisplay', () => {
       // ordering — what matters is no extra `postMessage` for the
       // joined call.
     });
+
+    // S16-tri — `tick.renderChain` poison-pill catch contract: a
+    // synchronous throw inside `doTick` outside the inner Slack
+    // try/catches (e.g. `getElapsedTime` in the timeout-check loop)
+    // must be (a) caught synchronously on the same tick — never
+    // escape as an unhandled rejection — (b) logged with sessionKey,
+    // and (c) leave the chain alive so the next tick's render
+    // proceeds. Pin so a future "drop the inner try/catch" refactor
+    // would force a visible test failure rather than silently
+    // disabling the session's progress UI for the rest of its life.
+    it('S16-tri: synchronous throw inside doTick is logged and renderChain stays alive', async () => {
+      const warnSpy = vi.spyOn((display as any).logger, 'warn');
+      let throwOnce = true;
+      mockMcpCallTracker.getElapsedTime.mockImplementation(() => {
+        if (throwOnce) {
+          throwOnce = false;
+          throw new Error('synthetic doTick failure');
+        }
+        return 5000;
+      });
+
+      display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
+      // Immediate tick fires → throws inside doTick → caught by inner
+      // try/catch → logger.warn fires → renderChain stays resolved.
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'mcp render tick failed (chain kept alive)',
+        expect.objectContaining({ sessionKey: 'session1', error: 'synthetic doTick failure' }),
+      );
+
+      // setInterval tick at +10s → fresh doTick runs and lands a
+      // postMessage, proving the chain is still accepting work.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(mockSlackApi.postMessage).toHaveBeenCalled();
+    });
+
+    // S16-bis — direct serialization probe for `tick.renderChain`. The
+    // S16 test only counts calls; this one pins the contract that two
+    // back-to-back ticks NEVER overlap a Slack API call. A future
+    // refactor that drops `.then(() => this.doTick(tick))` chaining
+    // (e.g. `void this.doTick(tick)`) would pass S16 but fail this.
+    it('S16-bis: tick.renderChain serializes back-to-back ticks (no concurrent Slack calls)', async () => {
+      // Manually-controlled deferred for the FIRST postMessage. The
+      // chain must not invoke the second render path until this resolves.
+      let resolveFirstPost!: (v: { ts: string; channel: string }) => void;
+      const firstPost = new Promise<{ ts: string; channel: string }>((resolve) => {
+        resolveFirstPost = resolve;
+      });
+
+      let postCallCount = 0;
+      mockSlackApi.postMessage.mockImplementation(() => {
+        postCallCount++;
+        if (postCallCount === 1) return firstPost;
+        // Defensive: no test path should reach here — second render must
+        // hit `updateMessage` once `messageTs` is assigned by the first.
+        return Promise.resolve({ ts: 'unexpected', channel: 'C123' });
+      });
+
+      // Fire the first immediate tick via registerCall.
+      display.registerCall('session1', 'call1', mcpConfig('codex', 'search'), 'C123', '111.222');
+      // Drain microtasks but keep the first postMessage pending.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(postCallCount).toBe(1);
+      expect(mockSlackApi.updateMessage).not.toHaveBeenCalled();
+
+      // Race-attempt: complete the call mid-flight and advance the
+      // setInterval — the second render path is now enqueued but MUST
+      // wait for the first postMessage to resolve. Without renderChain
+      // chaining, `updateMessage` would fire here on the un-set messageTs.
+      display.completeCall('call1', 5000);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      // Still only one Slack call in flight (the original post). No
+      // concurrent updateMessage interleaved.
+      expect(postCallCount).toBe(1);
+      expect(mockSlackApi.updateMessage).not.toHaveBeenCalled();
+
+      // Resolve the first postMessage; the chained tick can now run.
+      resolveFirstPost({ ts: '123.456', channel: 'C123' });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Second render landed via updateMessage (messageTs is now set).
+      // postCallCount must remain 1 — exactly one post per session.
+      expect(postCallCount).toBe(1);
+      expect(mockSlackApi.updateMessage).toHaveBeenCalled();
+    });
   });
 
   describe('completeCall', () => {

--- a/src/slack/__tests__/stream-processor.test.ts
+++ b/src/slack/__tests__/stream-processor.test.ts
@@ -4,6 +4,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  extractTaskIdFromResult,
   PendingForm,
   type SayFunction,
   type StreamCallbacks,
@@ -811,5 +812,42 @@ describe('StreamProcessor', () => {
       // already routes through threadPanel.appendText (covered above).
       expect(mockSay).not.toHaveBeenCalled();
     });
+  });
+});
+
+// Issue #794 — `extractTaskIdFromResult` is the single source of truth
+// for spawn-ack detection (cf. `ToolEventProcessor.isBackgroundTaskSpawnAck`
+// reuses the exact same regex). The array-shape branch must gate on
+// `type === 'text'` so non-text parts (image, tool_use, …) cannot
+// false-positive when they happen to carry a `text` metadata field.
+describe('extractTaskIdFromResult', () => {
+  it('string result: extracts task_id', () => {
+    expect(extractTaskIdFromResult('Started bg. task_id: abc-123')).toBe('abc-123');
+  });
+
+  it('array result with {type:"text"} part: extracts task_id', () => {
+    expect(extractTaskIdFromResult([{ type: 'text', text: 'Started bg. task_id: zeta-9' }])).toBe('zeta-9');
+  });
+
+  it('array result with non-text part carrying a `text` field: returns undefined (no false-positive)', () => {
+    // A future SDK shape — e.g. an image part with a captioning `text`
+    // metadata field — must NOT be mined for `task_id`. The
+    // `type === 'text'` gate is what holds this invariant.
+    expect(
+      extractTaskIdFromResult([{ type: 'image', source: { data: 'b64' }, text: 'task_id: WRONG' }]),
+    ).toBeUndefined();
+  });
+
+  it('array result with bare-string parts (legacy shape): still extracts task_id', () => {
+    expect(extractTaskIdFromResult(['Started bg. task_id: legacy-1'])).toBe('legacy-1');
+  });
+
+  it('array result with no task_id marker: returns undefined', () => {
+    expect(extractTaskIdFromResult([{ type: 'text', text: 'no marker here' }])).toBeUndefined();
+  });
+
+  it('null/undefined result: returns undefined', () => {
+    expect(extractTaskIdFromResult(undefined)).toBeUndefined();
+    expect(extractTaskIdFromResult(null)).toBeUndefined();
   });
 });

--- a/src/slack/__tests__/tool-event-processor.test.ts
+++ b/src/slack/__tests__/tool-event-processor.test.ts
@@ -575,6 +575,51 @@ describe('ToolEventProcessor', () => {
       expect(mcpStatusDisplay.completeCall).toHaveBeenCalledWith('call_123', 1000);
     });
 
+    // S14c — bg Task non-empty result with NO task_id marker also emits a
+    // dev-warn surfacing the shape, so a silent SDK content-block schema
+    // drift (e.g. `{type:'output_text',…}`, structured task_id field)
+    // leaves an operator breadcrumb instead of silently regressing #794.
+    it('S14c: bg Task result missing task_id on non-empty payload → logger.warn shape-drift signal', async () => {
+      const warnSpy = vi.spyOn((processor as any).logger, 'warn');
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_bg_drift', name: 'Task', input: makeBgTaskInput() }], ctx);
+      warnSpy.mockClear();
+
+      await processor.handleToolResult(
+        [{ toolUseId: 'tu_bg_drift', toolName: 'Task', result: 'unexpected shape, no marker', isError: false }],
+        ctx,
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('possible SDK content-block shape drift'),
+        expect.objectContaining({
+          toolUseId: 'tu_bg_drift',
+          resultType: 'string',
+          resultLength: 'unexpected shape, no marker'.length,
+        }),
+      );
+    });
+
+    // S14d — empty/null result must NOT emit the shape-drift warn (benign
+    // path — pin so a future "always-warn" regression doesn't spam logs
+    // on every empty bg Task result).
+    it('S14d: bg Task empty/null result → no shape-drift warn', async () => {
+      const warnSpy = vi.spyOn((processor as any).logger, 'warn');
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_bg_empty', name: 'Task', input: makeBgTaskInput() }], ctx);
+      warnSpy.mockClear();
+
+      await processor.handleToolResult(
+        [{ toolUseId: 'tu_bg_empty', toolName: 'Task', result: '', isError: false }],
+        ctx,
+      );
+
+      const driftWarns = warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('shape drift'),
+      );
+      expect(driftWarns).toHaveLength(0);
+    });
+
     // S14b — bg Task non-ack result without `task_id`: normal close too.
     it('S14b: bg Task result without task_id marker → endMcpTracking fires', async () => {
       const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
@@ -631,6 +676,47 @@ describe('ToolEventProcessor', () => {
 
       expect(mcpStatusDisplay.completeCall).toHaveBeenCalledWith('call_turn1', null);
       expect(mcpStatusDisplay.completeCall).not.toHaveBeenCalledWith('call_turn2', null);
+    });
+
+    // S15-quad — legacy cleanup() without turnId: must emit dev-warn so a
+    // misuse caller leaves a breadcrumb. Pins the warn so a future
+    // refactor that drops the legacy fallback (or its observability)
+    // can't silently regress the documented misuse-detection contract.
+    it('S15-quad: cleanup(sessionKey) WITHOUT turnId emits dev-warn when bg Task registry is non-empty', async () => {
+      const warnSpy = vi.spyOn((processor as any).logger, 'warn');
+
+      // Register a bg Task under turn-1 — entry indexed by turnId.
+      mcpCallTracker.startCall.mockReturnValueOnce('call_bg_leak');
+      const ctxTurn1: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-1' };
+      await processor.handleToolUse(
+        [{ id: 'tu_bg_leak', name: 'Task', input: makeBgTaskInput('leak probe') }],
+        ctxTurn1,
+      );
+
+      warnSpy.mockClear();
+
+      // Legacy caller — no turnId. The bg Task entry is keyed by turn-1
+      // and cannot be located from this fallback path → leaks.
+      await processor.cleanup('C123:thread_ts');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('cleanup() called without turnId'),
+        expect.objectContaining({ sessionKey: 'C123:thread_ts', registrySize: 1 }),
+      );
+    });
+
+    // S15-quad-b — counterpart: turnId-less cleanup with an EMPTY bg Task
+    // registry must NOT warn. Prevents a future "always-warn" regression
+    // that would log on every legitimate one-shot abort flow.
+    it('S15-quad-b: cleanup(sessionKey) WITHOUT turnId is silent when bg Task registry is empty', async () => {
+      const warnSpy = vi.spyOn((processor as any).logger, 'warn');
+
+      await processor.cleanup('C123:thread_ts');
+
+      const leakWarns = warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('cleanup() called without turnId'),
+      );
+      expect(leakWarns).toHaveLength(0);
     });
 
     // S15-tri — same-session, two turns: cleanup(turn1) leaves turn2 bg Task alone.

--- a/src/slack/__tests__/tool-event-processor.test.ts
+++ b/src/slack/__tests__/tool-event-processor.test.ts
@@ -30,10 +30,14 @@ describe('ToolEventProcessor', () => {
       registerCall: vi.fn(),
       completeCall: vi.fn(),
       cleanupSession: vi.fn(),
+      // Issue #794 — async final-render fence. Mock returns immediately
+      // so cleanup tests don't hang on a real Promise.
+      flushSession: vi.fn().mockResolvedValue(undefined),
     };
     mcpCallTracker = {
       startCall: vi.fn().mockReturnValue('call_123'),
       endCall: vi.fn().mockReturnValue(1000),
+      getElapsedTime: vi.fn().mockReturnValue(750),
       getToolStats: vi.fn().mockReturnValue(null),
     };
     processor = new ToolEventProcessor(toolTracker, mcpStatusDisplay, mcpCallTracker);
@@ -387,30 +391,294 @@ describe('ToolEventProcessor', () => {
   });
 
   describe('cleanup', () => {
-    it('should call cleanupSession on mcpStatusDisplay', () => {
-      processor.cleanup('C123:thread_ts');
+    it('should call flushSession on mcpStatusDisplay (issue #794)', async () => {
+      await processor.cleanup('C123:thread_ts');
 
+      // Issue #794 — `flushSession` is the awaitable final-render fence.
+      expect(mcpStatusDisplay.flushSession).toHaveBeenCalledWith('C123:thread_ts');
+      expect(mcpStatusDisplay.cleanupSession).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to cleanupSession when flushSession throws', async () => {
+      // flushSession does Slack I/O; on failure cleanup must still tear
+      // down the session tick synchronously so timers don't leak.
+      mcpStatusDisplay.flushSession.mockRejectedValueOnce(new Error('slack down'));
+
+      await processor.cleanup('C123:thread_ts');
+
+      expect(mcpStatusDisplay.flushSession).toHaveBeenCalledWith('C123:thread_ts');
       expect(mcpStatusDisplay.cleanupSession).toHaveBeenCalledWith('C123:thread_ts');
     });
 
-    it('should complete active MCP calls before cleanup', () => {
+    it('should complete active MCP calls before cleanup (legacy global sweep, no turnId)', async () => {
       // Track active MCP calls
       toolTracker.trackToolUse('tool_1', 'mcp__codex__search');
       toolTracker.trackMcpCall('tool_1', 'call_1');
       toolTracker.trackToolUse('tool_2', 'mcp__jira__search');
       toolTracker.trackMcpCall('tool_2', 'call_2');
 
-      processor.cleanup('C123:thread_ts');
+      // No turnId provided → legacy `getActiveMcpCallIds` sweep path.
+      await processor.cleanup('C123:thread_ts');
 
       // Should complete active calls
       expect(mcpStatusDisplay.completeCall).toHaveBeenCalledWith('call_1', null);
       expect(mcpStatusDisplay.completeCall).toHaveBeenCalledWith('call_2', null);
-      // Then cleanup session
-      expect(mcpStatusDisplay.cleanupSession).toHaveBeenCalledWith('C123:thread_ts');
+      // Then flush session (issue #794 await fence)
+      expect(mcpStatusDisplay.flushSession).toHaveBeenCalledWith('C123:thread_ts');
     });
 
-    it('should not throw without sessionKey', () => {
-      expect(() => processor.cleanup()).not.toThrow();
+    it('should not throw without sessionKey', async () => {
+      await expect(processor.cleanup()).resolves.not.toThrow();
+    });
+  });
+
+  /**
+   * Issue #794 — Subagent (Task) progress visibility in minimal mode.
+   *
+   * Three independent surfaces drive these tests:
+   *   1. `BackgroundTaskRegistry` — turn-scoped registry of live
+   *      `Task({run_in_background:true})` calls. Defends against
+   *      same-session turn replacement (cf. session-initializer:1138).
+   *   2. `isBackgroundTaskSpawnAck` — the bg Task tool_result that
+   *      arrives within ~1s with `task_id: …` is a spawn-ack, NOT a
+   *      completion. Suppress `endMcpTracking` so the progress UI
+   *      survives until turn end.
+   *   3. `cleanup(sessionKey, turnId)` — async, turn-scoped:
+   *      drains bg Task entries, sweeps callIds for THIS turn only,
+   *      then awaits `flushSession` for the final consolidated render.
+   */
+  describe('Subagent progress in minimal mode (issue #794)', () => {
+    function makeBgTaskInput(prompt = 'do something long') {
+      return {
+        subagent_type: 'general-purpose',
+        prompt,
+        run_in_background: true,
+      };
+    }
+    function makeFgTaskInput(prompt = 'do something fast') {
+      return {
+        subagent_type: 'general-purpose',
+        prompt,
+      };
+    }
+
+    // S15b — bg Task: `Subagent (bg)` displayType + registry add.
+    it('S15b: startSubagentTracking({run_in_background:true}) → displayType "Subagent (bg)"', async () => {
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_bg_subagent', name: 'Task', input: makeBgTaskInput() }], ctx);
+
+      expect(mcpStatusDisplay.registerCall).toHaveBeenCalledWith(
+        'C123:thread_ts',
+        'call_123',
+        expect.objectContaining({ displayType: 'Subagent (bg)' }),
+        'C123',
+        'thread_ts',
+      );
+    });
+
+    // S15c — fg Task: legacy `Subagent` displayType.
+    it('S15c: startSubagentTracking({run_in_background:false}) → displayType "Subagent"', async () => {
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_fg_subagent', name: 'Task', input: makeFgTaskInput() }], ctx);
+
+      expect(mcpStatusDisplay.registerCall).toHaveBeenCalledWith(
+        'C123:thread_ts',
+        'call_123',
+        expect.objectContaining({ displayType: 'Subagent' }),
+        'C123',
+        'thread_ts',
+      );
+    });
+
+    // S13 — bg Task spawn-ack: keeps progress UI alive.
+    it('S13: bg Task spawn-ack tool_result → endMcpTracking SKIPPED + onCompactDurationUpdate fired', async () => {
+      const compactCb = vi.fn().mockResolvedValue(undefined);
+      processor.setCompactDurationCallback(compactCb);
+
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_bg_ack', name: 'Task', input: makeBgTaskInput() }], ctx);
+
+      // Reset the call mock so we can isolate the result-handling effect.
+      mcpCallTracker.endCall.mockClear();
+      mcpStatusDisplay.completeCall.mockClear();
+
+      const spawnAckText = 'Task started in background. output_file: /tmp/x.json task_id: abc-123-def';
+      await processor.handleToolResult(
+        [{ toolUseId: 'tu_bg_ack', toolName: 'Task', result: spawnAckText, isError: false }],
+        ctx,
+      );
+
+      // Progress UI must survive — no endMcpTracking.
+      expect(mcpCallTracker.endCall).not.toHaveBeenCalled();
+      expect(mcpStatusDisplay.completeCall).not.toHaveBeenCalled();
+      // Compact one-line still closes via onCompactDurationUpdate.
+      // Pin the elapsed value (mock returns 750) so a future drift of
+      // `getElapsedTime` plumbing can't silently zero/null this field.
+      expect(mcpCallTracker.getElapsedTime).toHaveBeenCalledWith('call_123');
+      expect(compactCb).toHaveBeenCalledWith('tu_bg_ack', 750, 'C123');
+    });
+
+    // S13b — same spawn-ack semantics, but with the SDK's array
+    // tool_result shape ([{type:'text', text:'…task_id: …'}]). The
+    // Anthropic SDK returns this shape from real Task calls; a string-
+    // only test would let an extractTaskIdFromResult regression on the
+    // array branch slip past. (Issue #794.)
+    it('S13b: bg Task spawn-ack tool_result (array shape) → endMcpTracking SKIPPED + compactCb fired', async () => {
+      const compactCb = vi.fn().mockResolvedValue(undefined);
+      processor.setCompactDurationCallback(compactCb);
+
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_bg_ack_arr', name: 'Task', input: makeBgTaskInput() }], ctx);
+
+      mcpCallTracker.endCall.mockClear();
+      mcpStatusDisplay.completeCall.mockClear();
+
+      await processor.handleToolResult(
+        [
+          {
+            toolUseId: 'tu_bg_ack_arr',
+            toolName: 'Task',
+            result: [{ type: 'text', text: 'Task started in background. task_id: abc-123' }],
+            isError: false,
+          },
+        ],
+        ctx,
+      );
+
+      expect(mcpCallTracker.endCall).not.toHaveBeenCalled();
+      expect(mcpStatusDisplay.completeCall).not.toHaveBeenCalled();
+      expect(compactCb).toHaveBeenCalledWith('tu_bg_ack_arr', 750, 'C123');
+    });
+
+    // S14 — bg Task error result: normal close (no special-case).
+    it('S14: bg Task error tool_result → falls through to endMcpTracking + sendToolResult', async () => {
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_bg_err', name: 'Task', input: makeBgTaskInput() }], ctx);
+
+      mcpCallTracker.endCall.mockClear();
+      mcpStatusDisplay.completeCall.mockClear();
+
+      // Even with `task_id` text, isError=true is a real failure: close normally.
+      await processor.handleToolResult(
+        [
+          {
+            toolUseId: 'tu_bg_err',
+            toolName: 'Task',
+            result: 'Failed to spawn: subagent panic. task_id: nope',
+            isError: true,
+          },
+        ],
+        ctx,
+      );
+
+      expect(mcpCallTracker.endCall).toHaveBeenCalledWith('call_123');
+      expect(mcpStatusDisplay.completeCall).toHaveBeenCalledWith('call_123', 1000);
+    });
+
+    // S14b — bg Task non-ack result without `task_id`: normal close too.
+    it('S14b: bg Task result without task_id marker → endMcpTracking fires', async () => {
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_bg_no_id', name: 'Task', input: makeBgTaskInput() }], ctx);
+
+      mcpCallTracker.endCall.mockClear();
+
+      await processor.handleToolResult(
+        [{ toolUseId: 'tu_bg_no_id', toolName: 'Task', result: 'no marker here', isError: false }],
+        ctx,
+      );
+
+      expect(mcpCallTracker.endCall).toHaveBeenCalledWith('call_123');
+    });
+
+    // S15 — async cleanup with bg Task: drain registry + flushSession.
+    it('S15: cleanup(sessionKey, turnId) drains bg Task → endMcpTracking + flushSession awaited', async () => {
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      mcpCallTracker.startCall.mockReturnValueOnce('call_bg_task');
+      await processor.handleToolUse([{ id: 'tu_bg_drain', name: 'Task', input: makeBgTaskInput() }], ctx);
+
+      mcpCallTracker.endCall.mockClear();
+      mcpStatusDisplay.flushSession.mockClear();
+
+      // Turn ends with the bg Task still alive — cleanup must drain it.
+      await processor.cleanup('C123:thread_ts', 'C123:1:turn-A');
+
+      expect(mcpCallTracker.endCall).toHaveBeenCalledWith('call_bg_task');
+      expect(mcpStatusDisplay.flushSession).toHaveBeenCalledWith('C123:thread_ts');
+      // Ordering pin (issue #794) — flushSession MUST run AFTER endCall so
+      // the final render reflects the bg Task's `completed` flip. A drift
+      // here would re-introduce the "stuck running" symptom.
+      expect(mcpStatusDisplay.flushSession.mock.invocationCallOrder[0]).toBeGreaterThan(
+        mcpCallTracker.endCall.mock.invocationCallOrder[0],
+      );
+    });
+
+    // S15-bis — same-session, two turns: cleanup(turn1) leaves turn2 callIds alone.
+    it('S15-bis: cleanup(turn1) does NOT complete callIds registered under turn2 (callIdsByTurn)', async () => {
+      // turn1 — register one MCP call.
+      mcpCallTracker.startCall.mockReturnValueOnce('call_turn1');
+      const ctxTurn1: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-1' };
+      await processor.handleToolUse([{ id: 'tu_turn1', name: 'mcp__codex__search', input: { q: 't' } }], ctxTurn1);
+
+      // turn2 — same session, register another MCP call BEFORE turn1 cleans up.
+      mcpCallTracker.startCall.mockReturnValueOnce('call_turn2');
+      const ctxTurn2: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-2' };
+      await processor.handleToolUse([{ id: 'tu_turn2', name: 'mcp__codex__search', input: { q: 't' } }], ctxTurn2);
+
+      mcpStatusDisplay.completeCall.mockClear();
+
+      // turn1's cleanup arrives — must touch only turn1's callId.
+      await processor.cleanup('C123:thread_ts', 'C123:1:turn-1');
+
+      expect(mcpStatusDisplay.completeCall).toHaveBeenCalledWith('call_turn1', null);
+      expect(mcpStatusDisplay.completeCall).not.toHaveBeenCalledWith('call_turn2', null);
+    });
+
+    // S15-tri — same-session, two turns: cleanup(turn1) leaves turn2 bg Task alone.
+    it('S15-tri: cleanup(turn1) does NOT drain turn2 background Task entries', async () => {
+      mcpCallTracker.startCall.mockReturnValueOnce('call_bg_t1');
+      const ctxTurn1: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-1' };
+      await processor.handleToolUse(
+        [{ id: 'tu_bg_t1', name: 'Task', input: makeBgTaskInput('turn-1 task') }],
+        ctxTurn1,
+      );
+
+      mcpCallTracker.startCall.mockReturnValueOnce('call_bg_t2');
+      const ctxTurn2: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-2' };
+      await processor.handleToolUse(
+        [{ id: 'tu_bg_t2', name: 'Task', input: makeBgTaskInput('turn-2 task') }],
+        ctxTurn2,
+      );
+
+      mcpCallTracker.endCall.mockClear();
+
+      // turn1 cleanup — drain turn1 entry only.
+      await processor.cleanup('C123:thread_ts', 'C123:1:turn-1');
+
+      expect(mcpCallTracker.endCall).toHaveBeenCalledWith('call_bg_t1');
+      expect(mcpCallTracker.endCall).not.toHaveBeenCalledWith('call_bg_t2');
+    });
+
+    // Foreground Task spawn-ack-shaped result still closes normally.
+    it('foreground Task with task_id-shaped result still ends tracking (NOT a spawn-ack)', async () => {
+      const ctx: ToolEventContext = { ...mockContext, turnId: 'C123:1:turn-A' };
+      await processor.handleToolUse([{ id: 'tu_fg_task', name: 'Task', input: makeFgTaskInput() }], ctx);
+
+      mcpCallTracker.endCall.mockClear();
+
+      await processor.handleToolResult(
+        [
+          {
+            toolUseId: 'tu_fg_task',
+            toolName: 'Task',
+            result: 'something with task_id: abc',
+            isError: false,
+          },
+        ],
+        ctx,
+      );
+
+      // No registry entry → not a spawn-ack → normal close.
+      expect(mcpCallTracker.endCall).toHaveBeenCalledWith('call_123');
     });
   });
 
@@ -513,15 +781,20 @@ describe('ToolEventProcessor', () => {
         mockContext,
       );
 
-      // Simulate turn end without any tool_result arriving.
-      p.cleanup('C123:thread_ts');
+      // Simulate turn end without any tool_result arriving. Issue #794
+      // — `cleanup` is async; await it so the awaitable bg drain and
+      // flushSession both finish before assertions run.
+      await p.cleanup('C123:thread_ts');
 
       expect(status.unregister).toHaveBeenCalledTimes(2);
       // completeCall for both active calls arrives from the activeMcpCallIds
-      // sweep in cleanup(), not from a direct completeCall in sweep.
+      // sweep in cleanup() (legacy fallback when no turnId is provided).
       expect(mcpStatusDisplay.completeCall).toHaveBeenCalledWith('call_bg_a', null);
       expect(mcpStatusDisplay.completeCall).toHaveBeenCalledWith('call_bg_b', null);
-      expect(mcpStatusDisplay.cleanupSession).toHaveBeenCalledWith('C123:thread_ts');
+      // Issue #794 — final-render fence is `flushSession`, not the legacy
+      // `cleanupSession`. The mock provides `flushSession` so the
+      // feature-detect branch picks it.
+      expect(mcpStatusDisplay.flushSession).toHaveBeenCalledWith('C123:thread_ts');
     });
 
     it('tool_result after cleanup (already-swept) does not unregister again (idempotent)', async () => {
@@ -534,7 +807,7 @@ describe('ToolEventProcessor', () => {
         mockContext,
       );
 
-      p.cleanup('C123:thread_ts');
+      await p.cleanup('C123:thread_ts');
       expect(status.unregister).toHaveBeenCalledTimes(1);
 
       // late tool_result — entry is already gone from the registry, so no

--- a/src/slack/__tests__/tool-formatter.test.ts
+++ b/src/slack/__tests__/tool-formatter.test.ts
@@ -681,4 +681,68 @@ describe('ToolFormatter', () => {
       });
     });
   });
+
+  /**
+   * Issue #794 — `TaskToolSummary.runInBackground` is now a required
+   * boolean field (default false on every return path). Consumers
+   * (`startSubagentTracking`, `buildToolUseLogSummary`, formatter)
+   * branch on `summary.runInBackground` directly without an
+   * `=== true` guard, so an undefined return would regress every
+   * caller silently.
+   */
+  describe('getTaskToolSummary.runInBackground (issue #794)', () => {
+    it('returns runInBackground:true when input flags it explicitly', () => {
+      const summary = ToolFormatter.getTaskToolSummary({
+        subagent_type: 'general-purpose',
+        prompt: 'long task',
+        run_in_background: true,
+      });
+      expect(summary.runInBackground).toBe(true);
+    });
+
+    it('returns runInBackground:false by default when flag is omitted', () => {
+      const summary = ToolFormatter.getTaskToolSummary({
+        subagent_type: 'general-purpose',
+        prompt: 'fast task',
+      });
+      expect(summary.runInBackground).toBe(false);
+    });
+
+    it('returns runInBackground:false when flag is explicitly false', () => {
+      const summary = ToolFormatter.getTaskToolSummary({
+        subagent_type: 'general-purpose',
+        prompt: 'fast task',
+        run_in_background: false,
+      });
+      expect(summary.runInBackground).toBe(false);
+    });
+
+    it('returns runInBackground:false (not undefined) for invalid/empty input', () => {
+      // Field must be present even when input is unparseable, so callers
+      // can read it without an undefined check.
+      expect(ToolFormatter.getTaskToolSummary(null).runInBackground).toBe(false);
+      expect(ToolFormatter.getTaskToolSummary(undefined).runInBackground).toBe(false);
+      expect(ToolFormatter.getTaskToolSummary({}).runInBackground).toBe(false);
+      expect(ToolFormatter.getTaskToolSummary([] as unknown).runInBackground).toBe(false);
+    });
+
+    it('treats non-boolean run_in_background as false (string/number ignored)', () => {
+      // Defense: SDK shouldn't send these but we don't want to coerce
+      // truthy strings to true and silently change tracking behavior.
+      expect(
+        ToolFormatter.getTaskToolSummary({
+          subagent_type: 'general-purpose',
+          prompt: 'x',
+          run_in_background: 'true' as unknown as boolean,
+        }).runInBackground,
+      ).toBe(false);
+      expect(
+        ToolFormatter.getTaskToolSummary({
+          subagent_type: 'general-purpose',
+          prompt: 'x',
+          run_in_background: 1 as unknown as boolean,
+        }).runInBackground,
+      ).toBe(false);
+    });
+  });
 });

--- a/src/slack/cct/__tests__/builder.test.ts
+++ b/src/slack/cct/__tests__/builder.test.ts
@@ -63,6 +63,27 @@ describe('buildSlotRow', () => {
     expect(section.text.text).toContain('ToS-risk');
   });
 
+  // #801 — `inferred_shared` is the propagation arm of `RateLimitSource`.
+  // The /cct card surfaces it as `via inferred shared bucket` so operators
+  // can tell apart "this slot itself 429d" from "we inferred this slot is
+  // in the same bucket as a recently-limited sibling".
+  it('AC-7: rateLimitSource=inferred_shared renders via inferred shared bucket', () => {
+    const slot = setupSlot();
+    const state: SlotState = {
+      authState: 'healthy',
+      activeLeases: [],
+      rateLimitedAt: '2026-04-18T03:37:00Z',
+      rateLimitSource: 'inferred_shared',
+    };
+    const now = Date.parse('2026-04-18T03:42:00Z');
+    const blocks = buildSlotRow(slot, state, true, now, 'Asia/Seoul');
+    const text = (blocks[0] as any).text.text as string;
+    expect(text).toContain('rate-limited');
+    expect(text).toContain('via inferred shared bucket');
+    // Must NOT raw-leak the enum literal.
+    expect(text).not.toMatch(/via inferred_shared\b/);
+  });
+
   it('rate-limit timestamp + source render in the section multi-line body (always, not gated on isActive)', () => {
     const slot = setupSlot();
     const state: SlotState = {

--- a/src/slack/cct/builder.ts
+++ b/src/slack/cct/builder.ts
@@ -568,12 +568,31 @@ function formatRefreshErrorSegment(state: SlotState | undefined, nowMs: number):
  * Source suffix is omitted for legacy payloads that predate
  * `rateLimitSource` (raw enum matches the TokenManager classifier, same
  * shape both branches of `buildSlotStatusLine` emit).
+ *
+ * Exported so the `/cct` text-fallback in `cct-handler.ts` can render the
+ * exact same segment instead of hand-rolling the template.
+ * `userTz` / `nowMs` mirror `formatRateLimitedAt` defaults (Asia/Seoul,
+ * `Date.now()`) so non-Block-Kit callers can omit them.
  */
-function formatRateLimitedSegment(state: SlotState | undefined, userTz: string, nowMs: number): string | null {
+export function formatRateLimitedSegment(state: SlotState | undefined, userTz?: string, nowMs?: number): string | null {
   if (!state?.rateLimitedAt) return null;
-  const ts = formatRateLimitedAt(state.rateLimitedAt, userTz, nowMs);
-  const source = state.rateLimitSource ? ` via ${state.rateLimitSource}` : '';
+  const ts = formatRateLimitedAt(state.rateLimitedAt, userTz ?? 'Asia/Seoul', nowMs);
+  const source = formatRateLimitSource(state.rateLimitSource);
   return `rate-limited ${ts}${source}`;
+}
+
+/**
+ * Render the ` via <source>` suffix for a `rate-limited <ts>` segment.
+ * `inferred_shared` is humanised so operators can tell apart "this slot
+ * itself 429d" from "we inferred this slot is in the same bucket as a
+ * recently-limited sibling"; the other arms keep their raw enum suffix.
+ * Returns `''` when the source is missing (legacy payloads predating
+ * `rateLimitSource`) so callers can concatenate unconditionally.
+ */
+export function formatRateLimitSource(source: SlotState['rateLimitSource']): string {
+  if (!source) return '';
+  if (source === 'inferred_shared') return ' via inferred shared bucket';
+  return ` via ${source}`;
 }
 
 /**

--- a/src/slack/commands/cct-handler.ts
+++ b/src/slack/commands/cct-handler.ts
@@ -4,8 +4,7 @@ import type { CctStoreSnapshot, SlotState, UsageSnapshot } from '../../cct-store
 import { config } from '../../config';
 import { evaluateAndMaybeRotate, type RotationOutcome } from '../../oauth/auto-rotate';
 import { getTokenManager, type TokenSummary } from '../../token-manager';
-import { formatRateLimitedAt } from '../../util/format-rate-limited-at';
-import { formatUsageBar, formatUsageResetDelta } from '../cct/builder';
+import { formatRateLimitedSegment, formatUsageBar, formatUsageResetDelta } from '../cct/builder';
 import { CommandParser } from '../command-parser';
 import { renderCctCard } from '../z/topics/cct-topic';
 import type { CommandContext, CommandHandler, CommandResult } from './types';
@@ -205,11 +204,8 @@ async function buildStatusTextFallback(cardFallback: string | undefined): Promis
     ? snap.registry.slots.find((s) => s.keyId === snap.registry.activeKeyId)
     : undefined;
   if (!active) return header;
-  const state = snap.state[active.keyId];
-  if (!state?.rateLimitedAt) return header;
-  const ts = formatRateLimitedAt(state.rateLimitedAt);
-  const source = state.rateLimitSource ? ` via ${state.rateLimitSource}` : '';
-  return `${header}\nrate-limited ${ts}${source}`;
+  const segment = formatRateLimitedSegment(snap.state[active.keyId]);
+  return segment === null ? header : `${header}\n${segment}`;
 }
 
 /** Defensive snapshot read through the public `getSnapshot()` API. */

--- a/src/slack/mcp-status-tracker.ts
+++ b/src/slack/mcp-status-tracker.ts
@@ -29,6 +29,14 @@ interface SessionTick {
   messageTs: string | null;
   interval: NodeJS.Timeout | null;
   currentIntervalMs: number;
+  /**
+   * Issue #794 — serialized render queue. Every render path
+   * (setInterval tick, immediate-on-register tick, `flushSession`)
+   * enqueues onto this chain so Slack never sees interleaved
+   * `postMessage`/`updateMessage` for the same session, and
+   * `flushSession` can `await tick(tick)` to drain pending renders.
+   */
+  renderChain: Promise<void>;
 }
 
 const MCP_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
@@ -91,9 +99,17 @@ export class McpStatusDisplay {
         messageTs: null,
         interval: null,
         currentIntervalMs: 10_000,
+        renderChain: Promise.resolve(),
       };
       this.sessionTicks.set(sessionKey, tick);
       this.startTick(tick);
+      // Issue #794 — fire the first render synchronously (enqueued on
+      // `renderChain`) so short-lived calls don't wait the full 10s
+      // until the next setInterval before the user sees a progress
+      // line. Subsequent `registerCall`s with the same `sessionKey`
+      // hit the `has(sessionKey)` guard above and join the existing
+      // tick — no extra `postMessage` round-trip.
+      void this.tick(tick);
     }
   }
 
@@ -144,11 +160,53 @@ export class McpStatusDisplay {
     return count;
   }
 
+  /**
+   * Issue #794 — flush a session: drain the render chain (so any
+   * in-flight tick has finished its `postMessage`/`updateMessage`),
+   * enqueue one final tick to render the latest state, then — if no
+   * `running` calls remain — tear the tick down. Idempotent: a second
+   * call on the same `sessionKey` is a no-op once the tick is gone.
+   *
+   * Called by `ToolEventProcessor.cleanup(sessionKey, turnId)` AFTER
+   * it has marked every active callId as completed. The order matters:
+   *   1. completeCall → entry.status = 'completed' for each call.
+   *   2. flushSession → tick reads the completed state and renders the
+   *      "🟢 N개 작업 완료" / final allDone branch, then stops itself.
+   *
+   * Race-safety: `await this.tick(tick)` chains onto the existing
+   * `renderChain`, so even if a `setInterval` tick fired moments
+   * earlier, our enqueued tick runs after it. No interleaving with
+   * Slack API calls.
+   *
+   * The final fallback `cleanupSession(sessionKey)` is gated on "no
+   * remaining running calls" so a brand-new turn that registered a
+   * call between our render and our fallback doesn't get its just-
+   * registered tracker silently torn down. If running calls remain,
+   * we leave the tick running — the next turn (or this one's later
+   * cleanup) will re-flush.
+   */
+  async flushSession(sessionKey: string): Promise<void> {
+    const tick = this.sessionTicks.get(sessionKey);
+    if (!tick) return;
+    // Drain the chain: in-flight tick (if any) → our enqueued tick →
+    // we resolve. `doTick` handles the allDone teardown itself when
+    // every entry is non-running.
+    await this.tick(tick);
+    if (this.sessionTicks.has(sessionKey)) {
+      const remainingRunning = this.getSessionCalls(sessionKey).some((c) => c.status === 'running');
+      if (!remainingRunning) {
+        this.cleanupSession(sessionKey);
+      }
+      // Otherwise the setInterval keeps running — a new turn already
+      // registered a call against the same session and owns the tick.
+    }
+  }
+
   // --- Private tick management ---
 
   private startTick(tick: SessionTick): void {
     tick.interval = setInterval(() => {
-      this.tick(tick);
+      void this.tick(tick);
     }, tick.currentIntervalMs);
   }
 
@@ -159,7 +217,20 @@ export class McpStatusDisplay {
     }
   }
 
-  private async tick(tick: SessionTick): Promise<void> {
+  /**
+   * Issue #794 — public render-chain entry point. Every external
+   * caller (setInterval, registerCall's immediate first tick,
+   * flushSession) goes through here so all renders for a session
+   * serialize. The `.catch(() => {})` swallows prior errors so a
+   * single failed `postMessage` cannot poison the chain and starve
+   * every subsequent render.
+   */
+  private tick(tick: SessionTick): Promise<void> {
+    tick.renderChain = tick.renderChain.catch(() => {}).then(() => this.doTick(tick));
+    return tick.renderChain;
+  }
+
+  private async doTick(tick: SessionTick): Promise<void> {
     const calls = this.getSessionCalls(tick.sessionKey);
     if (calls.length === 0) {
       this.stopTick(tick);
@@ -189,7 +260,7 @@ export class McpStatusDisplay {
         this.stopTick(tick);
         tick.currentIntervalMs = minInterval;
         tick.interval = setInterval(() => {
-          this.tick(tick);
+          void this.tick(tick);
         }, tick.currentIntervalMs);
       }
     }

--- a/src/slack/mcp-status-tracker.ts
+++ b/src/slack/mcp-status-tracker.ts
@@ -218,15 +218,40 @@ export class McpStatusDisplay {
   }
 
   /**
-   * Issue #794 — public render-chain entry point. Every external
-   * caller (setInterval, registerCall's immediate first tick,
-   * flushSession) goes through here so all renders for a session
-   * serialize. The `.catch(() => {})` swallows prior errors so a
-   * single failed `postMessage` cannot poison the chain and starve
-   * every subsequent render.
+   * Issue #794 — public render-chain entry point. Every entry point
+   * within this class (setInterval, registerCall's immediate first
+   * tick, flushSession) goes through here so all renders for a
+   * session serialize. The structure has two safeguards:
+   *
+   * 1. **Inner try/catch** wraps `doTick(tick)` so this tick's
+   *    synchronous-or-async throw never escapes. Inner Slack I/O
+   *    already has its own try/catch+`logger.warn`, so the only
+   *    paths reaching here are unexpected throws inside `doTick`'s
+   *    pure-CPU code (`getSessionCalls`/`computeMinInterval`/
+   *    `buildConsolidatedText`). Logging-and-continuing here means
+   *    a regression that adds a throwing path won't silently
+   *    disable progress UI for the rest of the session, AND it
+   *    cannot escape as an unhandled rejection between this tick
+   *    and the next.
+   * 2. **Front `.catch(() => {})`** swallows any latent rejection
+   *    on the prior chain link (defense-in-depth — the inner
+   *    try/catch should make this unreachable, but a future edit
+   *    that reorders the chain shouldn't be able to break the
+   *    poison-pill contract).
    */
   private tick(tick: SessionTick): Promise<void> {
-    tick.renderChain = tick.renderChain.catch(() => {}).then(() => this.doTick(tick));
+    tick.renderChain = tick.renderChain
+      .catch(() => {})
+      .then(async () => {
+        try {
+          await this.doTick(tick);
+        } catch (err) {
+          this.logger.warn('mcp render tick failed (chain kept alive)', {
+            sessionKey: tick.sessionKey,
+            error: (err as Error)?.message ?? String(err),
+          });
+        }
+      });
     return tick.renderChain;
   }
 

--- a/src/slack/pipeline/__tests__/stream-executor.test.ts
+++ b/src/slack/pipeline/__tests__/stream-executor.test.ts
@@ -79,7 +79,11 @@ vi.mock('../../../token-manager', () => ({
     rotateOnRateLimit: rotateOnRateLimitMock,
     fetchAndStoreUsage: fetchAndStoreUsageMock,
   }),
-  parseCooldownTime: vi.fn(),
+  // Default to `null` (the production type signature is `Date | null`) so
+  // the new `parsedCooldown !== null` check in tryRotateToken behaves the
+  // same in tests as in production. Individual tests that need a parsed
+  // cooldown override with `vi.mocked(parseCooldownTime).mockReturnValueOnce(...)`.
+  parseCooldownTime: vi.fn().mockReturnValue(null),
 }));
 
 import { config } from '../../../config';
@@ -2747,6 +2751,81 @@ describe('W3-B rate-limit rotation wiring', () => {
     );
 
     expect(rotateOnRateLimitMock).not.toHaveBeenCalled();
+  });
+
+  // #801 AC-12 — `tryRotateToken` plumbs the new `knownReset` flag so
+  // `rotateOnRateLimit`'s shared-bucket propagation gate can distinguish a
+  // parsed wall-clock cooldown (direct evidence) from the 60-minute
+  // fallback (no evidence). The flag must mirror `parsedCooldown !== null`.
+  it('AC-12a: parsed cooldown text → rotateOnRateLimit called with knownReset:true', async () => {
+    // Override the parseCooldownTime mock to return a real Date for this call.
+    const tokenManagerModule = await import('../../../token-manager');
+    const parseMock = vi.mocked(tokenManagerModule.parseCooldownTime);
+    parseMock.mockReturnValueOnce(new Date(Date.now() + 30 * 60 * 1000));
+
+    const executor = new StreamExecutor(createMinimalDeps());
+    const say = vi.fn().mockResolvedValue(undefined);
+    const error = new Error("You've hit your limit · resets 8pm (Asia/Seoul). Claude Code process exited with code 1");
+    const activeSlot = { slotId: 'slot_abc', name: 'cct1', kind: 'setup_token' as const };
+
+    await (executor as any).handleError(
+      error,
+      {} as any,
+      'C123:thread123',
+      'C123',
+      'thread123',
+      [],
+      say,
+      false,
+      activeSlot,
+    );
+
+    expect(rotateOnRateLimitMock).toHaveBeenCalledTimes(1);
+    const [, opts] = rotateOnRateLimitMock.mock.calls[0];
+    expect(opts).toEqual(
+      expect.objectContaining({
+        source: 'error_string',
+        knownReset: true,
+        cooldownMinutes: expect.any(Number),
+      }),
+    );
+    expect(opts.cooldownMinutes).toBeGreaterThan(0);
+  });
+
+  it('AC-12b: unparseable error → rotateOnRateLimit called with knownReset:false and cooldownMinutes:60', async () => {
+    // Default mock returns undefined → tryRotateToken treats as null → fallback path.
+    const tokenManagerModule = await import('../../../token-manager');
+    const parseMock = vi.mocked(tokenManagerModule.parseCooldownTime);
+    parseMock.mockReturnValueOnce(null);
+
+    const executor = new StreamExecutor(createMinimalDeps());
+    const say = vi.fn().mockResolvedValue(undefined);
+    // The combined message still triggers isRateLimitError (contains "rate limit") so
+    // tryRotateToken runs — but parseCooldownTime returns null → fallback 60m path.
+    const error = new Error('rate limit exceeded');
+    const activeSlot = { slotId: 'slot_abc', name: 'cct1', kind: 'setup_token' as const };
+
+    await (executor as any).handleError(
+      error,
+      {} as any,
+      'C123:thread123',
+      'C123',
+      'thread123',
+      [],
+      say,
+      false,
+      activeSlot,
+    );
+
+    expect(rotateOnRateLimitMock).toHaveBeenCalledTimes(1);
+    const [, opts] = rotateOnRateLimitMock.mock.calls[0];
+    expect(opts).toEqual(
+      expect.objectContaining({
+        source: 'error_string',
+        knownReset: false,
+        cooldownMinutes: 60,
+      }),
+    );
   });
 });
 

--- a/src/slack/pipeline/stream-executor.ts
+++ b/src/slack/pipeline/stream-executor.ts
@@ -1520,7 +1520,7 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
           error: (err as Error)?.message ?? String(err),
         });
       }
-      await this.cleanup(session, sessionKey, abortController);
+      await this.cleanup(session, sessionKey, abortController, turnId);
     }
   }
 
@@ -2151,6 +2151,7 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
     session: ConversationSession,
     sessionKey: string,
     abortController?: AbortController,
+    turnId?: string,
   ): Promise<void> {
     // Ghost Session Fix #99: CAS guard — only remove if this request's controller is still registered
     this.deps.requestCoordinator.removeController(sessionKey, abortController);
@@ -2162,8 +2163,28 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
       this.summaryAbortControllers.delete(sessionKey);
     }
 
-    // Cleanup active MCP status tracking to prevent stuck timers
-    this.deps.toolEventProcessor.cleanup(sessionKey);
+    // Issue #794 — `toolEventProcessor.cleanup` is now async because it
+    // awaits `mcpStatusDisplay.flushSession` (final render) and the bg
+    // Task drain (`endMcpTracking`). We `await` it here so the user
+    // sees the final progress line before the rest of cleanup runs;
+    // the try/catch isolates any failure so subsequent cleanup steps
+    // (threadPanel update, todo cleanup) are not skipped — losing the
+    // progress final line is bad, but losing the panel/todo cleanup is
+    // worse (stale UI / leaked timers).
+    //
+    // `turnId` is threaded through from `execute()` so the cleanup can
+    // do a turn-scoped sweep instead of the legacy global one
+    // (defends against same-session turn replacement; see
+    // `tool-event-processor.ts` `callIdsByTurn` field doc).
+    try {
+      await this.deps.toolEventProcessor.cleanup(sessionKey, turnId);
+    } catch (err) {
+      this.logger.warn('toolEventProcessor.cleanup threw — continuing', {
+        sessionKey,
+        turnId,
+        error: (err as Error)?.message ?? String(err),
+      });
+    }
 
     try {
       await this.deps.threadPanel?.updatePanel(session, sessionKey);

--- a/src/slack/pipeline/stream-executor.ts
+++ b/src/slack/pipeline/stream-executor.ts
@@ -2024,9 +2024,19 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
     // Parse cooldown from both error message and stderr content.
     const errorText = `${error?.message || ''} ${error?.stderrContent || ''}`;
     const parsedCooldown = parseCooldownTime(errorText);
-    const cooldownMinutes = parsedCooldown
-      ? Math.max(1, Math.round((parsedCooldown.getTime() - Date.now()) / 60_000))
-      : 60; // default 1 hour
+    // `knownReset` distinguishes a parsed wall-clock (direct upstream evidence)
+    // from the 60-minute fallback; TokenManager gates shared-bucket cooldown
+    // propagation on it (see `docs/cct-shared-bucket-cooldown-propagation/spec.md`).
+    //
+    // We additionally reject parsed resets that are already in the past — a
+    // stale "resets 7pm" parsed at 8pm would otherwise be clamped to a 1-min
+    // cooldown by `Math.max(1, …)` and still report `knownReset: true`,
+    // letting the propagation gate fire across the whole pool with a synthetic
+    // 1-min cooldown (silent BLOCK from the audit). A stale reset is no
+    // better than the 60-min fallback, so degrade to that path.
+    const now = Date.now();
+    const knownReset = parsedCooldown !== null && parsedCooldown.getTime() > now;
+    const cooldownMinutes = knownReset ? Math.max(1, Math.round((parsedCooldown.getTime() - now) / 60_000)) : 60; // default 1 hour
 
     const reason = `stream-executor rate-limit${
       activeSlotAtQueryStart ? ` on slot=${activeSlotAtQueryStart.name}` : ''
@@ -2035,6 +2045,7 @@ Read 가능한 파일(텍스트, 코드, PDF, 이미지 등)이 첨부된 메시
     const rotated = await getTokenManager().rotateOnRateLimit(reason, {
       source: 'error_string',
       cooldownMinutes,
+      knownReset,
     });
 
     if (rotated) {

--- a/src/slack/stream-processor.ts
+++ b/src/slack/stream-processor.ts
@@ -272,6 +272,54 @@ export interface StreamResult {
 export type { EndTurnInfo };
 
 /**
+ * Single source of truth for the spawn-ack `task_id:` marker. Drift here
+ * would either suppress every `endMcpTracking` call (false-positive:
+ * leaks running state across turns) or kill the bg progress UI on real
+ * spawn-acks (false-negative: regresses #794). `ToolEventProcessor.isBackgroundTaskSpawnAck`
+ * reuses the same regex by going through `extractTaskIdFromResult`.
+ */
+const TASK_ID_RE = /task_id[:\s]+(\S+)/i;
+
+/**
+ * Extract `task_id` from a Task tool result.
+ *
+ * The SDK returns spawn-ack text like
+ *   `"Task started in background. output_file: /path task_id: abc123"`
+ * either as a top-level string or as a `{ type: 'text', text: ... }` part
+ * inside an array result. The array branch gates on `part.type === 'text'`
+ * — the SDK also emits `{type:'image', source:{…}}` (and other non-text
+ * shapes); without the gate, a future shape with a same-named `text`
+ * metadata field could leak a false-positive `task_id` match.
+ */
+export function extractTaskIdFromResult(result: unknown): string | undefined {
+  if (!result) return undefined;
+
+  if (typeof result === 'string') {
+    return result.match(TASK_ID_RE)?.[1];
+  }
+
+  if (Array.isArray(result)) {
+    for (const part of result) {
+      const text = textOfPart(part);
+      if (text === undefined) continue;
+      const match = text.match(TASK_ID_RE);
+      if (match) return match[1];
+    }
+  }
+
+  return undefined;
+}
+
+/** Narrow a content-array part to its text payload, gating on the
+ *  Anthropic schema's `type === 'text'` discriminant. */
+function textOfPart(part: unknown): string | undefined {
+  if (typeof part === 'string') return part;
+  const obj = part as { type?: unknown; text?: unknown } | null | undefined;
+  if (obj?.type !== 'text') return undefined;
+  return typeof obj.text === 'string' ? obj.text : undefined;
+}
+
+/**
  * StreamProcessor handles the for-await loop over Claude SDK messages
  */
 export class StreamProcessor {
@@ -1411,7 +1459,7 @@ export class StreamProcessor {
       if (!taskInput) continue;
 
       // Extract task_id from the result text (SDK returns it in the result)
-      const taskId = this.extractTaskIdFromResult(tr.result);
+      const taskId = extractTaskIdFromResult(tr.result);
       if (taskId) {
         const summary = ToolFormatter.getTaskToolSummary(taskInput);
         this.backgroundTaskMeta.set(taskId, {
@@ -1422,34 +1470,6 @@ export class StreamProcessor {
       }
       this.pendingTaskInputs.delete(tr.toolUseId);
     }
-  }
-
-  /**
-   * Extract task_id from a Task tool result.
-   * The SDK returns text like "Task started in background. output_file: /path task_id: abc123"
-   * or the result may contain structured data.
-   */
-  private extractTaskIdFromResult(result: any): string | undefined {
-    if (!result) return undefined;
-
-    // If result is a string, search for task_id pattern
-    if (typeof result === 'string') {
-      const match = result.match(/task_id[:\s]+(\S+)/i);
-      return match?.[1];
-    }
-
-    // If result is an array (common SDK format), search text parts
-    if (Array.isArray(result)) {
-      for (const part of result) {
-        const text = typeof part === 'string' ? part : part?.text;
-        if (typeof text === 'string') {
-          const match = text.match(/task_id[:\s]+(\S+)/i);
-          if (match) return match[1];
-        }
-      }
-    }
-
-    return undefined;
   }
 
   /**

--- a/src/slack/tool-event-processor.ts
+++ b/src/slack/tool-event-processor.ts
@@ -12,6 +12,7 @@ import type { McpStatusDisplay } from './mcp-status-tracker';
 import { getToolResultRenderMode, LOG_DETAIL, OutputFlag, shouldOutput } from './output-flags';
 import { shouldRunLegacyB4Path } from './pipeline/effective-phase';
 import type { ReactionManager } from './reaction-manager';
+import { extractTaskIdFromResult } from './stream-processor';
 import { ToolFormatter, type ToolResult } from './tool-formatter';
 import type { ToolTracker } from './tool-tracker';
 
@@ -60,6 +61,92 @@ class BackgroundBashRegistry {
     const entries = Array.from(bucket.values());
     this.map.delete(sessionKey);
     return entries;
+  }
+}
+
+/**
+ * Issue #794 — live `Task({run_in_background:true})` entry. Unlike
+ * BashBG (#688), Subagent has no AssistantStatusManager bg-counter, so
+ * no `unregister` is stored. Entries gate `endMcpTracking` on the
+ * spawn-ack so the McpStatusDisplay progress UI stays alive until the
+ * turn ends.
+ *
+ * Keyed by `(turnId, toolUseId)` so same-session turn replacement does
+ * not let one turn's cleanup drain another turn's just-spawned entries.
+ * `hasAnyByToolUseId` / `removeAnyByToolUseId` provide a turnId-less
+ * scan for the spawn-ack path, which fires before context.turnId is
+ * reliably threaded.
+ */
+interface BgTaskEntry {
+  callId: string;
+  toolUseId: string;
+  subagentLabel: string;
+  turnId: string;
+}
+
+class BackgroundTaskRegistry {
+  private map = new Map<string /*turnId*/, Map<string /*toolUseId*/, BgTaskEntry>>();
+
+  add(turnId: string, toolUseId: string, entry: BgTaskEntry): void {
+    let bucket = this.map.get(turnId);
+    if (!bucket) {
+      bucket = new Map();
+      this.map.set(turnId, bucket);
+    }
+    bucket.set(toolUseId, entry);
+  }
+
+  has(turnId: string, toolUseId: string): boolean {
+    return this.map.get(turnId)?.has(toolUseId) ?? false;
+  }
+
+  remove(turnId: string, toolUseId: string): BgTaskEntry | undefined {
+    const bucket = this.map.get(turnId);
+    if (!bucket) return undefined;
+    const entry = bucket.get(toolUseId);
+    if (!entry) return undefined;
+    bucket.delete(toolUseId);
+    if (bucket.size === 0) this.map.delete(turnId);
+    return entry;
+  }
+
+  drain(turnId: string): BgTaskEntry[] {
+    const bucket = this.map.get(turnId);
+    if (!bucket) return [];
+    const entries = Array.from(bucket.values());
+    this.map.delete(turnId);
+    return entries;
+  }
+
+  /**
+   * Spawn-ack detection runs before `context.turnId` is guaranteed; scan
+   * every turn bucket for `toolUseId`. `toolUseId` is unique per stream
+   * so a single bucket can match.
+   */
+  hasAnyByToolUseId(toolUseId: string): boolean {
+    for (const bucket of this.map.values()) {
+      if (bucket.has(toolUseId)) return true;
+    }
+    return false;
+  }
+
+  removeAnyByToolUseId(toolUseId: string): BgTaskEntry | undefined {
+    for (const [turnId, bucket] of this.map) {
+      const entry = bucket.get(toolUseId);
+      if (!entry) continue;
+      bucket.delete(toolUseId);
+      if (bucket.size === 0) this.map.delete(turnId);
+      return entry;
+    }
+    return undefined;
+  }
+
+  /** Total live entries across every turn bucket. Used by `cleanup()`'s
+   *  legacy-fallback warn — see ToolEventProcessor.cleanup JSDoc. */
+  get size(): number {
+    let total = 0;
+    for (const bucket of this.map.values()) total += bucket.size;
+    return total;
   }
 }
 
@@ -141,6 +228,17 @@ export class ToolEventProcessor {
    * `handleToolResult` (normal completion) or `cleanup()` (turn end).
    */
   private backgroundBashRegistry = new BackgroundBashRegistry();
+  /** Issue #794 — see `BgTaskEntry` doc. */
+  private backgroundTaskRegistry = new BackgroundTaskRegistry();
+  /**
+   * Issue #794 — turn-scoped index of live McpCallTracker callIds.
+   * Replaces the global `toolTracker.getActiveMcpCallIds()` sweep so
+   * `cleanup(sessionKey, turnId)` closes only its own turn's calls,
+   * preventing same-session turn replacement from false-completing a
+   * newer turn's just-registered calls. Populated at every `startCall`
+   * site, cleared at every `endCall` site.
+   */
+  private callIdsByTurn: Map<string, Set<string>> = new Map();
   /** Callback for updating compact tool call messages with duration */
   private onCompactDurationUpdate?: (toolUseId: string, duration: number | null, channel: string) => Promise<void>;
   /**
@@ -234,6 +332,7 @@ export class ToolEventProcessor {
     // Start call tracking
     const callId = this.mcpCallTracker.startCall(serverName, actualToolName);
     this.toolTracker.trackMcpCall(toolUse.id, callId);
+    if (context.turnId) this.addTurnCallId(context.turnId, callId);
 
     // Set hourglass reaction for MCP pending
     if (this.reactionManager && context.sessionKey) {
@@ -267,19 +366,47 @@ export class ToolEventProcessor {
   }
 
   /**
-   * Start subagent tracking and status display for Task tools
+   * Start subagent tracking and status display for Task tools.
+   *
+   * Issue #794 — `Task({run_in_background:true})` carries its own
+   * concerns:
+   *   - The user must see a progress line as soon as the tool_use lands
+   *     (handled by McpStatusDisplay's immediate first tick).
+   *   - The bg spawn-ack tool_result (`task_id: …`) must NOT close the
+   *     McpStatusDisplay entry; the registry add-call below installs the
+   *     gate that `isBackgroundTaskSpawnAck` consults from
+   *     `handleToolResult`. The entry is cleared either by `cleanup()`
+   *     drain at turn end, or — for non-ack results (error / missing
+   *     `task_id`) — by `removeAnyByToolUseId` in the
+   *     fall-through branch of `handleToolResult`.
+   *
+   * `subagentCallIds.add(callId)` is unconditional (fg + bg) so the
+   * existing `endMcpTracking` reaction-cleanup branch keeps treating
+   * Subagent calls separately from MCP — bg Task entries still flow
+   * through `endMcpTracking` at turn-end via the `cleanup` drain path.
    */
   private async startSubagentTracking(toolUse: ToolUseEvent, context: ToolEventContext): Promise<void> {
     const summary = ToolFormatter.getTaskToolSummary(toolUse.input);
     const subagentName = summary.subagentLabel || 'Task';
+    const isBackground = summary.runInBackground;
 
     // Start call tracking with virtual server name
     const callId = this.mcpCallTracker.startCall('_subagent', subagentName);
     this.toolTracker.trackMcpCall(toolUse.id, callId);
     this.subagentCallIds.add(callId);
+    if (context.turnId) this.addTurnCallId(context.turnId, callId);
+
+    if (isBackground && context.turnId) {
+      this.backgroundTaskRegistry.add(context.turnId, toolUse.id, {
+        callId,
+        toolUseId: toolUse.id,
+        subagentLabel: subagentName,
+        turnId: context.turnId,
+      });
+    }
 
     const config = {
-      displayType: 'Subagent',
+      displayType: isBackground ? 'Subagent (bg)' : 'Subagent',
       displayLabel: subagentName,
       initialDelay: 0,
       predictKey: { serverName: '_subagent', toolName: subagentName },
@@ -306,6 +433,7 @@ export class ToolEventProcessor {
 
     const callId = this.mcpCallTracker.startCall('_bash_bg', 'bash');
     this.toolTracker.trackMcpCall(toolUse.id, callId);
+    if (context.turnId) this.addTurnCallId(context.turnId, callId);
 
     const unregister =
       this.assistantStatusManager?.registerBackgroundBashActive(context.channel, context.threadTs) ?? (() => {});
@@ -360,6 +488,23 @@ export class ToolEventProcessor {
         }
       }
 
+      // Issue #794 — bg Task spawn-ack keeps the progress UI alive
+      // (cleanup at turn end owns completion). See
+      // `isBackgroundTaskSpawnAck` for the precondition contract.
+      if (this.isBackgroundTaskSpawnAck(toolResult)) {
+        const callId = this.toolTracker.getMcpCallId(toolResult.toolUseId);
+        const elapsed = callId ? (this.mcpCallTracker.getElapsedTime(callId) ?? 0) : 0;
+        if (this.onCompactDurationUpdate) {
+          await this.onCompactDurationUpdate(toolResult.toolUseId, elapsed, context.channel);
+        }
+        continue;
+      }
+
+      // Non-ack result on a tracked bg Task: drop the registry entry
+      // now so the turn-end drain doesn't see a stale entry, then fall
+      // through to the normal endMcpTracking + sendToolResult path.
+      this.backgroundTaskRegistry.removeAnyByToolUseId(toolResult.toolUseId);
+
       // End MCP call tracking and get duration
       const duration = await this.endMcpTracking(toolResult.toolUseId, context.sessionKey);
 
@@ -399,6 +544,9 @@ export class ToolEventProcessor {
 
     const duration = this.mcpCallTracker.endCall(callId);
     this.toolTracker.removeMcpCallId(toolUseId);
+    // Issue #794 — drop the callId from its turn bucket so the
+    // turn-scoped sweep in `cleanup()` does not double-complete it.
+    this.removeTurnCallId(callId);
 
     // MCP-specific cleanup (reactions)
     if (!this.subagentCallIds.has(callId)) {
@@ -413,6 +561,59 @@ export class ToolEventProcessor {
     this.mcpStatusDisplay.completeCall(callId, duration);
 
     return duration;
+  }
+
+  /**
+   * Issue #794 — index a McpCallTracker callId under its owning turnId
+   * so `cleanup(sessionKey, turnId)` can sweep only its own turn's
+   * calls. See `callIdsByTurn` field doc for the same-session
+   * turn-replacement race this guards against.
+   */
+  private addTurnCallId(turnId: string, callId: string): void {
+    let bucket = this.callIdsByTurn.get(turnId);
+    if (!bucket) {
+      bucket = new Set();
+      this.callIdsByTurn.set(turnId, bucket);
+    }
+    bucket.add(callId);
+  }
+
+  /**
+   * Issue #794 — remove a callId from whichever turn bucket holds it.
+   * The caller (`endMcpTracking`) does not know which turn registered
+   * the callId, so we scan all buckets. Bucket count is bounded by live
+   * turn count (≤ tens), so the linear scan is negligible.
+   */
+  private removeTurnCallId(callId: string): void {
+    for (const [turnId, bucket] of this.callIdsByTurn) {
+      if (bucket.delete(callId)) {
+        if (bucket.size === 0) this.callIdsByTurn.delete(turnId);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Issue #794 — bg Task spawn-ack detection. Three-part contract:
+   *   1. `isError === true`  → not a spawn-ack (real failure → close
+   *      the progress UI normally via the fall-through path).
+   *   2. The toolUseId must already be registered in
+   *      `backgroundTaskRegistry`. A foreground Task or any non-Task
+   *      tool always returns false here.
+   *   3. The result text must contain a `task_id` marker, parsed by
+   *      the shared `extractTaskIdFromResult` helper. We deliberately
+   *      reuse that helper instead of a local regex so a spec change
+   *      to the marker format propagates everywhere at once.
+   *
+   * Returning true tells `handleToolResult` to keep the McpStatusDisplay
+   * entry open (no `endMcpTracking` call). The compact one-line tool
+   * call is closed separately via `onCompactDurationUpdate` so the user
+   * still gets a `🟢 (Ns)` close on the inline tool bubble.
+   */
+  private isBackgroundTaskSpawnAck(toolResult: ToolResultEvent): boolean {
+    if (toolResult.isError === true) return false;
+    if (!this.backgroundTaskRegistry.hasAnyByToolUseId(toolResult.toolUseId)) return false;
+    return extractTaskIdFromResult(toolResult.result) !== undefined;
   }
 
   /**
@@ -468,23 +669,36 @@ export class ToolEventProcessor {
 
   /**
    * Cleanup resources on abort or completion.
-   * Completes any active MCP calls and cleans up the session tick.
+   *
+   * Async because `flushSession` awaits the McpStatusDisplay render
+   * chain so the final "completed" line lands before teardown. When
+   * `turnId` is provided we do a turn-scoped callId sweep; without it
+   * we fall back to a global sweep (same race exposure as pre-#794,
+   * kept for legacy callers).
+   *
+   * **Callers MUST pass `turnId` whenever bg Task entries may exist for
+   * the session.** The legacy `turnId`-less path drops the
+   * `backgroundTaskRegistry` drain entirely — entries indexed by
+   * `turnId` cannot be located without it, so they leak across turns.
+   * The legacy fallback only stays correct for paths that never spawn
+   * background Task tools (e.g. one-shot abort flows pre-#794).
+   *
+   * Drain order:
+   *   1. Background Bash counters (#688) — release before display close.
+   *   2. Background Task entries (#794) — endMcpTracking each (parallel)
+   *      so display entries flip to `completed` before flushSession.
+   *   3. Outstanding callId sweep (turn-scoped or legacy global).
+   *   4. `flushSession(sessionKey)` for final render + tick teardown.
    */
-  cleanup(sessionKey?: string): void {
-    // Issue #688 — sweep any background bashes that never produced a
-    // tool_result. Decrement their bg-bash counters BEFORE the general
-    // activeMcpCallIds sweep below — otherwise the native spinner text
-    // could continue to resolve to "waiting on background shell" after
-    // the turn is gone. `endMcpTracking` also runs below for the same
-    // callId via activeMcpCallIds, so we only touch the counter here and
-    // let the existing `completeCall(callId, null)` close the display.
+  async cleanup(sessionKey?: string, turnId?: string): Promise<void> {
     if (sessionKey) {
       const bgEntries = this.backgroundBashRegistry.drain(sessionKey);
       for (const entry of bgEntries) {
         try {
           entry.unregister();
         } catch (err) {
-          // Same warn-level rationale as handleToolResult's unregister catch.
+          // Idempotent — a throw here means two paths fight over the
+          // same entry; warn so a real concurrency bug doesn't hide.
           this.logger.warn('bg bash unregister threw during sweep', {
             sessionKey,
             toolUseId: entry.toolUseId,
@@ -494,15 +708,64 @@ export class ToolEventProcessor {
       }
     }
 
-    // Complete any outstanding MCP calls
-    const activeMcpCallIds = this.toolTracker.getActiveMcpCallIds();
-    for (const callId of activeMcpCallIds) {
-      this.mcpStatusDisplay.completeCall(callId, null);
+    if (turnId) {
+      const bgTaskEntries = this.backgroundTaskRegistry.drain(turnId);
+      // Parallel — `endMcpTracking` does Slack reaction-clear API calls;
+      // serializing N would multiply turn-end latency by N RTTs. The
+      // shared-state mutations inside (Map ops, completeCall) all run
+      // synchronously between awaits, so concurrency is safe.
+      await Promise.all(
+        bgTaskEntries.map(async (entry) => {
+          try {
+            await this.endMcpTracking(entry.toolUseId, sessionKey);
+          } catch (err) {
+            this.logger.warn('bg Task endMcpTracking threw during cleanup sweep', {
+              sessionKey,
+              turnId,
+              toolUseId: entry.toolUseId,
+              error: (err as Error)?.message ?? String(err),
+            });
+          }
+        }),
+      );
     }
 
-    // Cleanup session tick
+    if (turnId) {
+      const turnCallIds = this.callIdsByTurn.get(turnId);
+      if (turnCallIds) {
+        for (const callId of turnCallIds) {
+          this.mcpStatusDisplay.completeCall(callId, null);
+        }
+        this.callIdsByTurn.delete(turnId);
+      }
+    } else {
+      // Legacy fallback — same race exposure as before #794. The
+      // registry is keyed by turnId, so any bg Task entries leak here.
+      const bgTaskCount = this.backgroundTaskRegistry.size;
+      if (bgTaskCount > 0) {
+        this.logger.warn('cleanup() called without turnId — bg Task registry will leak', {
+          sessionKey,
+          registrySize: bgTaskCount,
+        });
+      }
+      const activeMcpCallIds = this.toolTracker.getActiveMcpCallIds();
+      for (const callId of activeMcpCallIds) {
+        this.mcpStatusDisplay.completeCall(callId, null);
+      }
+    }
+
     if (sessionKey) {
-      this.mcpStatusDisplay.cleanupSession(sessionKey);
+      try {
+        await this.mcpStatusDisplay.flushSession(sessionKey);
+      } catch (err) {
+        // flushSession does Slack I/O; on failure fall back to a
+        // synchronous tear-down so the session tick doesn't leak.
+        this.logger.warn('mcpStatusDisplay.flushSession threw — falling back to cleanupSession', {
+          sessionKey,
+          error: (err as Error)?.message ?? String(err),
+        });
+        this.mcpStatusDisplay.cleanupSession(sessionKey);
+      }
     }
   }
 }

--- a/src/slack/tool-event-processor.ts
+++ b/src/slack/tool-event-processor.ts
@@ -609,11 +609,36 @@ export class ToolEventProcessor {
    * entry open (no `endMcpTracking` call). The compact one-line tool
    * call is closed separately via `onCompactDurationUpdate` so the user
    * still gets a `🟢 (Ns)` close on the inline tool bubble.
+   *
+   * **SDK shape-drift telemetry**: when the toolUseId IS registered as a
+   * bg Task but `extractTaskIdFromResult` cannot find a marker on a
+   * non-empty result, we log once. That state is the silent-regression
+   * footprint for #794 — if the Anthropic SDK ever ships a new content
+   * block shape (`{type:'output_text',…}`, structured `task_id` field,
+   * etc.) every spawn-ack would fall through to `endMcpTracking` and
+   * close the bg progress UI immediately on spawn, with zero log signal.
+   * Each bg Task emits one tool_result, so this warn is bounded to
+   * once per missed spawn-ack.
    */
   private isBackgroundTaskSpawnAck(toolResult: ToolResultEvent): boolean {
     if (toolResult.isError === true) return false;
     if (!this.backgroundTaskRegistry.hasAnyByToolUseId(toolResult.toolUseId)) return false;
-    return extractTaskIdFromResult(toolResult.result) !== undefined;
+    if (extractTaskIdFromResult(toolResult.result) !== undefined) return true;
+
+    const result = toolResult.result;
+    const hasContent =
+      (typeof result === 'string' && result.length > 0) || (Array.isArray(result) && result.length > 0);
+    if (hasContent) {
+      this.logger.warn(
+        'bg Task tool_result missing task_id marker — possible SDK content-block shape drift (#794 regression risk)',
+        {
+          toolUseId: toolResult.toolUseId,
+          resultType: Array.isArray(result) ? 'array' : typeof result,
+          resultLength: typeof result === 'string' ? result.length : Array.isArray(result) ? result.length : null,
+        },
+      );
+    }
+    return false;
   }
 
   /**

--- a/src/slack/tool-formatter.ts
+++ b/src/slack/tool-formatter.ts
@@ -23,7 +23,13 @@ export interface TaskToolSummary {
   subagentType?: string;
   subagentLabel?: string;
   model?: string;
-  runInBackground?: boolean;
+  /**
+   * Whether the Task tool_use carried `run_in_background: true`. Issue #794 —
+   * required field (default `false`) so every consumer can branch on it
+   * without an undefined check; `getTaskToolSummary` must populate it on
+   * every return path, including invalid/empty input.
+   */
+  runInBackground: boolean;
   promptLength?: number;
   promptPreview?: string;
 }
@@ -205,8 +211,11 @@ export class ToolFormatter {
    * Build Task tool summary from tool input
    */
   static getTaskToolSummary(input: unknown): TaskToolSummary {
+    // Issue #794 — `runInBackground` is now a required field so every caller
+    // can treat it as a boolean without an `=== true` guard. Default false on
+    // all return paths, including invalid/empty input.
     if (!input || typeof input !== 'object' || Array.isArray(input)) {
-      return {};
+      return { runInBackground: false };
     }
 
     const taskInput = input as {
@@ -216,7 +225,9 @@ export class ToolFormatter {
       prompt?: unknown;
     };
 
-    const summary: TaskToolSummary = {};
+    const summary: TaskToolSummary = {
+      runInBackground: typeof taskInput.run_in_background === 'boolean' ? taskInput.run_in_background === true : false,
+    };
 
     if (typeof taskInput.subagent_type === 'string' && taskInput.subagent_type.trim()) {
       summary.subagentType = taskInput.subagent_type.trim();
@@ -236,10 +247,6 @@ export class ToolFormatter {
 
     if (typeof taskInput.model === 'string' && taskInput.model.trim()) {
       summary.model = taskInput.model.trim();
-    }
-
-    if (typeof taskInput.run_in_background === 'boolean') {
-      summary.runInBackground = taskInput.run_in_background;
     }
 
     if (typeof taskInput.prompt === 'string') {

--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -78,6 +78,122 @@ const DEFAULT_REAPER_INTERVAL_MS = 30 * 1000; // 30 seconds
 // stale and refresh on the next hint — prevents indefinite stickiness.
 const RATE_LIMIT_WINDOW_MS = 5 * 60 * 60 * 1000;
 
+// Shared-bucket cooldown propagation (#801).
+// `parseCooldownTime` rounds to the minute, so two cascade hits within the
+// same minute boundary land ≤60 000 ms apart; the 30 s slack covers network
+// jitter and clock skew. Override via `process.env.CCT_SHARED_BUCKET_WINDOW_MS`.
+const DEFAULT_SHARED_BUCKET_WINDOW_MS = 90_000;
+// Only direct upstream evidence may anchor a match — `manual` and
+// `inferred_shared` are excluded so a single inference cannot chain across
+// the whole pool (see `RateLimitSource` doc-comment).
+const DIRECT_EVIDENCE_SOURCES: ReadonlyArray<RateLimitSource> = ['error_string', 'response_header'];
+
+/**
+ * Read on each call so tests + ops can override without restart.
+ *
+ * Strict-integer parse: `Number.parseInt('90s', 10)` returns `90`, silently
+ * dropping the trailing unit and producing a 90 ms window — four orders of
+ * magnitude smaller than intended. We require the raw value to match
+ * `^\d+$` so a misconfigured `90s` / `1e9` / `5min` triggers the warn-and-
+ * fallback path instead of being silently accepted as a tiny window.
+ */
+function resolveSharedBucketWindowMs(): number {
+  const raw = process.env.CCT_SHARED_BUCKET_WINDOW_MS;
+  if (raw === undefined || raw === '') return DEFAULT_SHARED_BUCKET_WINDOW_MS;
+  if (/^\d+$/.test(raw)) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  logger.warn(
+    `CCT_SHARED_BUCKET_WINDOW_MS invalid (${raw}); falling back to default ${DEFAULT_SHARED_BUCKET_WINDOW_MS}ms`,
+  );
+  return DEFAULT_SHARED_BUCKET_WINDOW_MS;
+}
+
+/**
+ * #801 — Shared-bucket cooldown propagation helper.
+ *
+ * When a CCT slot is rate-limited and a sibling already carries a future
+ * `cooldownUntil` within ±`windowMs` (both sourced from direct upstream
+ * evidence — `error_string` / `response_header`), propagate the new
+ * `cooldownUntil` to every other eligible OAuth-attached CCT sibling that
+ * is not already in a future cooldown. Eliminates the N-1 wasted 429-spawn
+ * cycles that otherwise occur under a shared-bucket cascade.
+ *
+ * Runs INSIDE the existing `store.mutate(snap => …)` callback so direct
+ * `snap.state[...]` writes are safe — the surrounding CAS retry handles
+ * concurrent transactions.
+ */
+function propagateInferredSharedCooldownIfMatched(
+  snap: CctStoreSnapshot,
+  cooldownUntilIso: string,
+  nowMs: number,
+  nowIso: string,
+  windowMs: number,
+  currentId: string,
+): { matchedSiblingKeyId: string; propagatedCount: number } | null {
+  const anchorMs = new Date(cooldownUntilIso).getTime();
+  // Defence in depth: the caller computes `cooldownUntilIso` from
+  // `new Date(nowMs + cooldownMs).toISOString()`, which throws on a non-finite
+  // intermediate. If a future caller hands us a malformed ISO string anyway
+  // we'd silently match against `NaN` (and `Math.abs(NaN - x) <= W` is false),
+  // so propagation would just no-op. Bail explicitly with a warn so the
+  // misconfiguration is visible.
+  if (!Number.isFinite(anchorMs)) {
+    logger.warn(`shared-bucket propagation: non-finite anchor cooldownUntil=${cooldownUntilIso}; skipping`);
+    return null;
+  }
+
+  // Eligibility shared by both passes (match-anchor scan + propagation loop)
+  // so `disableRotation` / `api_key` / no-attachment / tombstoned siblings
+  // can neither anchor a match nor receive propagation. Iteration walks
+  // `registry.slots` (not `state` keys) so orphan state rows can't leak in.
+  function isEligibleSibling(slot: AuthKey): boolean {
+    if (slot.keyId === currentId) return false;
+    if (slot.kind === 'api_key') return false;
+    if (slot.kind === 'cct' && slot.oauthAttachment === undefined) return false;
+    if (slot.disableRotation) return false;
+    return !snap.state[slot.keyId]?.tombstoned;
+  }
+
+  let matchedSiblingKeyId: string | undefined;
+  for (const slot of snap.registry.slots) {
+    if (!isEligibleSibling(slot)) continue;
+    const stateK = snap.state[slot.keyId];
+    if (!stateK?.cooldownUntil) continue;
+    const existingMs = new Date(stateK.cooldownUntil).getTime();
+    if (!Number.isFinite(existingMs) || existingMs <= nowMs) continue;
+    const sourceK = stateK.rateLimitSource;
+    if (sourceK === undefined || !DIRECT_EVIDENCE_SOURCES.includes(sourceK)) continue;
+    if (Math.abs(existingMs - anchorMs) <= windowMs) {
+      matchedSiblingKeyId = slot.keyId;
+      break;
+    }
+  }
+
+  if (matchedSiblingKeyId === undefined) return null;
+
+  // AC-4 — never overwrite a sibling that already carries a future cooldown
+  // (preserves operator-set `manual`, earlier direct evidence, and any
+  // `inferred_shared` written by an earlier anchor in this same call).
+  let propagatedCount = 0;
+  for (const slot of snap.registry.slots) {
+    if (!isEligibleSibling(slot)) continue;
+    const stateK = snap.state[slot.keyId] ?? { authState: 'healthy' as AuthState, activeLeases: [] };
+    if (stateK.cooldownUntil) {
+      const existingMs = new Date(stateK.cooldownUntil).getTime();
+      if (Number.isFinite(existingMs) && existingMs > nowMs) continue;
+    }
+    stateK.cooldownUntil = cooldownUntilIso;
+    stateK.rateLimitedAt = nowIso;
+    stateK.rateLimitSource = 'inferred_shared';
+    snap.state[slot.keyId] = stateK;
+    propagatedCount += 1;
+  }
+
+  return { matchedSiblingKeyId, propagatedCount };
+}
+
 /** Month abbreviation → 0-based month index — preserved for legacy cooldown-string parsing. */
 const MONTH_MAP: Record<string, number> = {
   jan: 0,
@@ -188,6 +304,14 @@ export interface RotateOnRateLimitOptions {
   source: RateLimitSource;
   rateLimitedAt?: string;
   cooldownMinutes?: number;
+  /**
+   * `true` when the caller parsed an actual wall-clock reset (i.e.
+   * `parseCooldownTime` returned a `Date`); `false` when falling back to the
+   * 60-minute default. Gates shared-bucket cooldown propagation (#801) so two
+   * coincidental fallbacks cannot chain into a phantom shared bucket. Defaults
+   * to `false` for backward compat with non-stream-executor callers.
+   */
+  knownReset?: boolean;
 }
 
 export interface TokenManagerInitOptions {
@@ -739,10 +863,20 @@ export class TokenManager {
     const nowIso = new Date().toISOString();
     const nowMs = Date.now();
     const cooldownUntilIso = new Date(nowMs + cooldownMs).toISOString();
+    const sharedBucketWindowMs = resolveSharedBucketWindowMs();
 
-    const rotated = await this.store.mutate<{ keyId: string; name: string } | null>((snap) => {
+    // The propagation outcome rides back out of the mutate (rather than
+    // closure-captured) so each CAS retry produces a self-contained result —
+    // no stale-snapshot log can leak from a discarded retry, and TS doesn't
+    // narrow a captured `let` back to `null` across the await boundary.
+    type RotateMutateResult = {
+      rotated: { keyId: string; name: string } | null;
+      outcome: { matchedSiblingKeyId: string; propagatedCount: number } | null;
+    };
+
+    const result = await this.store.mutate<RotateMutateResult>((snap) => {
       const currentId = snap.registry.activeKeyId;
-      if (!currentId) return null;
+      if (!currentId) return { rotated: null, outcome: null };
       const state = snap.state[currentId] ?? { authState: 'healthy' as AuthState, activeLeases: [] };
       // rate-limit timestamp hygiene: overwrite if previous window has
       // expired (no cooldownUntil or cooldownUntil has passed), OR if the
@@ -762,6 +896,22 @@ export class TokenManager {
       state.cooldownUntil = cooldownUntilIso;
       snap.state[currentId] = state;
 
+      // Trigger gate — only fire propagation when the caller actually parsed
+      // a wall-clock reset AND the source is direct upstream evidence. Two
+      // coincidental 60-min fallbacks (`knownReset:false`) or operator/
+      // already-inferred sources cannot chain into a phantom shared bucket.
+      let outcome: RotateMutateResult['outcome'] = null;
+      if (effectiveOpts.knownReset === true && DIRECT_EVIDENCE_SOURCES.includes(source)) {
+        outcome = propagateInferredSharedCooldownIfMatched(
+          snap,
+          cooldownUntilIso,
+          nowMs,
+          nowIso,
+          sharedBucketWindowMs,
+          currentId,
+        );
+      }
+
       // rotate to next eligible
       if (snap.registry.slots.length > 1) {
         const currentIndex = snap.registry.slots.findIndex((s) => s.keyId === currentId);
@@ -774,17 +924,24 @@ export class TokenManager {
           if (candidate.kind === 'api_key') continue;
           if (isEligible(candidate, snap.state[candidate.keyId], nowMs)) {
             snap.registry.activeKeyId = candidate.keyId;
-            return { keyId: candidate.keyId, name: candidate.name };
+            return { rotated: { keyId: candidate.keyId, name: candidate.name }, outcome };
           }
         }
       }
-      return null;
+      return { rotated: null, outcome };
     });
+
+    const { rotated, outcome } = result;
 
     await this.refreshCache();
     logger.info(
       `rotateOnRateLimit: ${reason ?? '(no reason)'} source=${source} rotated=${rotated ? rotated.name : 'none'}`,
     );
+    if (outcome) {
+      logger.info(
+        `rotateOnRateLimit inferred_shared: matchedSibling=${outcome.matchedSiblingKeyId} propagated=${outcome.propagatedCount} windowMs=${sharedBucketWindowMs}`,
+      );
+    }
     return rotated;
   }
 


### PR DESCRIPTION
## Summary

Deploys main → dev. 8 commits, 30 files, +5132 / -152.

## Highlights

- **#819** `deploy(iq-64-dev)` — adds 3rd dev target (iq-64), Homebrew node fallback. **Dev matrix is now 3-wide (mac-mini-dev / oudwood-dev / iq-64-dev). First deploy will install LaunchDaemon plist on iq-64 — may need sudo.**
- **#818** `fix(slack)` — #795 round-2 polish (telemetry + tests)
- **#815** `feat(dashboard)` — aggregate sibling instances into one kanban view
- **#804** `fix(cct)` — 429 cascade에서 shared-bucket cooldown을 sibling CCT들로 전파
- **#795** `fix(slack)` — subagent(Task) progress visible in minimal mode

## Risk

- iq-64 is a *new* target; failure is isolated by `fail-fast: false` on the matrix — won't block mac-mini-dev / oudwood-dev.
- Other PRs ship test coverage with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Zhuge <z@2lab.ai>