### PR TITLE
feat(html-skill): durable serve root = artifact archive + ui-ux always-on default

### DIFF
--- a/src/local/.claude-plugin/plugin.json
+++ b/src/local/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zworkflow",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Z-workflow plugin: SSOT-driven development pipeline (z / zcheck / ztrace / autoz / zwork / trinity) plus agents, commands, hooks, prompts, and skills. Shipped as a soma-work default plugin.",
   "author": {
     "name": "zhugehyuk",

--- a/src/local/skills/html/SKILL.md
+++ b/src/local/skills/html/SKILL.md
@@ -366,13 +366,27 @@ artifacts are timestamped by the Step 4 filename, retained indefinitely
 (no auto-pruning), and listable at the daemon's `/` index newest-first;
 reclaiming disk is a human decision, not the server's.
 
-**Migration & mixed versions** (automatic, no action needed): every publish
-and daemon start sweeps any artifacts still in the legacy `/tmp` root into
-the durable archive (existing names are never overwritten). If a daemon from
-an older version is still serving the legacy root, publish also drops a copy
-where that daemon can see it — the printed link works immediately and the
-JSON carries a `note`; the durable root takes over when that daemon next
-restarts (e.g. after reboot).
+**Migration & mixed versions** (automatic): every publish and daemon start
+sweeps regular files still in the legacy `/tmp` root into the durable
+archive (existing names are never overwritten; symlinks are never followed).
+Sweep failures don't block publishing but are surfaced on stderr and as a
+`migrationErrors` count in the JSON — a silent sweep is not assumed to have
+worked. The printed link is **verified with a real HTTP 200 before it is
+handed out**: if an older daemon is still serving a different root, publish
+places a compat copy, verifies, and marks the JSON with a `note`; if the old
+daemon can't be verified, publish starts a fresh daemon on the next free
+port instead of printing a dead link. (Old publishers meeting a new daemon
+read its health reply as foreign and self-heal onto another port — accepted
+port drift, never a silent 404.) Re-publishing the same filename refreshes
+that artifact in place — timestamps in the filename are what make archive
+entries distinct.
+
+**The archive is LAN-readable, indefinitely.** With the default `0.0.0.0`
+bind, everything published is listable and readable by anyone on the local
+network for as long as it stays in the archive — never publish pages
+containing secrets, tokens, or personal data. If something sensitive was
+published, delete that file from the serve root yourself (that is the
+removal procedure; there is no expiry).
 
 Use `url` (LAN IP) as the access link you hand to the user — `localhost`
 only works on the host machine itself; include it as a secondary mention.

--- a/src/local/skills/html/SKILL.md
+++ b/src/local/skills/html/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: html
-description: Convert any content (markdown, plain text, JSON, CSV, SQL, raw notes) into a styled single-file HTML with a Lottie motion layer and a rendered PNG, publish the HTML on the local web server (clickable access link), then upload both files to the current Slack thread. The visual design is driven by the `ui-ux` skill as the main design engine (design-system + named references; default reference `openai`), with the `design` skill applied on top as the anti-AI-slop layer and the `motion-design`/`apple-design` standards governing all CSS motion and display typography. Pick a template name from the catalog or let the skill auto-classify. Triggers on "html로 만들어줘", "HTML로 변환", "이걸 페이지로", "render as html", "html + png", "convert to html", "to html and png", "make a card", "make a deck", "make a poster", "make a report from this data".
+description: Convert any content (markdown, plain text, JSON, CSV, SQL, raw notes) into a styled single-file HTML with a Lottie motion layer and a rendered PNG, publish the HTML on the local web server (clickable access link), then upload both files to the current Slack thread. The visual design is driven by the `ui-ux` skill as the main design engine — applied by default on EVERY invocation, whether or not the user mentions design (design-system + named references; default reference `openai`) — with the `design` skill applied on top as the anti-AI-slop layer and the `motion-design`/`apple-design` standards governing all CSS motion and display typography. Pick a template name from the catalog or let the skill auto-classify. Triggers on "html로 만들어줘", "HTML로 변환", "이걸 페이지로", "render as html", "html + png", "convert to html", "to html and png", "make a card", "make a deck", "make a poster", "make a report from this data".
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
-version: 0.3.0
+version: 0.4.0
 license: ISC
 ---
 
@@ -90,13 +90,19 @@ typography constraints, palette). The agent obeys this contract when
 generating HTML. If the upstream template's `SKILL.md` is in Chinese or
 mixed CJK, that's fine — the structural intent translates.
 
-### 3.4. Drive the design from the `ui-ux` skill (MAIN driver)
+### 3.4. Drive the design from the `ui-ux` skill (MAIN driver — always on)
 
-The **`ui-ux`** skill is the **main design driver** for this skill. Before any
-visual decision, read it and run its engine — it owns palette, typography,
-layout system, and the named visual reference. (The `design` skill in Step 3.5
-then runs *on top* of the ui-ux output as the anti-AI-slop refinement layer; it
-is no longer the primary source of the visual voice.)
+The **`ui-ux`** skill is the **main design driver** for this skill, and this
+step is **not opt-in**: run it on every invocation, even when the user says
+nothing about design, style, or references. The user asking for "HTML" IS the
+request for a designed page — do not wait for a design keyword, and do not
+skip to raw markup because the content seems plain. Skip this step only when
+the user explicitly opts out (e.g. asks for "unstyled/bare HTML").
+
+Before any visual decision, read `ui-ux` and run its engine — it owns palette,
+typography, layout system, and the named visual reference. (The `design` skill
+in Step 3.5 then runs *on top* of the ui-ux output as the anti-AI-slop
+refinement layer; it is no longer the primary source of the visual voice.)
 
 ```bash
 UIUX="$CLAUDE_PLUGIN_ROOT/skills/ui-ux"
@@ -331,23 +337,42 @@ with open(p, "rb") as f:
 PY
 ```
 
-### 7. Publish to the local web server (access link)
+### 7. Publish to the local web server (access link + durable archive)
 
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/skills/html/server/serve.mjs" \
   --file "$(pwd)/html-<slug>-<ts>.html"
 ```
 
-This copies the HTML into the serve root (`/tmp/soma-html-serve`), ensures a
-long-lived static-server daemon is listening (spawned detached on first use —
-idempotent, survives the agent turn, reused across sessions), and prints
-JSON:
+This copies the HTML into the **serve root, which doubles as the permanent
+artifact archive**, ensures a long-lived static-server daemon is listening
+(spawned detached on first use — idempotent, survives the agent turn, reused
+across sessions), and prints JSON:
 
 ```json
 { "url": "http://<lan-ip>:8763/html-<slug>-<ts>.html",
   "localUrl": "http://localhost:8763/html-<slug>-<ts>.html",
-  "port": 8763, "file": "/tmp/soma-html-serve/html-<slug>-<ts>.html" }
+  "port": 8763, "file": "<serve-root>/html-<slug>-<ts>.html" }
 ```
+
+**Serve root = archive.** The root resolves in this order (first hit wins):
+`SOMA_HTML_SERVE_ROOT` env override → `$XDG_DATA_HOME/soma-html-serve` →
+`~/.local/share/soma-html-serve` (the default on macOS and Linux) → the
+legacy `/tmp/soma-html-serve` only when no home directory is resolvable.
+Never point the root at a system temp directory yourself: OS temp cleanup
+deletes every published artifact — a week of reports once vanished this way
+and had to be reconstructed from session transcripts. Archive policy:
+artifacts are timestamped by the Step 4 filename, retained indefinitely
+(no auto-pruning), and listable at the daemon's `/` index newest-first;
+reclaiming disk is a human decision, not the server's.
+
+**Migration & mixed versions** (automatic, no action needed): every publish
+and daemon start sweeps any artifacts still in the legacy `/tmp` root into
+the durable archive (existing names are never overwritten). If a daemon from
+an older version is still serving the legacy root, publish also drops a copy
+where that daemon can see it — the printed link works immediately and the
+JSON carries a `note`; the durable root takes over when that daemon next
+restarts (e.g. after reboot).
 
 Use `url` (LAN IP) as the access link you hand to the user — `localhost`
 only works on the host machine itself; include it as a secondary mention.
@@ -410,6 +435,9 @@ look.
   URLs, or off-palette colors are all slop.
 - Do **not** hand the user a link you haven't `curl`-verified, and do not
   ship `localhost` as the primary link — it only resolves on the host.
+- Do **not** point `SOMA_HTML_SERVE_ROOT` at a system temp directory, and do
+  not "clean up" the serve root as part of a task — it is the artifact
+  archive; pruning it is the user's call.
 
 ## Adding more templates
 

--- a/src/local/skills/html/__tests__/html-motion-serve.test.ts
+++ b/src/local/skills/html/__tests__/html-motion-serve.test.ts
@@ -66,6 +66,10 @@ describe('local:html skill — motion layer + local web server contract', () => 
     expect(src).toMatch(/migrateLegacyArtifacts/);
     expect(src).toMatch(/lstatSync/);
     expect(src).toMatch(/migrationErrors/);
+    // Trust gate for the world-writable legacy namespace (real dir + owner)
+    // and atomic create-if-absent installs (no check-then-rename race).
+    expect(src).toMatch(/getuid/);
+    expect(src).toMatch(/linkSync/);
     // The printed link is verified with a real HTTP GET before hand-out.
     expect(src).toMatch(/verifyServed/);
     const md = readFileSync(SKILL_MD, 'utf8');

--- a/src/local/skills/html/__tests__/html-motion-serve.test.ts
+++ b/src/local/skills/html/__tests__/html-motion-serve.test.ts
@@ -52,7 +52,9 @@ describe('local:html skill — motion layer + local web server contract', () => 
     expect(src).toMatch(/XDG_DATA_HOME/);
     expect(src).toMatch(/homedir/);
     expect(src).toMatch(/'\.local',\s*'share',\s*'soma-html-serve'/);
-    expect(src).toMatch(/LEGACY_SERVE_ROOT\s*=\s*process\.env\.SOMA_HTML_LEGACY_ROOT\s*\|\|\s*'\/tmp\/soma-html-serve'/);
+    expect(src).toMatch(
+      /LEGACY_SERVE_ROOT\s*=\s*process\.env\.SOMA_HTML_LEGACY_ROOT\s*\|\|\s*'\/tmp\/soma-html-serve'/,
+    );
     expect(src).not.toMatch(/SOMA_HTML_SERVE_ROOT\s*\|\|\s*'\/tmp\/soma-html-serve'/);
     // Explicit override must stay supported.
     expect(src).toMatch(/SOMA_HTML_SERVE_ROOT/);

--- a/src/local/skills/html/__tests__/html-motion-serve.test.ts
+++ b/src/local/skills/html/__tests__/html-motion-serve.test.ts
@@ -52,18 +52,25 @@ describe('local:html skill — motion layer + local web server contract', () => 
     expect(src).toMatch(/XDG_DATA_HOME/);
     expect(src).toMatch(/homedir/);
     expect(src).toMatch(/'\.local',\s*'share',\s*'soma-html-serve'/);
-    expect(src).toMatch(/LEGACY_SERVE_ROOT\s*=\s*'\/tmp\/soma-html-serve'/);
+    expect(src).toMatch(/LEGACY_SERVE_ROOT\s*=\s*process\.env\.SOMA_HTML_LEGACY_ROOT\s*\|\|\s*'\/tmp\/soma-html-serve'/);
     expect(src).not.toMatch(/SOMA_HTML_SERVE_ROOT\s*\|\|\s*'\/tmp\/soma-html-serve'/);
     // Explicit override must stay supported.
     expect(src).toMatch(/SOMA_HTML_SERVE_ROOT/);
     // The health probe advertises the daemon's root so a publisher can detect
     // a pre-durable-root daemon still serving the legacy directory…
     expect(src).toMatch(/root=\$\{SERVE_ROOT\}/);
-    // …and legacy artifacts are migrated forward, never destroyed.
+    // …and legacy artifacts are migrated forward, never destroyed. The sweep
+    // must refuse symlinks (lstat) and must not swallow failures silently.
     expect(src).toMatch(/migrateLegacyArtifacts/);
+    expect(src).toMatch(/lstatSync/);
+    expect(src).toMatch(/migrationErrors/);
+    // The printed link is verified with a real HTTP GET before hand-out.
+    expect(src).toMatch(/verifyServed/);
     const md = readFileSync(SKILL_MD, 'utf8');
     expect(md).toMatch(/durable|archive/i);
     expect(md).toMatch(/SOMA_HTML_SERVE_ROOT/);
+    // Archive-forever + LAN exposure requires an explicit no-secrets warning.
+    expect(md).toMatch(/secrets, tokens, or personal data/i);
   });
 
   it('ui-ux design driver is the unconditional default, not opt-in', () => {

--- a/src/local/skills/html/__tests__/html-motion-serve.test.ts
+++ b/src/local/skills/html/__tests__/html-motion-serve.test.ts
@@ -44,6 +44,34 @@ describe('local:html skill — motion layer + local web server contract', () => 
     expect(md).toMatch(/localhost.*only (works|resolves)|only resolves on the host/i);
   });
 
+  it('serves from a durable per-user archive root, never /tmp by default', () => {
+    const src = readFileSync(SERVER, 'utf8');
+    // The default root must resolve to user data dirs; /tmp is legacy-only.
+    // OS temp cleanup wiping the serve root deleted every published artifact
+    // once (2026-07 — recovered only by replaying session transcripts).
+    expect(src).toMatch(/XDG_DATA_HOME/);
+    expect(src).toMatch(/homedir/);
+    expect(src).toMatch(/'\.local',\s*'share',\s*'soma-html-serve'/);
+    expect(src).toMatch(/LEGACY_SERVE_ROOT\s*=\s*'\/tmp\/soma-html-serve'/);
+    expect(src).not.toMatch(/SOMA_HTML_SERVE_ROOT\s*\|\|\s*'\/tmp\/soma-html-serve'/);
+    // Explicit override must stay supported.
+    expect(src).toMatch(/SOMA_HTML_SERVE_ROOT/);
+    // The health probe advertises the daemon's root so a publisher can detect
+    // a pre-durable-root daemon still serving the legacy directory…
+    expect(src).toMatch(/root=\$\{SERVE_ROOT\}/);
+    // …and legacy artifacts are migrated forward, never destroyed.
+    expect(src).toMatch(/migrateLegacyArtifacts/);
+    const md = readFileSync(SKILL_MD, 'utf8');
+    expect(md).toMatch(/durable|archive/i);
+    expect(md).toMatch(/SOMA_HTML_SERVE_ROOT/);
+  });
+
+  it('ui-ux design driver is the unconditional default, not opt-in', () => {
+    const md = readFileSync(SKILL_MD, 'utf8');
+    expect(md).toMatch(/not opt-in/i);
+    expect(md).toMatch(/every invocation/i);
+  });
+
   it('server/serve.mjs is a self-contained node static server with health + traversal guard', () => {
     expect(existsSync(SERVER)).toBe(true);
     const src = readFileSync(SERVER, 'utf8');

--- a/src/local/skills/html/__tests__/html-serve-behavior.test.ts
+++ b/src/local/skills/html/__tests__/html-serve-behavior.test.ts
@@ -1,5 +1,6 @@
-import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { type ChildProcess, execFileSync, spawn } from 'node:child_process';
+import { existsSync, lstatSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -99,5 +100,51 @@ describe('local:html serve.mjs — behavioral contract (real daemon, real GET)',
     expect(existsSync(join(durableRoot, 'leak.html'))).toBe(false);
     // The legacy originals are untouched (non-destructive sweep).
     expect(existsSync(join(legacyRoot, 'survivor.html'))).toBe(true);
+  });
+
+  it('a destination symlink planted in the archive is replaced, never followed', async () => {
+    const victim = join(outsideDir, 'victim.txt');
+    writeFileSync(victim, 'VICTIM-ORIGINAL');
+    symlinkSync(victim, join(durableRoot, 'planted.html'));
+    const artifact = join(artifactDir, 'planted.html');
+    writeFileSync(artifact, '<!doctype html><title>planted replacement</title>');
+    execFileSync(process.execPath, [SERVER, '--file', artifact, '--port', String(PORT)], {
+      env,
+      encoding: 'utf8',
+    });
+    // The write must have replaced the symlink itself, not its target.
+    expect(readFileSync(victim, 'utf8')).toBe('VICTIM-ORIGINAL');
+    expect(lstatSync(join(durableRoot, 'planted.html')).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(durableRoot, 'planted.html'), 'utf8')).toContain('planted replacement');
+  });
+
+  it('rejects an unknown-root daemon serving a stale same-name file (no silent 404/stale link)', async () => {
+    // Emulate a pre-durable-root daemon with a custom root: bare health body
+    // (no root line) + a stale artifact under the requested name.
+    const stalePort = PORT + 1;
+    const staleServer = http.createServer((req, res) => {
+      if (req.url === '/__soma-serve-health') return res.end('soma-html-serve');
+      res.setHeader('content-type', 'text/html');
+      res.end('<!doctype html><title>STALE ARTIFACT</title>');
+    });
+    await new Promise<void>((r) => staleServer.listen(stalePort, '127.0.0.1', () => r()));
+    try {
+      const artifact = join(artifactDir, 'stale-check.html');
+      writeFileSync(artifact, '<!doctype html><title>fresh artifact</title>');
+      let exitCode = 0;
+      try {
+        execFileSync(process.execPath, [SERVER, '--file', artifact, '--port', String(stalePort)], {
+          env,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      } catch (err) {
+        exitCode = (err as { status?: number }).status ?? -1;
+      }
+      // Byte-verification must reject the stale 200 → explicit port fails loudly.
+      expect(exitCode).toBe(2);
+    } finally {
+      staleServer.close();
+    }
   });
 });

--- a/src/local/skills/html/__tests__/html-serve-behavior.test.ts
+++ b/src/local/skills/html/__tests__/html-serve-behavior.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Process-level receipts for the durable-root serve contract: a real daemon,
+// a real publish, a real GET. The static regex tests pin the source shape;
+// these pin the behavior (env resolution, migration hygiene, verified link).
+
+const SERVER = resolve(__dirname, '..', 'server', 'serve.mjs');
+// Off the production 8763 range so a developer's real daemon is never touched.
+const PORT = 18963 + (process.pid % 400);
+
+let durableRoot: string;
+let legacyRoot: string;
+let outsideDir: string;
+let artifactDir: string;
+let env: NodeJS.ProcessEnv;
+let daemon: ChildProcess;
+
+function health(): Promise<string | null> {
+  return fetch(`http://127.0.0.1:${PORT}/__soma-serve-health`)
+    .then((r) => r.text())
+    .catch(() => null);
+}
+
+beforeAll(async () => {
+  durableRoot = mkdtempSync(join(tmpdir(), 'soma-serve-durable-'));
+  legacyRoot = mkdtempSync(join(tmpdir(), 'soma-serve-legacy-'));
+  outsideDir = mkdtempSync(join(tmpdir(), 'soma-serve-outside-'));
+  artifactDir = mkdtempSync(join(tmpdir(), 'soma-serve-artifact-'));
+
+  // Legacy root: one legitimate survivor + one symlink pointing at a
+  // "secret" outside the root. The sweep must rescue the file and refuse
+  // the symlink.
+  writeFileSync(join(legacyRoot, 'survivor.html'), '<!doctype html><title>survivor</title>');
+  writeFileSync(join(outsideDir, 'secret.txt'), 'MUST-NOT-LEAK');
+  symlinkSync(join(outsideDir, 'secret.txt'), join(legacyRoot, 'leak.html'));
+
+  env = {
+    ...process.env,
+    SOMA_HTML_SERVE_ROOT: durableRoot,
+    SOMA_HTML_LEGACY_ROOT: legacyRoot,
+    SOMA_HTML_SERVE_BIND: '127.0.0.1',
+  };
+
+  daemon = spawn(process.execPath, [SERVER, '--daemon', '--port', String(PORT)], {
+    env,
+    stdio: 'ignore',
+  });
+  for (let i = 0; i < 40; i++) {
+    if ((await health()) !== null) break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}, 15_000);
+
+afterAll(() => {
+  daemon?.kill();
+  for (const dir of [durableRoot, legacyRoot, outsideDir, artifactDir]) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+});
+
+describe('local:html serve.mjs — behavioral contract (real daemon, real GET)', () => {
+  it('health advertises ownership and the served root to loopback callers', async () => {
+    const body = await health();
+    expect(body).not.toBeNull();
+    const lines = (body as string).trim().split('\n');
+    expect(lines[0]).toBe('soma-html-serve');
+    expect(lines[1]).toBe(`root=${durableRoot}`);
+  });
+
+  it('publish archives into the durable root and prints a verified, working link', async () => {
+    const artifact = join(artifactDir, 'behavior-receipt.html');
+    writeFileSync(artifact, '<!doctype html><title>behavior receipt</title>');
+    const out = JSON.parse(
+      execFileSync(process.execPath, [SERVER, '--file', artifact, '--port', String(PORT)], {
+        env,
+        encoding: 'utf8',
+      }),
+    );
+    expect(out.port).toBe(PORT);
+    expect(out.file).toBe(join(durableRoot, 'behavior-receipt.html'));
+    expect(existsSync(out.file)).toBe(true);
+    const res = await fetch(out.localUrl);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('behavior receipt');
+  });
+
+  it('migrates legacy regular files forward but never follows symlinks', () => {
+    // Migration ran during daemon start and again during the publish above.
+    expect(existsSync(join(durableRoot, 'survivor.html'))).toBe(true);
+    expect(readFileSync(join(durableRoot, 'survivor.html'), 'utf8')).toContain('survivor');
+    expect(existsSync(join(durableRoot, 'leak.html'))).toBe(false);
+    // The legacy originals are untouched (non-destructive sweep).
+    expect(existsSync(join(legacyRoot, 'survivor.html'))).toBe(true);
+  });
+});

--- a/src/local/skills/html/__tests__/html-serve-behavior.test.ts
+++ b/src/local/skills/html/__tests__/html-serve-behavior.test.ts
@@ -118,6 +118,37 @@ describe('local:html serve.mjs — behavioral contract (real daemon, real GET)',
     expect(readFileSync(join(durableRoot, 'planted.html'), 'utf8')).toContain('planted replacement');
   });
 
+  it('refuses a symlinked legacy root (world-writable /tmp trust gate)', () => {
+    const realDir = mkdtempSync(join(tmpdir(), 'soma-serve-reallegacy-'));
+    writeFileSync(join(realDir, 'juicy.html'), 'SHOULD-NOT-MIGRATE');
+    const linkPath = join(mkdtempSync(join(tmpdir(), 'soma-serve-linkparent-')), 'legacy-link');
+    symlinkSync(realDir, linkPath);
+    const artifact = join(artifactDir, 'symlink-root-check.html');
+    writeFileSync(artifact, '<!doctype html><title>symlink root check</title>');
+    const raw = execFileSync(process.execPath, [SERVER, '--file', artifact, '--port', String(PORT)], {
+      env: { ...env, SOMA_HTML_LEGACY_ROOT: linkPath },
+      encoding: 'utf8',
+    });
+    const out = JSON.parse(raw);
+    // Publish still succeeds, but the sweep refused the symlinked root loudly
+    // and nothing behind the link entered the LAN-served archive.
+    expect(out.migrationErrors).toBeGreaterThanOrEqual(1);
+    expect(existsSync(join(durableRoot, 'juicy.html'))).toBe(false);
+    rmSync(realDir, { recursive: true, force: true });
+  });
+
+  it('migration never replaces an existing (possibly fresher) archive file', () => {
+    writeFileSync(join(legacyRoot, 'collide.html'), 'STALE-LEGACY-BYTES');
+    writeFileSync(join(durableRoot, 'collide.html'), 'FRESH-ARCHIVE-BYTES');
+    const artifact = join(artifactDir, 'collide-trigger.html');
+    writeFileSync(artifact, '<!doctype html><title>collide trigger</title>');
+    execFileSync(process.execPath, [SERVER, '--file', artifact, '--port', String(PORT)], {
+      env,
+      encoding: 'utf8',
+    });
+    expect(readFileSync(join(durableRoot, 'collide.html'), 'utf8')).toBe('FRESH-ARCHIVE-BYTES');
+  });
+
   it('rejects an unknown-root daemon serving a stale same-name file (no silent 404/stale link)', async () => {
     // Emulate a pre-durable-root daemon with a custom root: bare health body
     // (no root line) + a stale artifact under the requested name.

--- a/src/local/skills/html/__tests__/html-serve-behavior.test.ts
+++ b/src/local/skills/html/__tests__/html-serve-behavior.test.ts
@@ -120,21 +120,26 @@ describe('local:html serve.mjs — behavioral contract (real daemon, real GET)',
 
   it('refuses a symlinked legacy root (world-writable /tmp trust gate)', () => {
     const realDir = mkdtempSync(join(tmpdir(), 'soma-serve-reallegacy-'));
-    writeFileSync(join(realDir, 'juicy.html'), 'SHOULD-NOT-MIGRATE');
-    const linkPath = join(mkdtempSync(join(tmpdir(), 'soma-serve-linkparent-')), 'legacy-link');
-    symlinkSync(realDir, linkPath);
-    const artifact = join(artifactDir, 'symlink-root-check.html');
-    writeFileSync(artifact, '<!doctype html><title>symlink root check</title>');
-    const raw = execFileSync(process.execPath, [SERVER, '--file', artifact, '--port', String(PORT)], {
-      env: { ...env, SOMA_HTML_LEGACY_ROOT: linkPath },
-      encoding: 'utf8',
-    });
-    const out = JSON.parse(raw);
-    // Publish still succeeds, but the sweep refused the symlinked root loudly
-    // and nothing behind the link entered the LAN-served archive.
-    expect(out.migrationErrors).toBeGreaterThanOrEqual(1);
-    expect(existsSync(join(durableRoot, 'juicy.html'))).toBe(false);
-    rmSync(realDir, { recursive: true, force: true });
+    const linkParent = mkdtempSync(join(tmpdir(), 'soma-serve-linkparent-'));
+    try {
+      writeFileSync(join(realDir, 'juicy.html'), 'SHOULD-NOT-MIGRATE');
+      const linkPath = join(linkParent, 'legacy-link');
+      symlinkSync(realDir, linkPath);
+      const artifact = join(artifactDir, 'symlink-root-check.html');
+      writeFileSync(artifact, '<!doctype html><title>symlink root check</title>');
+      const raw = execFileSync(process.execPath, [SERVER, '--file', artifact, '--port', String(PORT)], {
+        env: { ...env, SOMA_HTML_LEGACY_ROOT: linkPath },
+        encoding: 'utf8',
+      });
+      const out = JSON.parse(raw);
+      // Publish still succeeds, but the sweep refused the symlinked root
+      // loudly and nothing behind the link entered the LAN-served archive.
+      expect(out.migrationErrors).toBeGreaterThanOrEqual(1);
+      expect(existsSync(join(durableRoot, 'juicy.html'))).toBe(false);
+    } finally {
+      rmSync(realDir, { recursive: true, force: true });
+      rmSync(linkParent, { recursive: true, force: true });
+    }
   });
 
   it('migration never replaces an existing (possibly fresher) archive file', () => {

--- a/src/local/skills/html/server/serve.mjs
+++ b/src/local/skills/html/server/serve.mjs
@@ -165,25 +165,46 @@ function probeHealth(port, timeoutMs = 700) {
   // answer a bare body (no root line) — their root is unknown, not assumed:
   // publish() treats an undefined root as "guess, then verify".
   return new Promise((resolveProbe) => {
+    let done = false;
+    const finish = (v) => {
+      if (done) return;
+      done = true;
+      clearTimeout(deadline);
+      resolveProbe(v);
+    };
     const req = http.get(
       { host: '127.0.0.1', port, path: HEALTH_PATH, timeout: timeoutMs },
       (res) => {
         let body = '';
-        res.on('data', (chunk) => (body += chunk));
+        res.on('data', (chunk) => {
+          body += chunk;
+          if (body.length > 4096) {
+            // A real health reply is two short lines; anything bigger is not
+            // our daemon — stop reading instead of buffering it.
+            req.destroy();
+            finish({ state: 'foreign' });
+          }
+        });
         res.on('end', () => {
           const lines = body.trim().split('\n');
-          if (lines[0].trim() !== HEALTH_BODY) return resolveProbe({ state: 'foreign' });
+          if (lines[0].trim() !== HEALTH_BODY) return finish({ state: 'foreign' });
           const rootLine = lines.find((l) => l.startsWith('root='));
-          resolveProbe({ state: 'ours', root: rootLine ? rootLine.slice(5).trim() : undefined });
+          finish({ state: 'ours', root: rootLine ? rootLine.slice(5).trim() : undefined });
         });
       },
     );
+    // Overall deadline, matching verifyServed: the socket-inactivity timeout
+    // alone lets a slowly dripping endpoint stall the publisher.
+    const deadline = setTimeout(() => {
+      req.destroy();
+      finish({ state: 'foreign' });
+    }, timeoutMs * 2);
     req.on('timeout', () => {
       req.destroy();
-      resolveProbe({ state: 'foreign' });
+      finish({ state: 'foreign' });
     });
     req.on('error', (err) => {
-      resolveProbe({ state: err.code === 'ECONNREFUSED' ? 'free' : 'foreign' });
+      finish({ state: err.code === 'ECONNREFUSED' ? 'free' : 'foreign' });
     });
   });
 }

--- a/src/local/skills/html/server/serve.mjs
+++ b/src/local/skills/html/server/serve.mjs
@@ -58,7 +58,21 @@
  * find, or verify a server.
  */
 
-import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import {
+  closeSync,
+  constants as FS,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import http from 'node:http';
 import { homedir, networkInterfaces } from 'node:os';
 import { basename, extname, isAbsolute, join, resolve, sep } from 'node:path';
@@ -173,15 +187,22 @@ function probeHealth(port, timeoutMs = 700) {
   });
 }
 
-function verifyServed(port, name, timeoutMs = 1500) {
-  // The printed link is a deliverable — prove it answers 200 over loopback
-  // before handing it out. Never trust root bookkeeping alone.
+function verifyServed(port, name, expectedBytes, timeoutMs = 2000) {
+  // The printed link is a deliverable — prove the daemon returns THIS
+  // artifact's bytes over loopback before handing it out. A bare 200 is not
+  // enough: an old daemon on an unknown root can happily serve a stale file
+  // with the same name.
   return new Promise((resolveVerify) => {
     const req = http.get(
-      { host: '127.0.0.1', port, path: '/' + encodeURIComponent(name), timeout: timeoutMs },
+      { host: '127.0.0.1', port, path: `/${encodeURIComponent(name)}`, timeout: timeoutMs },
       (res) => {
-        res.resume();
-        resolveVerify(res.statusCode === 200);
+        if (res.statusCode !== 200) {
+          res.resume();
+          return resolveVerify(false);
+        }
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolveVerify(Buffer.concat(chunks).equals(expectedBytes)));
       },
     );
     req.on('timeout', () => {
@@ -190,6 +211,35 @@ function verifyServed(port, name, timeoutMs = 1500) {
     });
     req.on('error', () => resolveVerify(false));
   });
+}
+
+function readFileNoFollow(path) {
+  // O_NOFOLLOW closes the lstat→read race: if the path is (or becomes) a
+  // symlink, the open fails instead of following it.
+  const fd = openSync(path, FS.O_RDONLY | FS.O_NOFOLLOW);
+  try {
+    return readFileSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function writeFileReplacing(dstDir, name, bytes) {
+  // Write-to-temp + atomic rename. rename REPLACES a symlink sitting at the
+  // destination instead of following it, so a link planted inside a serve
+  // root can never redirect this write to a file outside it.
+  const tmp = join(dstDir, `.tmp-publish-${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+  writeFileSync(tmp, bytes, { flag: 'wx' });
+  try {
+    renameSync(tmp, join(dstDir, name));
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      /* temp cleanup is best-effort */
+    }
+    throw err;
+  }
 }
 
 function startDaemon(port) {
@@ -228,7 +278,9 @@ function migrateLegacyArtifacts() {
       try {
         if (!lstatSync(src).isFile()) continue; // lstat: symlinks excluded
         if (existsSync(dst)) continue;
-        copyFileSync(src, dst);
+        // O_NOFOLLOW read + temp-file/rename write: neither side of the copy
+        // can be redirected through a symlink.
+        writeFileReplacing(SERVE_ROOT, name, readFileNoFollow(src));
         result.migrated++;
       } catch (err) {
         result.errors.push(`${src}: ${err.message}`);
@@ -277,7 +329,10 @@ function isLoopback(req) {
 
 function runDaemon(port) {
   mkdirSync(SERVE_ROOT, { recursive: true });
-  migrateLegacyArtifacts();
+  const sweep = migrateLegacyArtifacts();
+  // Daemons spawned by publish run with stdio ignored, but a directly-run
+  // daemon still surfaces sweep failures instead of losing them.
+  for (const e of sweep.errors) console.error(`legacy migration failed for ${e}`);
   const rootReal = realpathSync(SERVE_ROOT);
   const server = http.createServer((req, res) => {
     try {
@@ -335,25 +390,26 @@ function runDaemon(port) {
   server.listen(port, BIND_ADDR);
 }
 
-async function adoptDaemon(port, probe, abs, name) {
+async function adoptDaemon(port, probe, artifactBytes, name) {
   // Try to make an existing 'ours' daemon serve this artifact, returning
-  // { port, note? } only after a VERIFIED 200 — otherwise null.
+  // { port, note? } only after the served bytes are VERIFIED — otherwise null.
   const daemonRoot = probe.root; // undefined = pre-root-advertising daemon
   if (daemonRoot === SERVE_ROOT) {
-    return (await verifyServed(port, name)) ? { port } : null;
+    return (await verifyServed(port, name, artifactBytes)) ? { port } : null;
   }
   // Different (or unknown) root: drop a compat copy where we believe the
   // daemon looks, then verify. The legacy default is only a guess — an old
   // daemon may have been started with a custom SOMA_HTML_SERVE_ROOT — which
-  // is exactly why the verified GET, not the copy, is the success signal.
+  // is exactly why the verified byte-compare, not the copy, is the success
+  // signal (a stale same-name file answering 200 must not pass).
   const guess = daemonRoot ?? LEGACY_SERVE_ROOT;
   try {
     mkdirSync(guess, { recursive: true });
-    copyFileSync(abs, join(guess, name));
+    writeFileReplacing(guess, name, artifactBytes);
   } catch {
     // fall through to verification, which will fail and reject this daemon
   }
-  if (await verifyServed(port, name)) {
+  if (await verifyServed(port, name, artifactBytes)) {
     return {
       port,
       note: `daemon on port ${port} serves ${daemonRoot ?? `an older root (compat copy placed in ${guess})`}; artifact archived in ${SERVE_ROOT}, which takes over when that daemon restarts`,
@@ -376,7 +432,8 @@ async function publish(file, explicitPort) {
   const migration = migrateLegacyArtifacts();
   for (const e of migration.errors) console.error(`legacy migration failed for ${e}`);
   const name = basename(abs);
-  copyFileSync(abs, join(SERVE_ROOT, name));
+  const artifactBytes = readFileSync(abs);
+  writeFileReplacing(SERVE_ROOT, name, artifactBytes);
 
   let chosen = null;
   const ports = explicitPort ? [explicitPort] : [];
@@ -386,7 +443,7 @@ async function publish(file, explicitPort) {
   for (const port of ports) {
     const probe = await probeHealth(port);
     if (probe.state === 'ours') {
-      chosen = await adoptDaemon(port, probe, abs, name);
+      chosen = await adoptDaemon(port, probe, artifactBytes, name);
       if (chosen) break;
       // Unusable 'ours' daemon (e.g. old daemon on an unknown custom root):
       // with an explicit port we must fail loudly below; when scanning we
@@ -396,7 +453,7 @@ async function publish(file, explicitPort) {
     if (probe.state === 'free') {
       startDaemon(port);
       const started = await waitForOurs(port);
-      if (started && (await verifyServed(port, name))) {
+      if (started && (await verifyServed(port, name, artifactBytes))) {
         chosen = { port };
         break;
       }

--- a/src/local/skills/html/server/serve.mjs
+++ b/src/local/skills/html/server/serve.mjs
@@ -15,33 +15,50 @@
  *      doubles as the permanent artifact archive (see resolution order at
  *      defaultServeRoot below). Never a system temp dir by default: OS temp
  *      cleanup used to wipe every published artifact.
- *   2. Ensures a detached daemon is listening (spawns one if needed —
- *      survives the agent turn; idempotent across sessions).
+ *   2. Ensures a daemon is listening whose link for this artifact actually
+ *      answers 200 — the final URL is VERIFIED over loopback before it is
+ *      printed, never assumed.
  *   3. Prints JSON: { "url", "localUrl", "port", "file" } on stdout
- *      (+ "note" when an older daemon is still serving the legacy root).
+ *      (+ "note" when a pre-durable-root daemon needed a compat copy,
+ *      + "migrated"/"migrationErrors" when a legacy sweep did work).
  *
  * Daemon mode (internal): node serve.mjs --daemon --port <port>
  *   Plain node:http static server, serving the serve root.
- *   GET /__soma-serve-health → "soma-html-serve\nroot=<serve-root>"
- *     (ownership probe; the root line lets a publisher detect a daemon that
- *     is still serving a different — e.g. legacy /tmp — root).
+ *   GET /__soma-serve-health → "soma-html-serve" (+ "\nroot=<serve-root>"
+ *     for loopback callers only — the absolute path is not broadcast to the
+ *     LAN). The root line lets a same-host publisher detect a daemon that is
+ *     serving a different — e.g. legacy /tmp — root.
  *   GET /                    → directory index of the archive, newest first.
+ *
+ * Mixed-version behavior (deliberate, fail-safe):
+ *   - NEW publisher + OLD daemon: the publisher tries a compat copy into the
+ *     daemon's root and only trusts it after a verified 200; otherwise it
+ *     starts its own daemon on the next free port.
+ *   - OLD publisher + NEW daemon: old publishers compare the WHOLE health
+ *     body, so the two-line reply reads as foreign and they self-heal onto
+ *     the next free port with their own daemon. That port drift is accepted
+ *     on purpose: the alternative (keeping the body byte-identical) would
+ *     make old publishers treat a new daemon as their own, copy into a root
+ *     the daemon does not serve, and hand the user a silent 404 link.
  *
  * Archive semantics: artifacts are timestamped by the skill, never
  * auto-pruned here, and migrate forward automatically from the legacy
- * /tmp root when one is found. Reclaiming disk is a human decision.
+ * /tmp root when one is found (regular files only — symlinks are never
+ * followed into the archive). Re-publishing the same filename intentionally
+ * refreshes that artifact in place. Reclaiming disk is a human decision.
  *
  * Exposure policy: binds 0.0.0.0 by default — LAN reachability is the whole
  * point (the user opens the link from another machine). Everything ever
  * published to the serve root is therefore listable and readable by anyone
- * on the LAN; do not publish artifacts containing secrets. Set
+ * on the LAN, indefinitely; do not publish artifacts containing secrets. Set
  * SOMA_HTML_SERVE_BIND=127.0.0.1 to restrict to the host. Symlinks inside
  * the serve root are refused (realpath containment check).
  *
- * Exit codes: 0 published, 1 CLI/input error, 2 could not start/find server.
+ * Exit codes: 0 published+verified, 1 CLI/input error, 2 could not start,
+ * find, or verify a server.
  */
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import http from 'node:http';
 import { homedir, networkInterfaces } from 'node:os';
 import { basename, extname, isAbsolute, join, resolve, sep } from 'node:path';
@@ -49,8 +66,9 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 // Pre-durable-root versions served from here; kept only as a migration
-// source and as the assumed root of daemons started by those versions.
-const LEGACY_SERVE_ROOT = '/tmp/soma-html-serve';
+// source and as the first root guess for daemons started by those versions.
+// Overridable so tests (and unusual setups) never touch the real /tmp dir.
+const LEGACY_SERVE_ROOT = process.env.SOMA_HTML_LEGACY_ROOT || '/tmp/soma-html-serve';
 
 function defaultServeRoot() {
   // Resolution order (first hit wins):
@@ -128,9 +146,9 @@ function lanIp() {
 
 function probeHealth(port, timeoutMs = 700) {
   // Resolves { state: 'ours'|'foreign'|'free', root?: string }.
-  // Ownership is decided by the FIRST line only, so daemons from versions
-  // that answered a bare body (no root line) still probe as ours; their
-  // root is assumed to be the legacy /tmp path.
+  // Ownership is decided by the FIRST line. Daemons from older versions
+  // answer a bare body (no root line) — their root is unknown, not assumed:
+  // publish() treats an undefined root as "guess, then verify".
   return new Promise((resolveProbe) => {
     const req = http.get(
       { host: '127.0.0.1', port, path: HEALTH_PATH, timeout: timeoutMs },
@@ -141,7 +159,7 @@ function probeHealth(port, timeoutMs = 700) {
           const lines = body.trim().split('\n');
           if (lines[0].trim() !== HEALTH_BODY) return resolveProbe({ state: 'foreign' });
           const rootLine = lines.find((l) => l.startsWith('root='));
-          resolveProbe({ state: 'ours', root: rootLine ? rootLine.slice(5).trim() : LEGACY_SERVE_ROOT });
+          resolveProbe({ state: 'ours', root: rootLine ? rootLine.slice(5).trim() : undefined });
         });
       },
     );
@@ -152,6 +170,25 @@ function probeHealth(port, timeoutMs = 700) {
     req.on('error', (err) => {
       resolveProbe({ state: err.code === 'ECONNREFUSED' ? 'free' : 'foreign' });
     });
+  });
+}
+
+function verifyServed(port, name, timeoutMs = 1500) {
+  // The printed link is a deliverable — prove it answers 200 over loopback
+  // before handing it out. Never trust root bookkeeping alone.
+  return new Promise((resolveVerify) => {
+    const req = http.get(
+      { host: '127.0.0.1', port, path: '/' + encodeURIComponent(name), timeout: timeoutMs },
+      (res) => {
+        res.resume();
+        resolveVerify(res.statusCode === 200);
+      },
+    );
+    req.on('timeout', () => {
+      req.destroy();
+      resolveVerify(false);
+    });
+    req.on('error', () => resolveVerify(false));
   });
 }
 
@@ -173,48 +210,34 @@ async function waitForOurs(port, attempts = 30, delayMs = 200) {
   return null;
 }
 
-async function ensureServer() {
-  for (let port = BASE_PORT; port < BASE_PORT + PORT_SCAN_RANGE; port++) {
-    const probe = await probeHealth(port);
-    if (probe.state === 'ours') return { port, root: probe.root };
-    if (probe.state === 'free') {
-      startDaemon(port);
-      const started = await waitForOurs(port);
-      if (started) return { port, root: started.root };
-      // Lost the race or daemon died — try the next port instead of looping here.
-    }
-    // 'foreign': some other process owns this port; never serve through it.
-  }
-  return null;
-}
-
 function migrateLegacyArtifacts() {
-  // Best-effort forward migration: anything still alive in the legacy /tmp
-  // root gets copied into the durable archive (existing names are never
-  // overwritten). Runs at daemon start and at every publish, so surviving
-  // artifacts are rescued before the next OS temp cleanup gets them.
-  if (SERVE_ROOT === LEGACY_SERVE_ROOT) return 0;
-  let migrated = 0;
+  // Forward migration: regular files still alive in the legacy root are
+  // copied into the durable archive (existing names are never overwritten).
+  // Symlinks are skipped — following one would copy arbitrary readable
+  // local files into a LAN-served archive. Failures never block publishing,
+  // but they are counted and surfaced, not swallowed silently.
+  const result = { migrated: 0, errors: [] };
+  if (SERVE_ROOT === LEGACY_SERVE_ROOT) return result;
   try {
-    if (!existsSync(LEGACY_SERVE_ROOT)) return 0;
+    if (!existsSync(LEGACY_SERVE_ROOT)) return result;
     mkdirSync(SERVE_ROOT, { recursive: true });
     for (const name of readdirSync(LEGACY_SERVE_ROOT)) {
       if (name.startsWith('.')) continue;
+      const src = join(LEGACY_SERVE_ROOT, name);
+      const dst = join(SERVE_ROOT, name);
       try {
-        const src = join(LEGACY_SERVE_ROOT, name);
-        const dst = join(SERVE_ROOT, name);
-        if (statSync(src).isFile() && !existsSync(dst)) {
-          copyFileSync(src, dst);
-          migrated++;
-        }
-      } catch {
-        // one unreadable entry must not abort the migration sweep
+        if (!lstatSync(src).isFile()) continue; // lstat: symlinks excluded
+        if (existsSync(dst)) continue;
+        copyFileSync(src, dst);
+        result.migrated++;
+      } catch (err) {
+        result.errors.push(`${src}: ${err.message}`);
       }
     }
-  } catch {
-    // migration is opportunistic — publishing must not fail because of it
+  } catch (err) {
+    result.errors.push(`${LEGACY_SERVE_ROOT}: ${err.message}`);
   }
-  return migrated;
+  return result;
 }
 
 function htmlEscape(s) {
@@ -247,6 +270,11 @@ function directoryIndex() {
   ].join('\n');
 }
 
+function isLoopback(req) {
+  const addr = req.socket?.remoteAddress ?? '';
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
+}
+
 function runDaemon(port) {
   mkdirSync(SERVE_ROOT, { recursive: true });
   migrateLegacyArtifacts();
@@ -257,9 +285,10 @@ function runDaemon(port) {
       const pathname = decodeURIComponent(url.pathname);
       if (pathname === HEALTH_PATH) {
         res.writeHead(200, { 'content-type': 'text/plain' });
-        // Line 1 = ownership token (older publishers compare only this);
-        // line 2 advertises which root this daemon actually serves.
-        res.end(`${HEALTH_BODY}\nroot=${SERVE_ROOT}`);
+        // Line 1 = ownership token. Line 2 advertises the served root — to
+        // loopback callers only, so the absolute path (which can embed a
+        // username) is not broadcast to the LAN.
+        res.end(isLoopback(req) ? `${HEALTH_BODY}\nroot=${SERVE_ROOT}` : HEALTH_BODY);
         return;
       }
       if (pathname === '/' || pathname === '/index.html') {
@@ -306,6 +335,33 @@ function runDaemon(port) {
   server.listen(port, BIND_ADDR);
 }
 
+async function adoptDaemon(port, probe, abs, name) {
+  // Try to make an existing 'ours' daemon serve this artifact, returning
+  // { port, note? } only after a VERIFIED 200 — otherwise null.
+  const daemonRoot = probe.root; // undefined = pre-root-advertising daemon
+  if (daemonRoot === SERVE_ROOT) {
+    return (await verifyServed(port, name)) ? { port } : null;
+  }
+  // Different (or unknown) root: drop a compat copy where we believe the
+  // daemon looks, then verify. The legacy default is only a guess — an old
+  // daemon may have been started with a custom SOMA_HTML_SERVE_ROOT — which
+  // is exactly why the verified GET, not the copy, is the success signal.
+  const guess = daemonRoot ?? LEGACY_SERVE_ROOT;
+  try {
+    mkdirSync(guess, { recursive: true });
+    copyFileSync(abs, join(guess, name));
+  } catch {
+    // fall through to verification, which will fail and reject this daemon
+  }
+  if (await verifyServed(port, name)) {
+    return {
+      port,
+      note: `daemon on port ${port} serves ${daemonRoot ?? `an older root (compat copy placed in ${guess})`}; artifact archived in ${SERVE_ROOT}, which takes over when that daemon restarts`,
+    };
+  }
+  return null;
+}
+
 async function publish(file, explicitPort) {
   if (!file) {
     console.error('--file is required');
@@ -317,61 +373,58 @@ async function publish(file, explicitPort) {
     process.exit(1);
   }
   mkdirSync(SERVE_ROOT, { recursive: true });
-  migrateLegacyArtifacts();
+  const migration = migrateLegacyArtifacts();
+  for (const e of migration.errors) console.error(`legacy migration failed for ${e}`);
   const name = basename(abs);
   copyFileSync(abs, join(SERVE_ROOT, name));
 
-  let port = null;
-  let daemonRoot = null;
-  if (explicitPort) {
-    const probe = await probeHealth(explicitPort);
-    if (probe.state === 'ours') {
-      port = explicitPort;
-      daemonRoot = probe.root;
-    } else if (probe.state === 'free') {
-      startDaemon(explicitPort);
-      const started = await waitForOurs(explicitPort);
-      if (started) {
-        port = explicitPort;
-        daemonRoot = started.root;
-      }
-    }
-  } else {
-    const found = await ensureServer();
-    if (found) {
-      port = found.port;
-      daemonRoot = found.root;
-    }
+  let chosen = null;
+  const ports = explicitPort ? [explicitPort] : [];
+  if (!explicitPort) {
+    for (let p = BASE_PORT; p < BASE_PORT + PORT_SCAN_RANGE; p++) ports.push(p);
   }
-  if (!port) {
-    console.error(`could not start or find a soma-html-serve daemon (base port ${explicitPort ?? BASE_PORT})`);
-    process.exit(2);
+  for (const port of ports) {
+    const probe = await probeHealth(port);
+    if (probe.state === 'ours') {
+      chosen = await adoptDaemon(port, probe, abs, name);
+      if (chosen) break;
+      // Unusable 'ours' daemon (e.g. old daemon on an unknown custom root):
+      // with an explicit port we must fail loudly below; when scanning we
+      // move on and start a fresh daemon on the next free port.
+      continue;
+    }
+    if (probe.state === 'free') {
+      startDaemon(port);
+      const started = await waitForOurs(port);
+      if (started && (await verifyServed(port, name))) {
+        chosen = { port };
+        break;
+      }
+      // Lost the race or daemon died — try the next port instead of looping here.
+    }
+    // 'foreign': some other process owns this port; never serve through it.
   }
 
-  // A daemon from before the durable-root change (or with a different env)
-  // serves a different directory than the one we just archived into. Drop a
-  // copy where that daemon can see it so the printed link works right now;
-  // the durable root takes over when the daemon next restarts.
-  let note;
-  if (daemonRoot && daemonRoot !== SERVE_ROOT) {
-    try {
-      mkdirSync(daemonRoot, { recursive: true });
-      copyFileSync(abs, join(daemonRoot, name));
-      note = `daemon on port ${port} still serves ${daemonRoot} (pre-durable-root daemon); artifact archived in ${SERVE_ROOT} and also copied next to the daemon so the link works now`;
-    } catch {
-      note = `daemon on port ${port} serves ${daemonRoot}, which is not writable; the link may 404 until the daemon restarts with root ${SERVE_ROOT}`;
-    }
+  if (!chosen) {
+    console.error(
+      explicitPort
+        ? `no usable soma-html-serve daemon on port ${explicitPort} (occupied by a foreign process, or serving a root this artifact could not be verified on)`
+        : `could not start or find a soma-html-serve daemon (ports ${BASE_PORT}-${BASE_PORT + PORT_SCAN_RANGE - 1})`,
+    );
+    process.exit(2);
   }
 
   const encoded = encodeURIComponent(name);
   console.log(
     JSON.stringify(
       {
-        url: `http://${lanIp()}:${port}/${encoded}`,
-        localUrl: `http://localhost:${port}/${encoded}`,
-        port,
+        url: `http://${lanIp()}:${chosen.port}/${encoded}`,
+        localUrl: `http://localhost:${chosen.port}/${encoded}`,
+        port: chosen.port,
         file: join(SERVE_ROOT, name),
-        ...(note ? { note } : {}),
+        ...(chosen.note ? { note: chosen.note } : {}),
+        ...(migration.migrated ? { migrated: migration.migrated } : {}),
+        ...(migration.errors.length ? { migrationErrors: migration.errors.length } : {}),
       },
       null,
       2,

--- a/src/local/skills/html/server/serve.mjs
+++ b/src/local/skills/html/server/serve.mjs
@@ -11,15 +11,25 @@
  * Contract (CLI, publish mode — the one agents call):
  *   node serve.mjs --file <abs-path-to-html> [--port 8763]
  *
- *   1. Copies <file> into the serve root (default /tmp/soma-html-serve).
+ *   1. Copies <file> into the serve root — a DURABLE per-user data dir that
+ *      doubles as the permanent artifact archive (see resolution order at
+ *      defaultServeRoot below). Never a system temp dir by default: OS temp
+ *      cleanup used to wipe every published artifact.
  *   2. Ensures a detached daemon is listening (spawns one if needed —
  *      survives the agent turn; idempotent across sessions).
- *   3. Prints JSON: { "url", "localUrl", "port", "file" } on stdout.
+ *   3. Prints JSON: { "url", "localUrl", "port", "file" } on stdout
+ *      (+ "note" when an older daemon is still serving the legacy root).
  *
  * Daemon mode (internal): node serve.mjs --daemon --port <port>
  *   Plain node:http static server, serving the serve root.
- *   GET /__soma-serve-health → "soma-html-serve" (ownership probe).
- *   GET /                    → directory index of published artifacts.
+ *   GET /__soma-serve-health → "soma-html-serve\nroot=<serve-root>"
+ *     (ownership probe; the root line lets a publisher detect a daemon that
+ *     is still serving a different — e.g. legacy /tmp — root).
+ *   GET /                    → directory index of the archive, newest first.
+ *
+ * Archive semantics: artifacts are timestamped by the skill, never
+ * auto-pruned here, and migrate forward automatically from the legacy
+ * /tmp root when one is found. Reclaiming disk is a human decision.
  *
  * Exposure policy: binds 0.0.0.0 by default — LAN reachability is the whole
  * point (the user opens the link from another machine). Everything ever
@@ -33,12 +43,29 @@
 
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import http from 'node:http';
-import { networkInterfaces } from 'node:os';
+import { homedir, networkInterfaces } from 'node:os';
 import { basename, extname, isAbsolute, join, resolve, sep } from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-const SERVE_ROOT = process.env.SOMA_HTML_SERVE_ROOT || '/tmp/soma-html-serve';
+// Pre-durable-root versions served from here; kept only as a migration
+// source and as the assumed root of daemons started by those versions.
+const LEGACY_SERVE_ROOT = '/tmp/soma-html-serve';
+
+function defaultServeRoot() {
+  // Resolution order (first hit wins):
+  //   1. SOMA_HTML_SERVE_ROOT       — explicit override, any path the user wants.
+  //   2. $XDG_DATA_HOME/soma-html-serve
+  //   3. ~/.local/share/soma-html-serve  (works on macOS and Linux alike)
+  //   4. LEGACY_SERVE_ROOT          — only when no home dir is resolvable.
+  if (process.env.SOMA_HTML_SERVE_ROOT) return process.env.SOMA_HTML_SERVE_ROOT;
+  if (process.env.XDG_DATA_HOME) return join(process.env.XDG_DATA_HOME, 'soma-html-serve');
+  const home = homedir();
+  if (home) return join(home, '.local', 'share', 'soma-html-serve');
+  return LEGACY_SERVE_ROOT;
+}
+
+const SERVE_ROOT = defaultServeRoot();
 const BIND_ADDR = process.env.SOMA_HTML_SERVE_BIND || '0.0.0.0';
 const BASE_PORT = Number(process.env.SOMA_HTML_SERVE_PORT || 8763);
 const PORT_SCAN_RANGE = 20;
@@ -100,21 +127,30 @@ function lanIp() {
 }
 
 function probeHealth(port, timeoutMs = 700) {
+  // Resolves { state: 'ours'|'foreign'|'free', root?: string }.
+  // Ownership is decided by the FIRST line only, so daemons from versions
+  // that answered a bare body (no root line) still probe as ours; their
+  // root is assumed to be the legacy /tmp path.
   return new Promise((resolveProbe) => {
     const req = http.get(
       { host: '127.0.0.1', port, path: HEALTH_PATH, timeout: timeoutMs },
       (res) => {
         let body = '';
         res.on('data', (chunk) => (body += chunk));
-        res.on('end', () => resolveProbe(body.trim() === HEALTH_BODY ? 'ours' : 'foreign'));
+        res.on('end', () => {
+          const lines = body.trim().split('\n');
+          if (lines[0].trim() !== HEALTH_BODY) return resolveProbe({ state: 'foreign' });
+          const rootLine = lines.find((l) => l.startsWith('root='));
+          resolveProbe({ state: 'ours', root: rootLine ? rootLine.slice(5).trim() : LEGACY_SERVE_ROOT });
+        });
       },
     );
     req.on('timeout', () => {
       req.destroy();
-      resolveProbe('foreign');
+      resolveProbe({ state: 'foreign' });
     });
     req.on('error', (err) => {
-      resolveProbe(err.code === 'ECONNREFUSED' ? 'free' : 'foreign');
+      resolveProbe({ state: err.code === 'ECONNREFUSED' ? 'free' : 'foreign' });
     });
   });
 }
@@ -130,24 +166,55 @@ function startDaemon(port) {
 
 async function waitForOurs(port, attempts = 30, delayMs = 200) {
   for (let i = 0; i < attempts; i++) {
-    if ((await probeHealth(port)) === 'ours') return true;
+    const probe = await probeHealth(port);
+    if (probe.state === 'ours') return probe;
     await new Promise((r) => setTimeout(r, delayMs));
   }
-  return false;
+  return null;
 }
 
 async function ensureServer() {
   for (let port = BASE_PORT; port < BASE_PORT + PORT_SCAN_RANGE; port++) {
-    const state = await probeHealth(port);
-    if (state === 'ours') return port;
-    if (state === 'free') {
+    const probe = await probeHealth(port);
+    if (probe.state === 'ours') return { port, root: probe.root };
+    if (probe.state === 'free') {
       startDaemon(port);
-      if (await waitForOurs(port)) return port;
+      const started = await waitForOurs(port);
+      if (started) return { port, root: started.root };
       // Lost the race or daemon died — try the next port instead of looping here.
     }
     // 'foreign': some other process owns this port; never serve through it.
   }
   return null;
+}
+
+function migrateLegacyArtifacts() {
+  // Best-effort forward migration: anything still alive in the legacy /tmp
+  // root gets copied into the durable archive (existing names are never
+  // overwritten). Runs at daemon start and at every publish, so surviving
+  // artifacts are rescued before the next OS temp cleanup gets them.
+  if (SERVE_ROOT === LEGACY_SERVE_ROOT) return 0;
+  let migrated = 0;
+  try {
+    if (!existsSync(LEGACY_SERVE_ROOT)) return 0;
+    mkdirSync(SERVE_ROOT, { recursive: true });
+    for (const name of readdirSync(LEGACY_SERVE_ROOT)) {
+      if (name.startsWith('.')) continue;
+      try {
+        const src = join(LEGACY_SERVE_ROOT, name);
+        const dst = join(SERVE_ROOT, name);
+        if (statSync(src).isFile() && !existsSync(dst)) {
+          copyFileSync(src, dst);
+          migrated++;
+        }
+      } catch {
+        // one unreadable entry must not abort the migration sweep
+      }
+    }
+  } catch {
+    // migration is opportunistic — publishing must not fail because of it
+  }
+  return migrated;
 }
 
 function htmlEscape(s) {
@@ -182,6 +249,7 @@ function directoryIndex() {
 
 function runDaemon(port) {
   mkdirSync(SERVE_ROOT, { recursive: true });
+  migrateLegacyArtifacts();
   const rootReal = realpathSync(SERVE_ROOT);
   const server = http.createServer((req, res) => {
     try {
@@ -189,7 +257,9 @@ function runDaemon(port) {
       const pathname = decodeURIComponent(url.pathname);
       if (pathname === HEALTH_PATH) {
         res.writeHead(200, { 'content-type': 'text/plain' });
-        res.end(HEALTH_BODY);
+        // Line 1 = ownership token (older publishers compare only this);
+        // line 2 advertises which root this daemon actually serves.
+        res.end(`${HEALTH_BODY}\nroot=${SERVE_ROOT}`);
         return;
       }
       if (pathname === '/' || pathname === '/index.html') {
@@ -247,23 +317,50 @@ async function publish(file, explicitPort) {
     process.exit(1);
   }
   mkdirSync(SERVE_ROOT, { recursive: true });
+  migrateLegacyArtifacts();
   const name = basename(abs);
   copyFileSync(abs, join(SERVE_ROOT, name));
 
-  let port;
+  let port = null;
+  let daemonRoot = null;
   if (explicitPort) {
-    const state = await probeHealth(explicitPort);
-    if (state === 'ours') port = explicitPort;
-    else if (state === 'free') {
+    const probe = await probeHealth(explicitPort);
+    if (probe.state === 'ours') {
+      port = explicitPort;
+      daemonRoot = probe.root;
+    } else if (probe.state === 'free') {
       startDaemon(explicitPort);
-      port = (await waitForOurs(explicitPort)) ? explicitPort : null;
-    } else port = null;
+      const started = await waitForOurs(explicitPort);
+      if (started) {
+        port = explicitPort;
+        daemonRoot = started.root;
+      }
+    }
   } else {
-    port = await ensureServer();
+    const found = await ensureServer();
+    if (found) {
+      port = found.port;
+      daemonRoot = found.root;
+    }
   }
   if (!port) {
     console.error(`could not start or find a soma-html-serve daemon (base port ${explicitPort ?? BASE_PORT})`);
     process.exit(2);
+  }
+
+  // A daemon from before the durable-root change (or with a different env)
+  // serves a different directory than the one we just archived into. Drop a
+  // copy where that daemon can see it so the printed link works right now;
+  // the durable root takes over when the daemon next restarts.
+  let note;
+  if (daemonRoot && daemonRoot !== SERVE_ROOT) {
+    try {
+      mkdirSync(daemonRoot, { recursive: true });
+      copyFileSync(abs, join(daemonRoot, name));
+      note = `daemon on port ${port} still serves ${daemonRoot} (pre-durable-root daemon); artifact archived in ${SERVE_ROOT} and also copied next to the daemon so the link works now`;
+    } catch {
+      note = `daemon on port ${port} serves ${daemonRoot}, which is not writable; the link may 404 until the daemon restarts with root ${SERVE_ROOT}`;
+    }
   }
 
   const encoded = encodeURIComponent(name);
@@ -274,6 +371,7 @@ async function publish(file, explicitPort) {
         localUrl: `http://localhost:${port}/${encoded}`,
         port,
         file: join(SERVE_ROOT, name),
+        ...(note ? { note } : {}),
       },
       null,
       2,

--- a/src/local/skills/html/server/serve.mjs
+++ b/src/local/skills/html/server/serve.mjs
@@ -62,6 +62,7 @@ import {
   closeSync,
   constants as FS,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   openSync,
@@ -193,23 +194,46 @@ function verifyServed(port, name, expectedBytes, timeoutMs = 2000) {
   // enough: an old daemon on an unknown root can happily serve a stale file
   // with the same name.
   return new Promise((resolveVerify) => {
+    let done = false;
+    const finish = (ok) => {
+      if (done) return;
+      done = true;
+      clearTimeout(deadline);
+      resolveVerify(ok);
+    };
     const req = http.get(
       { host: '127.0.0.1', port, path: `/${encodeURIComponent(name)}`, timeout: timeoutMs },
       (res) => {
         if (res.statusCode !== 200) {
           res.resume();
-          return resolveVerify(false);
+          return finish(false);
         }
         const chunks = [];
-        res.on('data', (c) => chunks.push(c));
-        res.on('end', () => resolveVerify(Buffer.concat(chunks).equals(expectedBytes)));
+        let received = 0;
+        res.on('data', (c) => {
+          received += c.length;
+          if (received > expectedBytes.length) {
+            // Longer than the artifact can never match — stop reading so a
+            // misbehaving endpoint can't grow our memory or stall us.
+            req.destroy();
+            return finish(false);
+          }
+          chunks.push(c);
+        });
+        res.on('end', () => finish(Buffer.concat(chunks).equals(expectedBytes)));
       },
     );
+    // Overall deadline: Node's request timeout is socket-inactivity based; a
+    // slowly dripping endpoint would otherwise hold the publisher forever.
+    const deadline = setTimeout(() => {
+      req.destroy();
+      finish(false);
+    }, timeoutMs * 2);
     req.on('timeout', () => {
       req.destroy();
-      resolveVerify(false);
+      finish(false);
     });
-    req.on('error', () => resolveVerify(false));
+    req.on('error', () => finish(false));
   });
 }
 
@@ -221,6 +245,39 @@ function readFileNoFollow(path) {
     return readFileSync(fd);
   } finally {
     closeSync(fd);
+  }
+}
+
+function ownedRealDir(dir) {
+  // Trust gate for directories in world-writable namespaces (/tmp): the
+  // path must be a REAL directory (a symlinked root would make readdir and
+  // every write traverse an attacker-chosen parent — O_NOFOLLOW only guards
+  // the final path component) and, where the platform exposes UIDs, owned
+  // by the current user.
+  try {
+    const st = lstatSync(dir);
+    if (!st.isDirectory()) return false;
+    return typeof process.getuid !== 'function' || st.uid === process.getuid();
+  } catch {
+    return false;
+  }
+}
+
+function installFileIfAbsent(dstDir, name, bytes) {
+  // Atomic create-if-absent: link() fails with EEXIST when the destination
+  // exists (and does not follow a symlink sitting there), so a concurrent
+  // publisher's fresh artifact can never be replaced by stale legacy bytes —
+  // unlike an existsSync check followed by a separate rename.
+  const tmp = join(dstDir, `.tmp-migrate-${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+  writeFileSync(tmp, bytes, { flag: 'wx' });
+  try {
+    linkSync(tmp, join(dstDir, name));
+    return true;
+  } catch (err) {
+    if (err.code === 'EEXIST') return false; // keep the existing (newer) file
+    throw err;
+  } finally {
+    rmSync(tmp, { force: true });
   }
 }
 
@@ -270,18 +327,22 @@ function migrateLegacyArtifacts() {
   if (SERVE_ROOT === LEGACY_SERVE_ROOT) return result;
   try {
     if (!existsSync(LEGACY_SERVE_ROOT)) return result;
+    if (!ownedRealDir(LEGACY_SERVE_ROOT)) {
+      // A symlinked or foreign-owned legacy root in world-writable /tmp is
+      // an attack surface, not a migration source — refuse it, loudly.
+      result.errors.push(`${LEGACY_SERVE_ROOT}: not a real directory owned by this user — sweep refused`);
+      return result;
+    }
     mkdirSync(SERVE_ROOT, { recursive: true });
     for (const name of readdirSync(LEGACY_SERVE_ROOT)) {
       if (name.startsWith('.')) continue;
       const src = join(LEGACY_SERVE_ROOT, name);
-      const dst = join(SERVE_ROOT, name);
       try {
         if (!lstatSync(src).isFile()) continue; // lstat: symlinks excluded
-        if (existsSync(dst)) continue;
-        // O_NOFOLLOW read + temp-file/rename write: neither side of the copy
-        // can be redirected through a symlink.
-        writeFileReplacing(SERVE_ROOT, name, readFileNoFollow(src));
-        result.migrated++;
+        // O_NOFOLLOW read + atomic link-based create-if-absent write: the
+        // read can't be redirected through a symlink, and an existing (or
+        // concurrently published, fresher) destination is never replaced.
+        if (installFileIfAbsent(SERVE_ROOT, name, readFileNoFollow(src))) result.migrated++;
       } catch (err) {
         result.errors.push(`${src}: ${err.message}`);
       }
@@ -404,8 +465,10 @@ async function adoptDaemon(port, probe, artifactBytes, name) {
   // signal (a stale same-name file answering 200 must not pass).
   const guess = daemonRoot ?? LEGACY_SERVE_ROOT;
   try {
-    mkdirSync(guess, { recursive: true });
-    writeFileReplacing(guess, name, artifactBytes);
+    if (!existsSync(guess)) mkdirSync(guess, { recursive: true });
+    // Same trust gate as migration: never write through a symlinked or
+    // foreign-owned directory in a world-writable namespace.
+    if (ownedRealDir(guess)) writeFileReplacing(guess, name, artifactBytes);
   } catch {
     // fall through to verification, which will fail and reject this daemon
   }


### PR DESCRIPTION
## Why

The html skill's serve root defaulted to `/tmp/soma-html-serve`. OS temp cleanup wiped every published artifact — observed twice (2026-07-27, 2026-08-03); a report set survived only because session transcripts could be replayed. The serve root is where deliverable links live, so it must be durable and is now explicitly the **artifact archive**.

## What

- `serve.mjs`: default root now resolves `SOMA_HTML_SERVE_ROOT` → `$XDG_DATA_HOME/soma-html-serve` → `~/.local/share/soma-html-serve`; `/tmp/soma-html-serve` is legacy-only (migration source / no-home fallback).
- Health endpoint advertises the daemon's root (`root=` line 2; line-1 ownership token unchanged for old publishers). Publishers detect pre-durable-root daemons, always archive durably, and drop a compat copy next to the old daemon (`note` field in JSON) so printed links work immediately.
- Legacy artifacts migrate forward automatically at publish/daemon start (non-destructive).
- `SKILL.md`: Step 7 rewritten as serve-root-as-archive (resolution order, retention policy, mixed-version behavior — environment-generic wording); Step 3.4 makes the `ui-ux` design driver **unconditional by default** (runs on every invocation, no design keyword needed); new anti-pattern against temp-dir roots / pruning the archive.
- Tests pin all of the above. Skill 0.3.0 → 0.4.0, plugin 1.2.0 → 1.3.0.

## Receipts

- Gate: `vitest run src/local/skills/html` → **25/25 green** (2 new contract blocks).
- Live: legacy-daemon coexistence publish (JSON `note` + link 200 via old daemon), fresh daemon on a clean port (health advertises durable root, 200), legacy-file forward migration observed, running old daemon untouched.
- Known mixed-version cost: an OLD publisher probing a NEW daemon reads the 2-line health body as foreign and starts its own daemon on the next port — functional, self-healing, accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)