### PR TITLE
fix(deploy): rename mac-mini→iq-m16 / iq-64→iq-m64 runner labels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,8 +63,8 @@ jobs:
             cat >> "$GITHUB_OUTPUT" <<'EOF'
           {"include":[
             {
-              "name":"mac-mini-dev",
-              "runner_label":"soma-work",
+              "name":"iq-m16-dev",
+              "runner_label":"iq-m16",
               "github_env":"development",
               "deploy_env":"dev",
               "target_dir":"/opt/soma-work/dev"
@@ -77,8 +77,8 @@ jobs:
               "target_dir":"/opt/soma-work/dev"
             },
             {
-              "name":"iq-64-dev",
-              "runner_label":"iq-64",
+              "name":"iq-m64-dev",
+              "runner_label":"iq-m64",
               "github_env":"development",
               "deploy_env":"dev",
               "target_dir":"/opt/soma-work/dev"
@@ -89,8 +89,8 @@ jobs:
             cat >> "$GITHUB_OUTPUT" <<'EOF'
           {"include":[
             {
-              "name":"mac-mini-main",
-              "runner_label":"soma-work",
+              "name":"iq-m16-main",
+              "runner_label":"iq-m16",
               "github_env":"production",
               "deploy_env":"main",
               "target_dir":"/opt/soma-work/main"

--- a/src/deploy/__tests__/deploy-config.test.ts
+++ b/src/deploy/__tests__/deploy-config.test.ts
@@ -14,8 +14,10 @@ describe('deploy config expectations', () => {
 
     expect(workflow).toContain('branches: [deploy/dev, deploy/prod]');
     expect(workflow).toContain('deploy/prod)');
-    expect(workflow).toContain('"name":"mac-mini-dev"');
+    expect(workflow).toContain('"name":"iq-m16-dev"');
     expect(workflow).toContain('"name":"oudwood-dev"');
+    expect(workflow).toContain('"name":"iq-m64-dev"');
+    expect(workflow).toContain('"name":"iq-m16-main"');
     expect(workflow).toContain('"deploy_env":"dev"');
     expect(workflow).toContain('"target_dir":"/opt/soma-work/dev"');
     expect(workflow).toContain('"target_dir":"/opt/soma-work/main"');


### PR DESCRIPTION
## Summary

Macmini와 iq-64 self-hosted runner의 custom 라벨을 GitHub Actions API로 일괄 rename하고, deploy 매트릭스를 그에 맞춰 업데이트.

| runner | display name | custom label (before → after) |
|---|---|---|
| #24 | iq-macmini | `iq-macmini` → **`iq-m16`** |
| #23 | iq-64      | `iq-64`      → **`iq-m64`**  |

## 매트릭스 변경

| matrix entry | name | runner_label |
|---|---|---|
| (was) `mac-mini-dev` | → **`iq-m16-dev`** | `soma-work` → **`iq-m16`** |
| `oudwood-dev` | (unchanged) | `oudwood-512` (unchanged) |
| (was) `iq-64-dev` | → **`iq-m64-dev`** | `iq-64` → **`iq-m64`** |
| (was) `mac-mini-main` | → **`iq-m16-main`** | `soma-work` → **`iq-m16`** |

## 배경

`mac-mini-dev` / `mac-mini-main` matrix entry는 `runner_label: "soma-work"`를 매칭하도록 되어 있었지만, macmini runner는 2026-04-30 경 v2.334.0으로 재등록되면서 라벨이 `iq-macmini`로 바뀌었음. 이후 모든 mac-mini deploy job은 매칭 runner를 못 찾고 timeout까지 queued 상태로 대기. 마지막 성공 deploy는 2026-04-29 (run #25101050115). PR #812 머지 후 트리거된 #25474141737은 `mac-mini-dev`가 4h+ queued 상태였음.

## Test plan

- [ ] PR 머지 후 `git push origin main:deploy/dev`로 deploy trigger
- [ ] `prepare` job (oudwood-512) bundle 빌드 성공
- [ ] **3개 deploy matrix job 전부 성공** — `iq-m16-dev`, `oudwood-dev`, `iq-m64-dev`
- [ ] `iq-m16-dev`가 더 이상 queued 상태로 timeout되지 않음

## Notes

- Runner display names (agentName)은 그대로 둠 (`iq-macmini`, `iq-64`). 변경하려면 `./config.sh remove` + 재등록(sudo 필요) 필요. workflow 매칭은 라벨로 이루어지므로 cosmetic 차이.
- GitHub UI runner 페이지에서 라벨이 새 값으로 바뀐 것 확인 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)