### PR TITLE
feat(auth): per-user llmux tenant keys — meter each Slack user as their own llmux tenant

### DIFF
--- a/src/auth/__tests__/auth-runtime.test.ts
+++ b/src/auth/__tests__/auth-runtime.test.ts
@@ -12,11 +12,13 @@ vi.mock('../../config', () => ({
       llmux: { baseUrl: 'http://localhost:3456', apiKey: 'llmux-local' },
     },
   },
+  LLMUX_PLACEHOLDER_API_KEY: 'llmux-local',
 }));
 
 import {
   getAuthMode,
   getAuthRuntimeSnapshot,
+  getLlmuxAdminKey,
   getLlmuxSettings,
   initAuthRuntimeDefault,
   resetAuthRuntimeForTests,
@@ -88,6 +90,50 @@ describe('auth-runtime (#llmux runtime switch)', () => {
     snap.llmux.baseUrl = 'http://mutated';
     expect(getAuthMode()).toBe('ccp');
     expect(getLlmuxSettings().baseUrl).toBe('http://localhost:3456');
+  });
+
+  describe('getLlmuxAdminKey (control-plane credential)', () => {
+    let originalLlmuxConfig: string | undefined;
+    let originalXdg: string | undefined;
+
+    beforeEach(() => {
+      originalLlmuxConfig = process.env.LLMUX_CONFIG;
+      originalXdg = process.env.XDG_CONFIG_HOME;
+      delete process.env.LLMUX_CONFIG;
+      // Point the second candidate (`$XDG_CONFIG_HOME/llmux.json`) at an empty
+      // temp dir so a real llmux install on the host cannot leak in.
+      process.env.XDG_CONFIG_HOME = dir;
+    });
+
+    afterEach(() => {
+      if (originalLlmuxConfig === undefined) delete process.env.LLMUX_CONFIG;
+      else process.env.LLMUX_CONFIG = originalLlmuxConfig;
+      if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = originalXdg;
+    });
+
+    it('returns an operator-set key as-is — no llmux config file is consulted', () => {
+      // Pointing LLMUX_CONFIG at a readable file proves it is NOT read: the
+      // operator key wins outright.
+      const llmuxConfig = path.join(dir, 'llmux.json');
+      fs.writeFileSync(llmuxConfig, JSON.stringify({ proxy: { api_key: 'from-file' } }));
+      process.env.LLMUX_CONFIG = llmuxConfig;
+      setLlmuxSettings({ apiKey: 'operator-key' });
+      expect(getLlmuxAdminKey()).toBe('operator-key');
+    });
+
+    it('falls back to the co-located llmux config key when the operator left the placeholder', () => {
+      const llmuxConfig = path.join(dir, 'llmux.json');
+      fs.writeFileSync(llmuxConfig, JSON.stringify({ proxy: { api_key: 'admin-from-llmux-config' } }));
+      process.env.LLMUX_CONFIG = llmuxConfig;
+      expect(getLlmuxSettings().apiKey).toBe('llmux-local'); // placeholder
+      expect(getLlmuxAdminKey()).toBe('admin-from-llmux-config');
+    });
+
+    it('keeps the placeholder when no llmux config file yields a key', () => {
+      process.env.LLMUX_CONFIG = path.join(dir, 'does-not-exist.json');
+      expect(getLlmuxAdminKey()).toBe('llmux-local');
+    });
   });
 
   describe('initAuthRuntimeDefault (boot probe)', () => {

--- a/src/auth/__tests__/auth-runtime.test.ts
+++ b/src/auth/__tests__/auth-runtime.test.ts
@@ -134,6 +134,28 @@ describe('auth-runtime (#llmux runtime switch)', () => {
       process.env.LLMUX_CONFIG = path.join(dir, 'does-not-exist.json');
       expect(getLlmuxAdminKey()).toBe('llmux-local');
     });
+
+    it('never hands the LOCAL llmux config key to a remote baseUrl', () => {
+      // The config file describes the daemon on THIS host, and callers send
+      // whatever this returns to whatever baseUrl points at — so a remote
+      // target must be configured with its own key instead.
+      const llmuxConfig = path.join(dir, 'llmux.json');
+      fs.writeFileSync(llmuxConfig, JSON.stringify({ proxy: { api_key: 'local-admin-secret' } }));
+      process.env.LLMUX_CONFIG = llmuxConfig;
+
+      setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456' });
+      expect(getLlmuxAdminKey()).toBe('llmux-local');
+
+      // Loopback aliases do unlock it.
+      for (const baseUrl of ['http://127.0.0.1:3456', 'http://127.5.5.5:3456', 'http://[::1]:3456']) {
+        setLlmuxSettings({ baseUrl });
+        expect(getLlmuxAdminKey()).toBe('local-admin-secret');
+      }
+
+      // An unparseable baseUrl is NOT loopback.
+      setLlmuxSettings({ baseUrl: 'not a url' });
+      expect(getLlmuxAdminKey()).toBe('llmux-local');
+    });
   });
 
   describe('initAuthRuntimeDefault (boot probe)', () => {

--- a/src/auth/__tests__/auth-runtime.test.ts
+++ b/src/auth/__tests__/auth-runtime.test.ts
@@ -156,6 +156,24 @@ describe('auth-runtime (#llmux runtime switch)', () => {
       setLlmuxSettings({ baseUrl: 'not a url' });
       expect(getLlmuxAdminKey()).toBe('llmux-local');
     });
+
+    it('gates on the REQUEST destination, not the persisted setting', () => {
+      // llmux-client takes a per-request baseUrl override (the Settings modal
+      // probes a CANDIDATE url), so a loopback setting must not unlock the
+      // local secret for a request that actually leaves this host.
+      const llmuxConfig = path.join(dir, 'llmux.json');
+      fs.writeFileSync(llmuxConfig, JSON.stringify({ proxy: { api_key: 'local-admin-secret' } }));
+      process.env.LLMUX_CONFIG = llmuxConfig;
+
+      setLlmuxSettings({ baseUrl: 'http://localhost:3456' });
+      expect(getLlmuxAdminKey('http://10.0.0.5:3456')).toBe('llmux-local');
+      expect(getLlmuxAdminKey()).toBe('local-admin-secret');
+
+      // Converse: a remote live setting still allows an explicit loopback target.
+      setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456' });
+      expect(getLlmuxAdminKey('http://127.0.0.1:3456')).toBe('local-admin-secret');
+      expect(getLlmuxAdminKey()).toBe('llmux-local');
+    });
   });
 
   describe('initAuthRuntimeDefault (boot probe)', () => {

--- a/src/auth/__tests__/llmux-client.test.ts
+++ b/src/auth/__tests__/llmux-client.test.ts
@@ -2,10 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Control-plane calls now authenticate with the ADMIN key (llmux requires one
 // even on loopback since it went multi-tenant), so the client reads
-// `getLlmuxAdminKey()` rather than the data-plane `apiKey`.
+// `getLlmuxAdminKey()` rather than the data-plane `apiKey`. The real resolver
+// is destination-aware; this double stands in for "loopback target → local
+// admin key, off-host target → placeholder only".
+const { adminKeyMock } = vi.hoisted(() => ({
+  adminKeyMock: vi.fn((target?: string) => {
+    const loopback = target === undefined || target.includes('localhost') || target.includes('127.0.0.1');
+    return loopback ? 'admin-key' : 'llmux-local';
+  }),
+}));
+
 vi.mock('../auth-runtime', () => ({
   getLlmuxSettings: () => ({ baseUrl: 'http://localhost:3456', apiKey: 'llmux-local' }),
-  getLlmuxAdminKey: () => 'admin-key',
+  getLlmuxAdminKey: adminKeyMock,
 }));
 
 import {
@@ -76,6 +85,21 @@ describe('llmux-client', () => {
     fetchMock.mockResolvedValue(okResponse(STATUS_DOC));
     await fetchLlmuxStatus({ baseUrl: 'http://10.1.1.1:9999/' });
     expect(fetchMock.mock.calls[0][0]).toBe('http://10.1.1.1:9999/llmux/status');
+  });
+
+  it('resolves the admin credential against the OVERRIDE target, not the live setting', async () => {
+    // Live setting is loopback here; probing a candidate on another host must
+    // not carry this machine's llmux admin key off-box.
+    adminKeyMock.mockClear();
+    // Fresh Response per call — a Response body is single-read.
+    fetchMock.mockImplementation(async () => okResponse(STATUS_DOC));
+    await fetchLlmuxStatus({ baseUrl: 'http://10.1.1.1:9999/' });
+    expect(adminKeyMock).toHaveBeenCalledWith('http://10.1.1.1:9999');
+    expect(fetchMock.mock.calls[0][1].headers['x-api-key']).toBe('llmux-local');
+
+    await fetchLlmuxStatus();
+    expect(adminKeyMock).toHaveBeenLastCalledWith('http://localhost:3456');
+    expect(fetchMock.mock.calls[1][1].headers['x-api-key']).toBe('admin-key');
   });
 
   it('switchLlmuxAccount POSTs the account body and surfaces 409 refusals', async () => {

--- a/src/auth/__tests__/llmux-client.test.ts
+++ b/src/auth/__tests__/llmux-client.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Control-plane calls now authenticate with the ADMIN key (llmux requires one
+// even on loopback since it went multi-tenant), so the client reads
+// `getLlmuxAdminKey()` rather than the data-plane `apiKey`.
 vi.mock('../auth-runtime', () => ({
-  getLlmuxSettings: () => ({ baseUrl: 'http://localhost:3456', apiKey: 'proxy-key' }),
+  getLlmuxSettings: () => ({ baseUrl: 'http://localhost:3456', apiKey: 'llmux-local' }),
+  getLlmuxAdminKey: () => 'admin-key',
 }));
 
 import {
@@ -53,14 +57,14 @@ describe('llmux-client', () => {
     vi.unstubAllGlobals();
   });
 
-  it('fetchLlmuxStatus GETs /llmux/status with the x-api-key header', async () => {
+  it('fetchLlmuxStatus GETs /llmux/status with the admin x-api-key header', async () => {
     fetchMock.mockResolvedValue(okResponse(STATUS_DOC));
     const status = await fetchLlmuxStatus();
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:3456/llmux/status',
       expect.objectContaining({
         method: 'GET',
-        headers: expect.objectContaining({ 'x-api-key': 'proxy-key' }),
+        headers: expect.objectContaining({ 'x-api-key': 'admin-key' }),
       }),
     );
     expect(status.current).toBe('claude:me@example.com');

--- a/src/auth/__tests__/llmux-tenant-keys.test.ts
+++ b/src/auth/__tests__/llmux-tenant-keys.test.ts
@@ -39,6 +39,10 @@ function newKeyDoc(overrides?: Record<string, unknown>) {
   };
 }
 
+const KEYS_URL = 'http://localhost:3456/llmux/keys';
+const NEW_URL = 'http://localhost:3456/llmux/keys/new';
+const ROTATE_URL = 'http://localhost:3456/llmux/keys/rotate';
+
 describe('llmux tenant keys (per-user metering)', () => {
   let dir: string;
   let storePath: string;
@@ -63,84 +67,136 @@ describe('llmux tenant keys (per-user metering)', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  /** llmux with no keys at all: list is empty, `keys/new` succeeds. */
+  function mockEmptyDaemon(doc: Record<string, unknown> = newKeyDoc()) {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('/llmux/keys')) return okResponse({ keys: [] });
+      return okResponse(doc);
+    });
+  }
+
+  const urlsOf = () => fetchMock.mock.calls.map((c) => c[0]);
+
   it('issues a key on first use, persists it, and serves later calls from the store', async () => {
-    fetchMock.mockImplementation(async () => okResponse(newKeyDoc()));
+    mockEmptyDaemon();
 
     const secret = await ensureTenantKey('U1', { name: 'Zhuge', email: 'z@example.com' });
     expect(secret).toBe('lmk-abcdef-secret');
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe('http://localhost:3456/llmux/keys/new');
+    // Reclaim lookup precedes creation (see the display-name cases below).
+    expect(urlsOf()).toEqual([KEYS_URL, NEW_URL]);
+    const init = fetchMock.mock.calls[1][1];
     expect(init.method).toBe('POST');
     expect(init.headers['x-api-key']).toBe('admin-key');
-    // The name embeds the Slack id, which is what makes it unique per user.
+    // The name embeds the Slack id, which is what makes the key re-identifiable.
     expect(JSON.parse(init.body)).toEqual({ name: 'Zhuge (U1)', email: 'z@example.com', kind: 'default' });
 
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
     expect(persisted.version).toBe(1);
-    expect(persisted.tenants.U1).toMatchObject({ id: 'k-1', secret: 'lmk-abcdef-secret', keyPrefix: 'lmk-abc' });
+    expect(persisted.tenants.U1).toMatchObject({
+      id: 'k-1',
+      secret: 'lmk-abcdef-secret',
+      keyPrefix: 'lmk-abc',
+      baseUrl: 'http://localhost:3456',
+    });
+    // The file holds plaintext secrets — owner-only.
+    expect(fs.statSync(storePath).mode & 0o777).toBe(0o600);
 
     // Second call is a pure store hit — no further llmux traffic.
     await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('falls back to the Slack id when no display name is known', async () => {
-    fetchMock.mockImplementation(async () => okResponse(newKeyDoc({ name: 'U9' })));
+    mockEmptyDaemon(newKeyDoc({ name: 'U9' }));
     await ensureTenantKey('U9');
-    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ name: 'U9', kind: 'default' });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ name: 'U9', kind: 'default' });
   });
 
-  it('self-heals a 409 (name taken) by rotating the existing key', async () => {
+  // ===== reclaim is keyed on the immutable Slack id, not the display name =====
+
+  it('rotates an existing key named by the bare Slack id instead of creating a second one', async () => {
     fetchMock.mockImplementation(async (url: string) => {
-      if (url.endsWith('/llmux/keys/new')) {
-        return okResponse({ type: 'error', error: { message: 'name already in use' } }, 409);
+      if (url.endsWith('/llmux/keys')) {
+        return okResponse({ keys: [{ id: 'k-live', name: 'U1', key_prefix: 'lmk-live', revoked_at_ms: null }] });
       }
+      return okResponse({ ok: true, key: { id: 'k-live', key_prefix: 'lmk-new', key: 'lmk-rotated-secret' } });
+    });
+
+    // The user now HAS a display name, so keyName() would produce a different
+    // name than the stored key — creating would silently split their metering.
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-rotated-secret');
+    expect(urlsOf()).toEqual([KEYS_URL, ROTATE_URL]);
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ id: 'k-live' });
+
+    const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    // Name is llmux's (there is no rename); the id is preserved.
+    expect(persisted.tenants.U1).toMatchObject({ id: 'k-live', name: 'U1', secret: 'lmk-rotated-secret' });
+  });
+
+  it('rotates an existing key whose display name is stale, ignoring revoked and foreign entries', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
       if (url.endsWith('/llmux/keys')) {
         return okResponse({
           keys: [
-            { id: 'k-old', name: 'Zhuge (U1)', key_prefix: 'lmk-old', revoked_at_ms: 1_700_000_000_000 },
-            { id: 'k-live', name: 'Zhuge (U1)', key_prefix: 'lmk-live', revoked_at_ms: null },
-            { id: 'k-other', name: 'Someone (U2)', key_prefix: 'lmk-x', revoked_at_ms: null },
+            { id: 'k-old', name: 'Old Name (U1)', revoked_at_ms: 1_700_000_000_000 },
+            { id: 'k-live', name: 'Old Name (U1)', key_prefix: 'lmk-live', revoked_at_ms: null },
+            { id: 'k-other', name: 'Someone (U2)', revoked_at_ms: null },
           ],
         });
       }
       return okResponse({ ok: true, key: { id: 'k-live', key_prefix: 'lmk-new', key: 'lmk-rotated-secret' } });
     });
 
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-rotated-secret');
-    expect(fetchMock.mock.calls.map((c) => c[0])).toEqual([
-      'http://localhost:3456/llmux/keys/new',
-      'http://localhost:3456/llmux/keys',
-      'http://localhost:3456/llmux/keys/rotate',
-    ]);
-    // Rotation targets the non-revoked key with OUR exact name.
-    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({ id: 'k-live' });
-
+    await expect(ensureTenantKey('U1', { name: 'New Name' })).resolves.toBe('lmk-rotated-secret');
+    expect(urlsOf()).toEqual([KEYS_URL, ROTATE_URL]);
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ id: 'k-live' });
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
-    expect(persisted.tenants.U1).toMatchObject({ id: 'k-live', secret: 'lmk-rotated-secret' });
     expect(persisted.tenants.U1.rotatedAtMs).toBeGreaterThan(0);
+  });
+
+  it('self-heals a 409 raced after an empty listing', async () => {
+    let listCalls = 0;
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('/llmux/keys')) {
+        listCalls += 1;
+        // First listing sees nothing; by the time we create, a key exists.
+        return okResponse({
+          keys: listCalls === 1 ? [] : [{ id: 'k-live', name: 'Zhuge (U1)', revoked_at_ms: null }],
+        });
+      }
+      if (url.endsWith('/llmux/keys/new')) {
+        return okResponse({ type: 'error', error: { message: 'name already in use' } }, 409);
+      }
+      return okResponse({ ok: true, key: { id: 'k-live', key_prefix: 'lmk-new', key: 'lmk-rotated-secret' } });
+    });
+
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-rotated-secret');
+    expect(urlsOf()).toEqual([KEYS_URL, NEW_URL, KEYS_URL, ROTATE_URL]);
   });
 
   it('treats a 409 with no matching live key as a failure (shared-key fallback)', async () => {
     fetchMock.mockImplementation(async (url: string) => {
-      if (url.endsWith('/llmux/keys/new')) return okResponse({ ok: false }, 409);
-      return okResponse({ keys: [{ id: 'k-old', name: 'Zhuge (U1)', revoked_at_ms: 1_700_000_000_000 }] });
+      if (url.endsWith('/llmux/keys')) {
+        return okResponse({ keys: [{ id: 'k-old', name: 'Zhuge (U1)', revoked_at_ms: 1_700_000_000_000 }] });
+      }
+      return okResponse({ ok: false }, 409);
     });
     await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
   });
+
+  // ===== failure handling =====
 
   it('returns null on a non-2xx and negative-caches the failure', async () => {
     fetchMock.mockImplementation(async () =>
       okResponse({ type: 'error', error: { message: 'admin credential required' } }, 403),
     );
     await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const callsAfterFirst = fetchMock.mock.calls.length;
     // Immediate retry must NOT hit llmux again — one broken llmux would
-    // otherwise add a failing request to every dispatch.
+    // otherwise add failing requests to every dispatch.
     await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterFirst);
   });
 
   it('returns null without any llmux call in ccp mode', async () => {
@@ -149,36 +205,60 @@ describe('llmux tenant keys (per-user metering)', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('reloads persisted keys after a restart — no re-issue', async () => {
-    fetchMock.mockImplementation(async () => okResponse(newKeyDoc()));
-    await ensureTenantKey('U1', { name: 'Zhuge' });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    // Fresh module state (simulated restart) against the same store file.
-    resetLlmuxTenantKeysForTests(storePath);
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('issues at most one key for concurrent dispatches of the same user', async () => {
-    // Hold the issuance open so the second call necessarily overlaps the first.
-    let resolveIssue!: (res: Response) => void;
-    const gate = new Promise<Response>((resolve) => {
-      resolveIssue = resolve;
-    });
-    fetchMock.mockImplementation(() => gate);
-
-    const calls = [ensureTenantKey('U1', { name: 'Zhuge' }), ensureTenantKey('U1', { name: 'Zhuge' })];
-    resolveIssue(okResponse(newKeyDoc()));
-
-    expect(await Promise.all(calls)).toEqual(['lmk-abcdef-secret', 'lmk-abcdef-secret']);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
   it('never throws when llmux is unreachable', async () => {
     fetchMock.mockImplementation(async () => {
       throw new Error('ECONNREFUSED');
     });
     await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+  });
+
+  // ===== store reuse is bound to the issuing daemon =====
+
+  it('reloads persisted keys after a restart — no re-issue', async () => {
+    mockEmptyDaemon();
+    await ensureTenantKey('U1', { name: 'Zhuge' });
+    const callsAfterIssue = fetchMock.mock.calls.length;
+
+    // Fresh module state (simulated restart) against the same store file.
+    resetLlmuxTenantKeysForTests(storePath);
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterIssue);
+  });
+
+  it('re-issues when the daemon changed — a key from another llmux is not reused', async () => {
+    mockEmptyDaemon();
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    fetchMock.mockClear();
+
+    // Operator re-points soma-work at a different llmux. The stored secret is
+    // meaningless there (it would 401 without ever falling back), so a fresh
+    // key must be issued against the new daemon.
+    setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456' });
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('/llmux/keys')) return okResponse({ keys: [] });
+      return okResponse(newKeyDoc({ id: 'k-remote', key: 'lmk-remote-secret', key_prefix: 'lmk-rem' }));
+    });
+
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-remote-secret');
+    expect(urlsOf()).toEqual(['http://10.0.0.5:3456/llmux/keys', 'http://10.0.0.5:3456/llmux/keys/new']);
+    const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    expect(persisted.tenants.U1).toMatchObject({ id: 'k-remote', baseUrl: 'http://10.0.0.5:3456' });
+  });
+
+  it('issues at most one key for concurrent dispatches of the same user', async () => {
+    // Hold the creation open so the second call necessarily overlaps the first.
+    let resolveIssue!: (res: Response) => void;
+    const gate = new Promise<Response>((resolve) => {
+      resolveIssue = resolve;
+    });
+    fetchMock.mockImplementation((url: string) =>
+      url.endsWith('/llmux/keys') ? Promise.resolve(okResponse({ keys: [] })) : gate,
+    );
+
+    const calls = [ensureTenantKey('U1', { name: 'Zhuge' }), ensureTenantKey('U1', { name: 'Zhuge' })];
+    resolveIssue(okResponse(newKeyDoc()));
+
+    expect(await Promise.all(calls)).toEqual(['lmk-abcdef-secret', 'lmk-abcdef-secret']);
+    expect(urlsOf().filter((url) => url === NEW_URL)).toHaveLength(1);
   });
 });

--- a/src/auth/__tests__/llmux-tenant-keys.test.ts
+++ b/src/auth/__tests__/llmux-tenant-keys.test.ts
@@ -96,8 +96,9 @@ describe('llmux tenant keys (per-user metering)', () => {
     expect(JSON.parse(init.body)).toEqual({ name: 'Zhuge (U1)', email: 'z@example.com', kind: 'default' });
 
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
-    expect(persisted.version).toBe(1);
-    expect(persisted.tenants.U1).toMatchObject({
+    expect(persisted.version).toBe(2);
+    // Slot is (user, daemon).
+    expect(persisted.tenants.U1[LOCAL]).toMatchObject({
       id: 'k-1',
       secret: 'lmk-abcdef-secret',
       keyPrefix: 'lmk-abc',
@@ -141,7 +142,7 @@ describe('llmux tenant keys (per-user metering)', () => {
 
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
     // Name is llmux's (there is no rename); the id is preserved.
-    expect(persisted.tenants.U1).toMatchObject({ id: 'k-live', name: 'U1', secret: 'lmk-rotated-secret' });
+    expect(persisted.tenants.U1[LOCAL]).toMatchObject({ id: 'k-live', name: 'U1', secret: 'lmk-rotated-secret' });
   });
 
   it('rotates an existing key whose display name is stale, ignoring revoked and foreign entries', async () => {
@@ -165,7 +166,7 @@ describe('llmux tenant keys (per-user metering)', () => {
     expect(urlsOf()).toEqual([KEYS_URL, ROTATE_URL]);
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ id: 'k-live' });
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
-    expect(persisted.tenants.U1.rotatedAtMs).toBeGreaterThan(0);
+    expect(persisted.tenants.U1[LOCAL].rotatedAtMs).toBeGreaterThan(0);
   });
 
   it('self-heals a 409 raced after an empty listing', async () => {
@@ -302,7 +303,28 @@ describe('llmux tenant keys (per-user metering)', () => {
     });
     expect(urlsOf()).toEqual([`${REMOTE}/llmux/keys`, `${REMOTE}/llmux/keys/new`]);
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
-    expect(persisted.tenants.U1).toMatchObject({ id: 'k-remote', baseUrl: REMOTE });
+    expect(persisted.tenants.U1[REMOTE]).toMatchObject({ id: 'k-remote', baseUrl: REMOTE });
+  });
+
+  it('carries ONE daemon’s admin credential for the whole issuance, even if settings flip mid-flight', async () => {
+    // The URL is already snapshotted; the admin key must be too. Otherwise the
+    // create leg would present daemon B's secret to daemon A's URL.
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('/llmux/keys')) {
+        setLlmuxSettings({ baseUrl: REMOTE, apiKey: 'admin-key-B' });
+        return okResponse({ keys: [] });
+      }
+      return okResponse(newKeyDoc());
+    });
+
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-abcdef-secret',
+      baseUrl: LOCAL,
+    });
+    expect(urlsOf()).toEqual([KEYS_URL, NEW_URL]);
+    const headers = fetchMock.mock.calls.map((c) => c[1].headers['x-api-key']);
+    expect(headers).toEqual(['admin-key', 'admin-key']);
+    expect(headers).not.toContain('admin-key-B');
   });
 
   it('a failure against one daemon does not suppress issuance against another', async () => {
@@ -348,6 +370,71 @@ describe('llmux tenant keys (per-user metering)', () => {
 
     resolveLocal(okResponse(newKeyDoc()));
     await expect(localCall).resolves.toEqual({ secret: 'lmk-abcdef-secret', baseUrl: LOCAL });
+  });
+
+  it('keeps BOTH daemons’ keys when concurrent issuances land out of order', async () => {
+    // The slow daemon-A issuance completes AFTER daemon B's. With a flat
+    // per-user slot A would clobber B, and the next B lookup — a miss — would
+    // force-rotate B's key out from under live dispatches still using it.
+    let resolveLocal!: (res: Response) => void;
+    const localCreate = new Promise<Response>((resolve) => {
+      resolveLocal = resolve;
+    });
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/llmux/keys')) return Promise.resolve(okResponse({ keys: [] }));
+      if (url.startsWith(LOCAL)) return localCreate;
+      return Promise.resolve(okResponse(newKeyDoc({ id: 'k-remote', key: 'lmk-remote-secret' })));
+    });
+
+    const localCall = ensureTenantKey('U1', { name: 'Zhuge' });
+    await new Promise((resolve) => setImmediate(resolve));
+    setLlmuxSettings({ baseUrl: REMOTE });
+    await ensureTenantKey('U1', { name: 'Zhuge' }); // daemon B finishes first
+    resolveLocal(okResponse(newKeyDoc())); // …daemon A finishes last
+    await localCall;
+
+    const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    expect(persisted.tenants.U1[LOCAL]).toMatchObject({ id: 'k-1', secret: 'lmk-abcdef-secret' });
+    expect(persisted.tenants.U1[REMOTE]).toMatchObject({ id: 'k-remote', secret: 'lmk-remote-secret' });
+
+    // After a restart each daemon still serves its OWN key — no re-issue.
+    resetLlmuxTenantKeysForTests(storePath);
+    fetchMock.mockClear();
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-remote-secret',
+      baseUrl: REMOTE,
+    });
+    setLlmuxSettings({ baseUrl: LOCAL });
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-abcdef-secret',
+      baseUrl: LOCAL,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('migrates a v1 flat store, dropping records with no daemon attribution', async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        version: 1,
+        tenants: {
+          U1: { id: 'k-1', secret: 'lmk-v1-secret', keyPrefix: 'lmk-abc', name: 'Zhuge (U1)', baseUrl: LOCAL },
+          // Pre-daemon-tracking record: presenting it to the wrong llmux 401s,
+          // so it is dropped and re-issued instead.
+          U2: { id: 'k-2', secret: 'lmk-orphan', keyPrefix: 'lmk-orp', name: 'U2' },
+        },
+      }),
+    );
+    resetLlmuxTenantKeysForTests(storePath);
+
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-v1-secret',
+      baseUrl: LOCAL,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    mockEmptyDaemon(newKeyDoc({ id: 'k-2b', name: 'U2', key: 'lmk-reissued' }));
+    await expect(ensureTenantKey('U2')).resolves.toEqual({ secret: 'lmk-reissued', baseUrl: LOCAL });
   });
 
   it('issues at most one key for concurrent dispatches of the same user', async () => {

--- a/src/auth/__tests__/llmux-tenant-keys.test.ts
+++ b/src/auth/__tests__/llmux-tenant-keys.test.ts
@@ -39,9 +39,12 @@ function newKeyDoc(overrides?: Record<string, unknown>) {
   };
 }
 
-const KEYS_URL = 'http://localhost:3456/llmux/keys';
-const NEW_URL = 'http://localhost:3456/llmux/keys/new';
-const ROTATE_URL = 'http://localhost:3456/llmux/keys/rotate';
+/** The daemon the suite runs against by default, and the one it switches to. */
+const LOCAL = 'http://localhost:3456';
+const REMOTE = 'http://10.0.0.5:3456';
+const KEYS_URL = `${LOCAL}/llmux/keys`;
+const NEW_URL = `${LOCAL}/llmux/keys/new`;
+const ROTATE_URL = `${LOCAL}/llmux/keys/rotate`;
 
 describe('llmux tenant keys (per-user metering)', () => {
   let dir: string;
@@ -54,7 +57,7 @@ describe('llmux tenant keys (per-user metering)', () => {
     resetAuthRuntimeForTests(path.join(dir, 'auth-runtime.json'));
     resetLlmuxTenantKeysForTests(storePath);
     delete process.env.AUTH_MODE;
-    setLlmuxSettings({ baseUrl: 'http://localhost:3456', apiKey: 'admin-key' });
+    setLlmuxSettings({ baseUrl: LOCAL, apiKey: 'admin-key' });
     setAuthMode('llmux');
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
@@ -80,8 +83,9 @@ describe('llmux tenant keys (per-user metering)', () => {
   it('issues a key on first use, persists it, and serves later calls from the store', async () => {
     mockEmptyDaemon();
 
-    const secret = await ensureTenantKey('U1', { name: 'Zhuge', email: 'z@example.com' });
-    expect(secret).toBe('lmk-abcdef-secret');
+    // The lease pairs the secret with the daemon it is valid at.
+    const leased = await ensureTenantKey('U1', { name: 'Zhuge', email: 'z@example.com' });
+    expect(leased).toEqual({ secret: 'lmk-abcdef-secret', baseUrl: LOCAL });
 
     // Reclaim lookup precedes creation (see the display-name cases below).
     expect(urlsOf()).toEqual([KEYS_URL, NEW_URL]);
@@ -97,13 +101,16 @@ describe('llmux tenant keys (per-user metering)', () => {
       id: 'k-1',
       secret: 'lmk-abcdef-secret',
       keyPrefix: 'lmk-abc',
-      baseUrl: 'http://localhost:3456',
+      baseUrl: LOCAL,
     });
     // The file holds plaintext secrets — owner-only.
     expect(fs.statSync(storePath).mode & 0o777).toBe(0o600);
 
     // Second call is a pure store hit — no further llmux traffic.
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-abcdef-secret',
+      baseUrl: LOCAL,
+    });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -125,7 +132,10 @@ describe('llmux tenant keys (per-user metering)', () => {
 
     // The user now HAS a display name, so keyName() would produce a different
     // name than the stored key — creating would silently split their metering.
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-rotated-secret');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-rotated-secret',
+      baseUrl: LOCAL,
+    });
     expect(urlsOf()).toEqual([KEYS_URL, ROTATE_URL]);
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ id: 'k-live' });
 
@@ -148,7 +158,10 @@ describe('llmux tenant keys (per-user metering)', () => {
       return okResponse({ ok: true, key: { id: 'k-live', key_prefix: 'lmk-new', key: 'lmk-rotated-secret' } });
     });
 
-    await expect(ensureTenantKey('U1', { name: 'New Name' })).resolves.toBe('lmk-rotated-secret');
+    await expect(ensureTenantKey('U1', { name: 'New Name' })).resolves.toEqual({
+      secret: 'lmk-rotated-secret',
+      baseUrl: LOCAL,
+    });
     expect(urlsOf()).toEqual([KEYS_URL, ROTATE_URL]);
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ id: 'k-live' });
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
@@ -171,7 +184,10 @@ describe('llmux tenant keys (per-user metering)', () => {
       return okResponse({ ok: true, key: { id: 'k-live', key_prefix: 'lmk-new', key: 'lmk-rotated-secret' } });
     });
 
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-rotated-secret');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-rotated-secret',
+      baseUrl: LOCAL,
+    });
     expect(urlsOf()).toEqual([KEYS_URL, NEW_URL, KEYS_URL, ROTATE_URL]);
   });
 
@@ -227,7 +243,10 @@ describe('llmux tenant keys (per-user metering)', () => {
 
   it('creates only after a SUCCESSFUL empty listing', async () => {
     mockEmptyDaemon();
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-abcdef-secret',
+      baseUrl: LOCAL,
+    });
     expect(urlsOf()).toEqual([KEYS_URL, NEW_URL]);
   });
 
@@ -253,28 +272,37 @@ describe('llmux tenant keys (per-user metering)', () => {
 
     // Fresh module state (simulated restart) against the same store file.
     resetLlmuxTenantKeysForTests(storePath);
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-abcdef-secret',
+      baseUrl: LOCAL,
+    });
     expect(fetchMock).toHaveBeenCalledTimes(callsAfterIssue);
   });
 
   it('re-issues when the daemon changed — a key from another llmux is not reused', async () => {
     mockEmptyDaemon();
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-abcdef-secret',
+      baseUrl: LOCAL,
+    });
     fetchMock.mockClear();
 
     // Operator re-points soma-work at a different llmux. The stored secret is
     // meaningless there (it would 401 without ever falling back), so a fresh
     // key must be issued against the new daemon.
-    setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456' });
+    setLlmuxSettings({ baseUrl: REMOTE });
     fetchMock.mockImplementation(async (url: string) => {
       if (url.endsWith('/llmux/keys')) return okResponse({ keys: [] });
       return okResponse(newKeyDoc({ id: 'k-remote', key: 'lmk-remote-secret', key_prefix: 'lmk-rem' }));
     });
 
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-remote-secret');
-    expect(urlsOf()).toEqual(['http://10.0.0.5:3456/llmux/keys', 'http://10.0.0.5:3456/llmux/keys/new']);
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-remote-secret',
+      baseUrl: REMOTE,
+    });
+    expect(urlsOf()).toEqual([`${REMOTE}/llmux/keys`, `${REMOTE}/llmux/keys/new`]);
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
-    expect(persisted.tenants.U1).toMatchObject({ id: 'k-remote', baseUrl: 'http://10.0.0.5:3456' });
+    expect(persisted.tenants.U1).toMatchObject({ id: 'k-remote', baseUrl: REMOTE });
   });
 
   it('a failure against one daemon does not suppress issuance against another', async () => {
@@ -283,13 +311,16 @@ describe('llmux tenant keys (per-user metering)', () => {
 
     // The negative cache is scoped to the daemon that failed, so re-pointing at
     // a healthy llmux issues immediately instead of degrading for 10 minutes.
-    setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456' });
+    setLlmuxSettings({ baseUrl: REMOTE });
     fetchMock.mockImplementation(async (url: string) =>
       url.endsWith('/llmux/keys')
         ? okResponse({ keys: [] })
         : okResponse(newKeyDoc({ id: 'k-remote', key: 'lmk-remote-secret' })),
     );
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-remote-secret');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-remote-secret',
+      baseUrl: REMOTE,
+    });
   });
 
   it('does not hand an in-flight issuance for one daemon to a dispatch targeting another', async () => {
@@ -299,7 +330,7 @@ describe('llmux tenant keys (per-user metering)', () => {
     });
     fetchMock.mockImplementation((url: string) => {
       if (url.endsWith('/llmux/keys')) return Promise.resolve(okResponse({ keys: [] }));
-      if (url.startsWith('http://localhost:3456')) return localCreate;
+      if (url.startsWith(LOCAL)) return localCreate;
       return Promise.resolve(okResponse(newKeyDoc({ id: 'k-remote', key: 'lmk-remote-secret' })));
     });
 
@@ -307,13 +338,16 @@ describe('llmux tenant keys (per-user metering)', () => {
     // Let the preflight settle so the create against localhost is in flight.
     await new Promise((resolve) => setImmediate(resolve));
 
-    setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456' });
+    setLlmuxSettings({ baseUrl: REMOTE });
     // Must NOT be served the pending localhost issuance — that key is worthless
     // at the new daemon.
-    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-remote-secret');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toEqual({
+      secret: 'lmk-remote-secret',
+      baseUrl: REMOTE,
+    });
 
     resolveLocal(okResponse(newKeyDoc()));
-    await expect(localCall).resolves.toBe('lmk-abcdef-secret');
+    await expect(localCall).resolves.toEqual({ secret: 'lmk-abcdef-secret', baseUrl: LOCAL });
   });
 
   it('issues at most one key for concurrent dispatches of the same user', async () => {
@@ -329,7 +363,8 @@ describe('llmux tenant keys (per-user metering)', () => {
     const calls = [ensureTenantKey('U1', { name: 'Zhuge' }), ensureTenantKey('U1', { name: 'Zhuge' })];
     resolveIssue(okResponse(newKeyDoc()));
 
-    expect(await Promise.all(calls)).toEqual(['lmk-abcdef-secret', 'lmk-abcdef-secret']);
+    const lease = { secret: 'lmk-abcdef-secret', baseUrl: LOCAL };
+    expect(await Promise.all(calls)).toEqual([lease, lease]);
     expect(urlsOf().filter((url) => url === NEW_URL)).toHaveLength(1);
   });
 });

--- a/src/auth/__tests__/llmux-tenant-keys.test.ts
+++ b/src/auth/__tests__/llmux-tenant-keys.test.ts
@@ -1,0 +1,184 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Freeze the env-derived defaults so the suite is independent of the host's
+// AUTH_MODE / ANTHROPIC_* environment (same shape as auth-runtime.test.ts).
+vi.mock('../../config', () => ({
+  config: {
+    auth: {
+      mode: 'ccp',
+      llmux: { baseUrl: 'http://localhost:3456', apiKey: 'llmux-local' },
+    },
+  },
+  LLMUX_PLACEHOLDER_API_KEY: 'llmux-local',
+}));
+
+import { resetAuthRuntimeForTests, setAuthMode, setLlmuxSettings } from '../auth-runtime';
+import { ensureTenantKey, resetLlmuxTenantKeysForTests } from '../llmux-tenant-keys';
+
+function okResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+/** `POST /llmux/keys/new` success payload (llmux `src/proxy/server.rs`). */
+function newKeyDoc(overrides?: Record<string, unknown>) {
+  return {
+    ok: true,
+    id: 'k-1',
+    name: 'Zhuge (U1)',
+    email: 'z@example.com',
+    kind: 'default',
+    key_prefix: 'lmk-abc',
+    suspended: false,
+    created_at_ms: 1_700_000_000_000,
+    revoked_at_ms: null,
+    key: 'lmk-abcdef-secret',
+    ...overrides,
+  };
+}
+
+describe('llmux tenant keys (per-user metering)', () => {
+  let dir: string;
+  let storePath: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'llmux-tenant-keys-'));
+    storePath = path.join(dir, 'llmux-tenant-keys.json');
+    resetAuthRuntimeForTests(path.join(dir, 'auth-runtime.json'));
+    resetLlmuxTenantKeysForTests(storePath);
+    delete process.env.AUTH_MODE;
+    setLlmuxSettings({ baseUrl: 'http://localhost:3456', apiKey: 'admin-key' });
+    setAuthMode('llmux');
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetAuthRuntimeForTests();
+    resetLlmuxTenantKeysForTests();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('issues a key on first use, persists it, and serves later calls from the store', async () => {
+    fetchMock.mockImplementation(async () => okResponse(newKeyDoc()));
+
+    const secret = await ensureTenantKey('U1', { name: 'Zhuge', email: 'z@example.com' });
+    expect(secret).toBe('lmk-abcdef-secret');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://localhost:3456/llmux/keys/new');
+    expect(init.method).toBe('POST');
+    expect(init.headers['x-api-key']).toBe('admin-key');
+    // The name embeds the Slack id, which is what makes it unique per user.
+    expect(JSON.parse(init.body)).toEqual({ name: 'Zhuge (U1)', email: 'z@example.com', kind: 'default' });
+
+    const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    expect(persisted.version).toBe(1);
+    expect(persisted.tenants.U1).toMatchObject({ id: 'k-1', secret: 'lmk-abcdef-secret', keyPrefix: 'lmk-abc' });
+
+    // Second call is a pure store hit — no further llmux traffic.
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the Slack id when no display name is known', async () => {
+    fetchMock.mockImplementation(async () => okResponse(newKeyDoc({ name: 'U9' })));
+    await ensureTenantKey('U9');
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ name: 'U9', kind: 'default' });
+  });
+
+  it('self-heals a 409 (name taken) by rotating the existing key', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('/llmux/keys/new')) {
+        return okResponse({ type: 'error', error: { message: 'name already in use' } }, 409);
+      }
+      if (url.endsWith('/llmux/keys')) {
+        return okResponse({
+          keys: [
+            { id: 'k-old', name: 'Zhuge (U1)', key_prefix: 'lmk-old', revoked_at_ms: 1_700_000_000_000 },
+            { id: 'k-live', name: 'Zhuge (U1)', key_prefix: 'lmk-live', revoked_at_ms: null },
+            { id: 'k-other', name: 'Someone (U2)', key_prefix: 'lmk-x', revoked_at_ms: null },
+          ],
+        });
+      }
+      return okResponse({ ok: true, key: { id: 'k-live', key_prefix: 'lmk-new', key: 'lmk-rotated-secret' } });
+    });
+
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-rotated-secret');
+    expect(fetchMock.mock.calls.map((c) => c[0])).toEqual([
+      'http://localhost:3456/llmux/keys/new',
+      'http://localhost:3456/llmux/keys',
+      'http://localhost:3456/llmux/keys/rotate',
+    ]);
+    // Rotation targets the non-revoked key with OUR exact name.
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({ id: 'k-live' });
+
+    const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    expect(persisted.tenants.U1).toMatchObject({ id: 'k-live', secret: 'lmk-rotated-secret' });
+    expect(persisted.tenants.U1.rotatedAtMs).toBeGreaterThan(0);
+  });
+
+  it('treats a 409 with no matching live key as a failure (shared-key fallback)', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('/llmux/keys/new')) return okResponse({ ok: false }, 409);
+      return okResponse({ keys: [{ id: 'k-old', name: 'Zhuge (U1)', revoked_at_ms: 1_700_000_000_000 }] });
+    });
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+  });
+
+  it('returns null on a non-2xx and negative-caches the failure', async () => {
+    fetchMock.mockImplementation(async () =>
+      okResponse({ type: 'error', error: { message: 'admin credential required' } }, 403),
+    );
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Immediate retry must NOT hit llmux again — one broken llmux would
+    // otherwise add a failing request to every dispatch.
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null without any llmux call in ccp mode', async () => {
+    setAuthMode('ccp');
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads persisted keys after a restart — no re-issue', async () => {
+    fetchMock.mockImplementation(async () => okResponse(newKeyDoc()));
+    await ensureTenantKey('U1', { name: 'Zhuge' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Fresh module state (simulated restart) against the same store file.
+    resetLlmuxTenantKeysForTests(storePath);
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('issues at most one key for concurrent dispatches of the same user', async () => {
+    // Hold the issuance open so the second call necessarily overlaps the first.
+    let resolveIssue!: (res: Response) => void;
+    const gate = new Promise<Response>((resolve) => {
+      resolveIssue = resolve;
+    });
+    fetchMock.mockImplementation(() => gate);
+
+    const calls = [ensureTenantKey('U1', { name: 'Zhuge' }), ensureTenantKey('U1', { name: 'Zhuge' })];
+    resolveIssue(okResponse(newKeyDoc()));
+
+    expect(await Promise.all(calls)).toEqual(['lmk-abcdef-secret', 'lmk-abcdef-secret']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws when llmux is unreachable', async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+  });
+});

--- a/src/auth/__tests__/llmux-tenant-keys.test.ts
+++ b/src/auth/__tests__/llmux-tenant-keys.test.ts
@@ -197,6 +197,38 @@ describe('llmux tenant keys (per-user metering)', () => {
     // otherwise add failing requests to every dispatch.
     await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(callsAfterFirst);
+    // Fails closed: a failed listing must never lead to a create.
+    expect(urlsOf()).not.toContain(NEW_URL);
+  });
+
+  it('fails CLOSED when the preflight listing errors — no key is created', async () => {
+    // "We could not look" is indistinguishable from "this user has no key", and
+    // creating on that ignorance mints a duplicate tenant whenever the display
+    // name changed since the first issuance. Degrade to the shared key instead.
+    fetchMock.mockImplementation(async (url: string) =>
+      url.endsWith('/llmux/keys') ? okResponse({ error: 'boom' }, 500) : okResponse(newKeyDoc()),
+    );
+
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+    expect(urlsOf()).toEqual([KEYS_URL]);
+
+    // …and the failure is negative-cached like any other.
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails CLOSED when the preflight listing is unparseable', async () => {
+    fetchMock.mockImplementation(async (url: string) =>
+      url.endsWith('/llmux/keys') ? okResponse({ notKeys: true }) : okResponse(newKeyDoc()),
+    );
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+    expect(urlsOf()).toEqual([KEYS_URL]);
+  });
+
+  it('creates only after a SUCCESSFUL empty listing', async () => {
+    mockEmptyDaemon();
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-abcdef-secret');
+    expect(urlsOf()).toEqual([KEYS_URL, NEW_URL]);
   });
 
   it('returns null without any llmux call in ccp mode', async () => {
@@ -243,6 +275,45 @@ describe('llmux tenant keys (per-user metering)', () => {
     expect(urlsOf()).toEqual(['http://10.0.0.5:3456/llmux/keys', 'http://10.0.0.5:3456/llmux/keys/new']);
     const persisted = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
     expect(persisted.tenants.U1).toMatchObject({ id: 'k-remote', baseUrl: 'http://10.0.0.5:3456' });
+  });
+
+  it('a failure against one daemon does not suppress issuance against another', async () => {
+    fetchMock.mockImplementation(async () => okResponse({ error: 'boom' }, 500));
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBeNull();
+
+    // The negative cache is scoped to the daemon that failed, so re-pointing at
+    // a healthy llmux issues immediately instead of degrading for 10 minutes.
+    setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456' });
+    fetchMock.mockImplementation(async (url: string) =>
+      url.endsWith('/llmux/keys')
+        ? okResponse({ keys: [] })
+        : okResponse(newKeyDoc({ id: 'k-remote', key: 'lmk-remote-secret' })),
+    );
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-remote-secret');
+  });
+
+  it('does not hand an in-flight issuance for one daemon to a dispatch targeting another', async () => {
+    let resolveLocal!: (res: Response) => void;
+    const localCreate = new Promise<Response>((resolve) => {
+      resolveLocal = resolve;
+    });
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/llmux/keys')) return Promise.resolve(okResponse({ keys: [] }));
+      if (url.startsWith('http://localhost:3456')) return localCreate;
+      return Promise.resolve(okResponse(newKeyDoc({ id: 'k-remote', key: 'lmk-remote-secret' })));
+    });
+
+    const localCall = ensureTenantKey('U1', { name: 'Zhuge' });
+    // Let the preflight settle so the create against localhost is in flight.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456' });
+    // Must NOT be served the pending localhost issuance — that key is worthless
+    // at the new daemon.
+    await expect(ensureTenantKey('U1', { name: 'Zhuge' })).resolves.toBe('lmk-remote-secret');
+
+    resolveLocal(okResponse(newKeyDoc()));
+    await expect(localCall).resolves.toBe('lmk-abcdef-secret');
   });
 
   it('issues at most one key for concurrent dispatches of the same user', async () => {

--- a/src/auth/__tests__/query-env-builder.llmux.test.ts
+++ b/src/auth/__tests__/query-env-builder.llmux.test.ts
@@ -32,6 +32,7 @@ function makeLease(keyId: string, accessToken: string, kind: SlotAuthLease['kind
 
 describe('buildQueryEnv — llmux mode (#llmux)', () => {
   let originalOauth: string | undefined;
+  let originalBaseUrl: string | undefined;
 
   beforeEach(() => {
     originalOauth = process.env.CLAUDE_CODE_OAUTH_TOKEN;
@@ -39,11 +40,18 @@ describe('buildQueryEnv — llmux mode (#llmux)', () => {
     // otherwise Claude Code would prefer the OAuth token over the API key and
     // silently bypass the proxy.
     process.env.CLAUDE_CODE_OAUTH_TOKEN = 'INHERITED-OAUTH-TOKEN';
+    // The "does NOT mutate process.env" case reads ANTHROPIC_BASE_URL, which a
+    // developer machine pointed at a local llmux legitimately exports. Clear it
+    // for the duration so the assertion measures buildQueryEnv, not the host.
+    originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_BASE_URL;
   });
 
   afterEach(() => {
     if (originalOauth === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     else process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOauth;
+    if (originalBaseUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+    else process.env.ANTHROPIC_BASE_URL = originalBaseUrl;
   });
 
   it('points the SDK at the llmux proxy with a throwaway API key', () => {
@@ -63,6 +71,17 @@ describe('buildQueryEnv — llmux mode (#llmux)', () => {
     expect(env.ANTHROPIC_API_KEY).toBe('llmux-local');
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
     expect(Object.values(env)).not.toContain('sk-ant-oat01-SHOULD-NOT-APPEAR');
+  });
+
+  it('uses the per-user llmux tenant key when one was issued', () => {
+    const { env } = buildQueryEnv(makeLease('llmux', 'llmux-local'), { llmuxTenantKey: 'lmk-abc' });
+    expect(env.ANTHROPIC_API_KEY).toBe('lmk-abc');
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://localhost:3456');
+  });
+
+  it('falls back to the shared key (legacy tenant) when issuance produced nothing', () => {
+    expect(buildQueryEnv(makeLease('llmux', 'x'), { llmuxTenantKey: null }).env.ANTHROPIC_API_KEY).toBe('llmux-local');
+    expect(buildQueryEnv(makeLease('llmux', 'x'), {}).env.ANTHROPIC_API_KEY).toBe('llmux-local');
   });
 
   it('does NOT mutate process.env', () => {

--- a/src/auth/__tests__/query-env-builder.llmux.test.ts
+++ b/src/auth/__tests__/query-env-builder.llmux.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SlotAuthLease } from '../../credentials-manager';
 import { buildQueryEnv } from '../query-env-builder';
@@ -14,7 +17,10 @@ vi.mock('../../config', () => ({
       llmux: { baseUrl: 'http://localhost:3456', apiKey: 'llmux-local' },
     },
   },
+  LLMUX_PLACEHOLDER_API_KEY: 'llmux-local',
 }));
+
+import { resetAuthRuntimeForTests, setLlmuxSettings } from '../auth-runtime';
 
 function makeLease(keyId: string, accessToken: string, kind: SlotAuthLease['kind'] = 'api_key'): SlotAuthLease {
   return {
@@ -73,14 +79,15 @@ describe('buildQueryEnv — llmux mode (#llmux)', () => {
     expect(Object.values(env)).not.toContain('sk-ant-oat01-SHOULD-NOT-APPEAR');
   });
 
-  it('uses the per-user llmux tenant key when one was issued', () => {
-    const { env } = buildQueryEnv(makeLease('llmux', 'llmux-local'), { llmuxTenantKey: 'lmk-abc' });
+  it('uses the per-user llmux tenant lease when one was issued', () => {
+    const tenant = { secret: 'lmk-abc', baseUrl: 'http://localhost:3456' };
+    const { env } = buildQueryEnv(makeLease('llmux', 'llmux-local'), { llmuxTenant: tenant });
     expect(env.ANTHROPIC_API_KEY).toBe('lmk-abc');
     expect(env.ANTHROPIC_BASE_URL).toBe('http://localhost:3456');
   });
 
   it('falls back to the shared key (legacy tenant) when issuance produced nothing', () => {
-    expect(buildQueryEnv(makeLease('llmux', 'x'), { llmuxTenantKey: null }).env.ANTHROPIC_API_KEY).toBe('llmux-local');
+    expect(buildQueryEnv(makeLease('llmux', 'x'), { llmuxTenant: null }).env.ANTHROPIC_API_KEY).toBe('llmux-local');
     expect(buildQueryEnv(makeLease('llmux', 'x'), {}).env.ANTHROPIC_API_KEY).toBe('llmux-local');
   });
 
@@ -88,5 +95,40 @@ describe('buildQueryEnv — llmux mode (#llmux)', () => {
     buildQueryEnv(makeLease('llmux', 'llmux-local'));
     expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('INHERITED-OAUTH-TOKEN');
     expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
+  });
+
+  // The production composition: `ensureTenantKey` resolves against daemon A
+  // while an operator flips the live setting to daemon B. The env built from
+  // that lease must describe A ENTIRELY — pairing A's key with B's URL would
+  // 401 on B instead of degrading to the shared key.
+  describe('daemon flip between issuance and env build', () => {
+    let dir: string;
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'query-env-llmux-'));
+      resetAuthRuntimeForTests(path.join(dir, 'auth-runtime.json'));
+    });
+
+    afterEach(() => {
+      resetAuthRuntimeForTests();
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('keeps the tenant lease coherent: both URL and key come from daemon A', () => {
+      const tenantFromA = { secret: 'lmk-issued-by-A', baseUrl: 'http://localhost:3456' };
+      setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456', apiKey: 'shared-key-B' });
+
+      const { env } = buildQueryEnv(makeLease('llmux', 'x'), { llmuxTenant: tenantFromA });
+      expect(env.ANTHROPIC_BASE_URL).toBe('http://localhost:3456');
+      expect(env.ANTHROPIC_API_KEY).toBe('lmk-issued-by-A');
+    });
+
+    it('a dispatch without a lease uses the NEW daemon and its shared key', () => {
+      setLlmuxSettings({ baseUrl: 'http://10.0.0.5:3456', apiKey: 'shared-key-B' });
+
+      const { env } = buildQueryEnv(makeLease('llmux', 'x'));
+      expect(env.ANTHROPIC_BASE_URL).toBe('http://10.0.0.5:3456');
+      expect(env.ANTHROPIC_API_KEY).toBe('shared-key-B');
+    });
   });
 });

--- a/src/auth/__tests__/query-env-builder.test.ts
+++ b/src/auth/__tests__/query-env-builder.test.ts
@@ -55,6 +55,15 @@ describe('buildQueryEnv', () => {
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-TOKEN-B');
   });
 
+  it('ignores an llmux tenant key in ccp mode (the lease token still wins)', () => {
+    // The option is llmux-only; a caller that always passes it (claude-handler)
+    // must not perturb the OAuth-lease path.
+    const lease = makeLease('slot-a', 'sk-ant-oat01-TOKEN-C', 'cct');
+    const { env } = buildQueryEnv(lease, { llmuxTenantKey: 'lmk-should-be-ignored' });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-TOKEN-C');
+    expect(env.ANTHROPIC_API_KEY).not.toBe('lmk-should-be-ignored');
+  });
+
   it('does NOT mutate process.env', () => {
     const lease = makeLease('slot-a', 'sk-ant-oat01-FRESH', 'cct');
     buildQueryEnv(lease);

--- a/src/auth/__tests__/query-env-builder.test.ts
+++ b/src/auth/__tests__/query-env-builder.test.ts
@@ -55,11 +55,12 @@ describe('buildQueryEnv', () => {
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-TOKEN-B');
   });
 
-  it('ignores an llmux tenant key in ccp mode (the lease token still wins)', () => {
+  it('ignores an llmux tenant lease in ccp mode (the lease token still wins)', () => {
     // The option is llmux-only; a caller that always passes it (claude-handler)
     // must not perturb the OAuth-lease path.
     const lease = makeLease('slot-a', 'sk-ant-oat01-TOKEN-C', 'cct');
-    const { env } = buildQueryEnv(lease, { llmuxTenantKey: 'lmk-should-be-ignored' });
+    const tenant = { secret: 'lmk-should-be-ignored', baseUrl: 'http://localhost:3456' };
+    const { env } = buildQueryEnv(lease, { llmuxTenant: tenant });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-TOKEN-C');
     expect(env.ANTHROPIC_API_KEY).not.toBe('lmk-should-be-ignored');
   });

--- a/src/auth/auth-runtime.ts
+++ b/src/auth/auth-runtime.ts
@@ -191,6 +191,20 @@ function readLlmuxConfigApiKey(): string | null {
 }
 
 /**
+ * Whether `baseUrl` addresses a daemon on THIS host. Unparseable input is NOT
+ * loopback — an unrecognized URL must never unlock the local-credential path.
+ */
+function isLoopbackBaseUrl(baseUrl: string): boolean {
+  try {
+    // Node keeps IPv6 literals bracketed in `hostname` ("[::1]").
+    const host = new URL(baseUrl).hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    return host === 'localhost' || host === '::1' || host === '127.0.0.1' || host.startsWith('127.');
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Credential for llmux's CONTROL plane (`/llmux/*`).
  *
  * llmux requires an ADMIN credential on every control endpoint — including
@@ -206,13 +220,20 @@ function readLlmuxConfigApiKey(): string | null {
  *      `proxy.api_key`, which llmux resolves to admin. This mirrors llmux's own
  *      behavior for server-local CLIs, which auto-present that key. Cached for
  *      60s.
+ *
+ *      ONLY when the live `baseUrl` is loopback. That file belongs to the llmux
+ *      running on THIS host, and callers send whatever this function returns to
+ *      whatever `baseUrl` points at — so without the gate, "placeholder apiKey +
+ *      remote baseUrl" would ship the local daemon's admin secret to a foreign
+ *      host. A remote llmux must be given its own key explicitly (path 1).
  *   3. Otherwise return the placeholder unchanged (legacy behavior: harmless
  *      against single-tenant/older llmux, 403 against multi-tenant llmux —
  *      which every caller already degrades gracefully on).
  */
 export function getLlmuxAdminKey(): string {
-  const { apiKey } = getLlmuxSettings();
+  const { apiKey, baseUrl } = getLlmuxSettings();
   if (apiKey.trim() !== '' && apiKey !== LLMUX_PLACEHOLDER_API_KEY) return apiKey;
+  if (!isLoopbackBaseUrl(baseUrl)) return apiKey;
 
   const now = Date.now();
   if (_llmuxConfigKeyCache === null || now - _llmuxConfigKeyCache.readAtMs >= LLMUX_CONFIG_KEY_TTL_MS) {

--- a/src/auth/auth-runtime.ts
+++ b/src/auth/auth-runtime.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
-import { type AuthMode, config } from '../config';
+import { type AuthMode, config, LLMUX_PLACEHOLDER_API_KEY } from '../config';
 import { Logger } from '../logger';
 
 const logger = new Logger('AuthRuntime');
@@ -144,6 +145,82 @@ export function getLlmuxSettings(): { baseUrl: string; apiKey: string } {
   return { ...state().llmux };
 }
 
+/**
+ * Cached result of the llmux-config file read used by {@link getLlmuxAdminKey}.
+ * `key` is `null` when no candidate file yielded a usable `proxy.api_key`.
+ * Short TTL so an operator who starts/edits llmux does not need a restart,
+ * while a per-dispatch key lookup stays free of syscalls.
+ */
+let _llmuxConfigKeyCache: { key: string | null; readAtMs: number } | null = null;
+const LLMUX_CONFIG_KEY_TTL_MS = 60_000;
+
+/**
+ * Candidate paths of llmux's OWN config file, in llmux's resolution order
+ * (llmux `src/config/mod.rs`): `$LLMUX_CONFIG`, else
+ * `$XDG_CONFIG_HOME/llmux.json`, else `~/.config/llmux.json`.
+ *
+ * Reading these external-tool env names directly is a deliberate, documented
+ * exception to the `SOMA_`-prefixed-config rule (rules/config.md §5): they are
+ * llmux's variables, not ours — re-declaring them under a `SOMA_` name would
+ * create a second source of truth for someone else's config path.
+ */
+function llmuxConfigCandidates(): string[] {
+  const explicit = process.env.LLMUX_CONFIG?.trim();
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  return [
+    ...(explicit ? [explicit] : []),
+    path.join(xdg && xdg !== '' ? xdg : path.join(os.homedir(), '.config'), 'llmux.json'),
+  ];
+}
+
+/** First candidate file with a non-empty `.proxy.api_key`, else null. Never throws. */
+function readLlmuxConfigApiKey(): string | null {
+  for (const candidate of llmuxConfigCandidates()) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(candidate, 'utf-8')) as { proxy?: { api_key?: unknown } };
+      const key = parsed?.proxy?.api_key;
+      if (typeof key === 'string' && key.trim() !== '') return key.trim();
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        logger.warn(`llmux config ${candidate} unreadable (${(err as Error).message}); no admin key from it`);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Credential for llmux's CONTROL plane (`/llmux/*`).
+ *
+ * llmux requires an ADMIN credential on every control endpoint — including
+ * loopback callers (llmux `src/proxy/server.rs` client_auth), unlike the data
+ * plane which lets loopback through as the `local` tenant. So the placeholder
+ * data-plane key is NOT sufficient here.
+ *
+ * Resolution:
+ *   1. Operator-set `llmux.apiKey` (runtime settings / `ANTHROPIC_API_KEY`)
+ *      always wins — an explicit key is an explicit choice.
+ *   2. Otherwise (the operator left {@link LLMUX_PLACEHOLDER_API_KEY}) read the
+ *      co-located llmux daemon's own config file and use its legacy
+ *      `proxy.api_key`, which llmux resolves to admin. This mirrors llmux's own
+ *      behavior for server-local CLIs, which auto-present that key. Cached for
+ *      60s.
+ *   3. Otherwise return the placeholder unchanged (legacy behavior: harmless
+ *      against single-tenant/older llmux, 403 against multi-tenant llmux —
+ *      which every caller already degrades gracefully on).
+ */
+export function getLlmuxAdminKey(): string {
+  const { apiKey } = getLlmuxSettings();
+  if (apiKey.trim() !== '' && apiKey !== LLMUX_PLACEHOLDER_API_KEY) return apiKey;
+
+  const now = Date.now();
+  if (_llmuxConfigKeyCache === null || now - _llmuxConfigKeyCache.readAtMs >= LLMUX_CONFIG_KEY_TTL_MS) {
+    _llmuxConfigKeyCache = { key: readLlmuxConfigApiKey(), readAtMs: now };
+  }
+  return _llmuxConfigKeyCache.key ?? apiKey;
+}
+
 /** Full snapshot for card rendering (defensive copy). */
 export function getAuthRuntimeSnapshot(): AuthRuntimeState {
   const s = state();
@@ -215,4 +292,5 @@ export async function initAuthRuntimeDefault(probe: (baseUrl: string) => Promise
 export function resetAuthRuntimeForTests(overridePath?: string): void {
   _state = null;
   _storePath = overridePath ?? null;
+  _llmuxConfigKeyCache = null;
 }

--- a/src/auth/auth-runtime.ts
+++ b/src/auth/auth-runtime.ts
@@ -221,19 +221,24 @@ function isLoopbackBaseUrl(baseUrl: string): boolean {
  *      behavior for server-local CLIs, which auto-present that key. Cached for
  *      60s.
  *
- *      ONLY when the live `baseUrl` is loopback. That file belongs to the llmux
- *      running on THIS host, and callers send whatever this function returns to
- *      whatever `baseUrl` points at — so without the gate, "placeholder apiKey +
- *      remote baseUrl" would ship the local daemon's admin secret to a foreign
- *      host. A remote llmux must be given its own key explicitly (path 1).
+ *      ONLY when the daemon this credential is about to be SENT TO is loopback.
+ *      That file belongs to the llmux running on THIS host, so without the gate
+ *      "placeholder apiKey + remote destination" would ship the local daemon's
+ *      admin secret to a foreign host. A remote llmux must be given its own key
+ *      explicitly (path 1).
  *   3. Otherwise return the placeholder unchanged (legacy behavior: harmless
  *      against single-tenant/older llmux, 403 against multi-tenant llmux —
  *      which every caller already degrades gracefully on).
+ *
+ * @param targetBaseUrl the URL this credential will actually be sent to.
+ *   Callers with a per-request baseUrl override (llmux-client's Settings-modal
+ *   candidate probe) MUST pass it — the live setting can be loopback while the
+ *   request goes off-host. Omitted → the live setting.
  */
-export function getLlmuxAdminKey(): string {
+export function getLlmuxAdminKey(targetBaseUrl?: string): string {
   const { apiKey, baseUrl } = getLlmuxSettings();
   if (apiKey.trim() !== '' && apiKey !== LLMUX_PLACEHOLDER_API_KEY) return apiKey;
-  if (!isLoopbackBaseUrl(baseUrl)) return apiKey;
+  if (!isLoopbackBaseUrl(targetBaseUrl?.trim() || baseUrl)) return apiKey;
 
   const now = Date.now();
   if (_llmuxConfigKeyCache === null || now - _llmuxConfigKeyCache.readAtMs >= LLMUX_CONFIG_KEY_TTL_MS) {

--- a/src/auth/llmux-client.ts
+++ b/src/auth/llmux-client.ts
@@ -1,5 +1,5 @@
 import { Logger } from '../logger';
-import { getLlmuxSettings } from './auth-runtime';
+import { getLlmuxAdminKey, getLlmuxSettings } from './auth-runtime';
 
 const logger = new Logger('LlmuxClient');
 
@@ -13,10 +13,10 @@ const logger = new Logger('LlmuxClient');
  *   - `POST /llmux/add-account` `{api_key,name?}` → add an api-key account
  *   - `POST /llmux/remove-account` `{name,confirm:true}` → remove an account
  *
- * Auth: llmux exempts loopback peers; non-loopback peers must present the
- * proxy api key as `x-api-key`. We always send the live runtime apiKey — on
- * loopback it is ignored, elsewhere it is exactly the key the SDK subprocess
- * already uses for `/v1/messages`, so no extra secret is introduced.
+ * Auth: these are CONTROL-plane endpoints, which multi-tenant llmux gates on an
+ * admin credential for every peer — the loopback exemption applies to the data
+ * plane only. We send `getLlmuxAdminKey()` as `x-api-key`; see its doc in
+ * `auth-runtime.ts` for how the admin credential is resolved.
  *
  * Every method takes an optional `baseUrl` override (the Settings modal
  * validates a *candidate* URL before persisting); default is the live
@@ -116,9 +116,14 @@ async function request<T>(
       method,
       headers: {
         'content-type': 'application/json',
-        // Loopback llmux ignores this; remote llmux validates it against its
-        // proxy api key (same key the SDK uses for /v1/messages).
-        'x-api-key': settings.apiKey,
+        // Control-plane endpoints (`/llmux/*` except `/llmux/models`) require
+        // an ADMIN credential even on loopback since llmux went multi-tenant
+        // (llmux #22) — the loopback exemption only covers the data plane. So
+        // send the admin key, not the data-plane one: `getLlmuxAdminKey()`
+        // returns the operator-set key when there is one and otherwise falls
+        // back to the co-located llmux config's `proxy.api_key` (which llmux
+        // resolves to admin) when the operator left the placeholder.
+        'x-api-key': getLlmuxAdminKey(),
       },
       body: opts?.body === undefined ? undefined : JSON.stringify(opts.body),
       signal: controller.signal,

--- a/src/auth/llmux-client.ts
+++ b/src/auth/llmux-client.ts
@@ -123,7 +123,12 @@ async function request<T>(
         // returns the operator-set key when there is one and otherwise falls
         // back to the co-located llmux config's `proxy.api_key` (which llmux
         // resolves to admin) when the operator left the placeholder.
-        'x-api-key': getLlmuxAdminKey(),
+        //
+        // Resolved against `base`, NOT the live setting: `opts.baseUrl` (the
+        // Settings modal's candidate probe) can address another host while the
+        // persisted setting is still loopback, and the local llmux config's key
+        // must never leave this machine.
+        'x-api-key': getLlmuxAdminKey(base),
       },
       body: opts?.body === undefined ? undefined : JSON.stringify(opts.body),
       signal: controller.signal,

--- a/src/auth/llmux-tenant-keys.ts
+++ b/src/auth/llmux-tenant-keys.ts
@@ -69,10 +69,20 @@ const NEGATIVE_CACHE_MS = 10 * 60 * 1000;
 
 let _state: TenantKeyStore | null = null;
 let _storePath: string | null = null;
-/** userId → epoch ms of the last failed issuance (retry suppressed until +TTL). */
+/** {@link tenantCacheKey} → epoch ms of the last failed issuance (retry suppressed until +TTL). */
 const _negativeCache = new Map<string, number>();
-/** userId → in-flight issuance, so concurrent dispatches issue at most one key. */
+/** {@link tenantCacheKey} → in-flight issuance, so concurrent dispatches issue at most one key. */
 const _inFlight = new Map<string, Promise<string | null>>();
+
+/**
+ * Both per-user caches are scoped to the DAEMON as well as the user: a key is
+ * only valid at its issuer, so an in-flight issuance against llmux A must not
+ * be handed to a dispatch that now targets B, and a failure against A must not
+ * suppress issuance against B.
+ */
+function tenantCacheKey(baseUrl: string, userId: string): string {
+  return `${baseUrl}\n${userId}`;
+}
 
 function storePath(): string {
   if (_storePath === null) _storePath = path.join(DATA_DIR, 'llmux-tenant-keys.json');
@@ -160,14 +170,17 @@ function currentBaseUrl(): string {
 }
 
 async function llmuxPost<T>(pathName: string, body: unknown): Promise<{ status: number; body: T | null }> {
+  const base = currentBaseUrl();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error(`llmux POST ${pathName} timed out`)), REQUEST_TIMEOUT_MS);
   try {
-    const res = await fetch(`${currentBaseUrl()}${pathName}`, {
+    const res = await fetch(`${base}${pathName}`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'x-api-key': getLlmuxAdminKey(),
+        // Resolved against the URL we are actually posting to — the admin
+        // credential must never be sent to a daemon it does not belong to.
+        'x-api-key': getLlmuxAdminKey(base),
       },
       body: JSON.stringify(body),
       signal: controller.signal,
@@ -186,12 +199,13 @@ async function llmuxPost<T>(pathName: string, body: unknown): Promise<{ status: 
 }
 
 async function llmuxGetKeys(): Promise<{ status: number; body: { keys?: LlmuxIssuedKey[] } | null }> {
+  const base = currentBaseUrl();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error('llmux GET /llmux/keys timed out')), REQUEST_TIMEOUT_MS);
   try {
-    const res = await fetch(`${currentBaseUrl()}/llmux/keys`, {
+    const res = await fetch(`${base}/llmux/keys`, {
       method: 'GET',
-      headers: { 'content-type': 'application/json', 'x-api-key': getLlmuxAdminKey() },
+      headers: { 'content-type': 'application/json', 'x-api-key': getLlmuxAdminKey(base) },
       signal: controller.signal,
     });
     const text = await res.text();
@@ -224,9 +238,9 @@ function remember(userId: string, record: TenantKeyRecord): string {
   return record.secret;
 }
 
-function fail(userId: string, reason: string): null {
-  _negativeCache.set(userId, Date.now());
-  logger.warn('llmux tenant key issuance failed; falling back to the shared key', { userId, reason });
+function fail(userId: string, baseUrl: string, reason: string): null {
+  _negativeCache.set(tenantCacheKey(baseUrl, userId), Date.now());
+  logger.warn('llmux tenant key issuance failed; falling back to the shared key', { userId, baseUrl, reason });
   return null;
 }
 
@@ -266,7 +280,7 @@ async function rotateExisting(
   const rotated = await llmuxPost<{ key?: LlmuxIssuedKey }>('/llmux/keys/rotate', { id: key.id });
   const secret = nonEmptyString(rotated.body?.key?.key);
   if (rotated.status !== 200 || !secret) {
-    return fail(userId, `POST /llmux/keys/rotate → ${rotated.status}`);
+    return fail(userId, baseUrl, `POST /llmux/keys/rotate → ${rotated.status}`);
   }
   return remember(userId, {
     id: key.id,
@@ -289,8 +303,15 @@ async function issue(userId: string, profile?: { name?: string; email?: string }
     // first issuance would otherwise create a second key under the new name
     // (no 409, because the names differ) and split their billing history.
     // Costs one GET per issuance — i.e. per user per store lifetime.
+    //
+    // FAIL CLOSED when the listing itself fails: we then cannot tell "this user
+    // has no key" from "we could not look", and creating on that ignorance is
+    // exactly how a transient 500 mints a duplicate tenant. Degrade to the
+    // shared key instead; the next dispatch after the negative-cache window
+    // retries.
     const existing = await findExistingKey(userId);
-    if (existing.ok && existing.key) return await rotateExisting(userId, existing.key, email, baseUrl);
+    if (!existing.ok) return fail(userId, baseUrl, `preflight ${existing.reason}`);
+    if (existing.key) return await rotateExisting(userId, existing.key, email, baseUrl);
 
     const created = await llmuxPost<LlmuxIssuedKey>('/llmux/keys/new', {
       name,
@@ -298,18 +319,18 @@ async function issue(userId: string, profile?: { name?: string; email?: string }
       kind: 'default',
     });
     if (created.status === 409) {
-      // Race fallback: someone issued this user's key between our list and our
-      // create (or the list call itself failed above). Re-list and reclaim.
+      // Race fallback: someone issued this user's key between our (successful,
+      // empty) listing and our create. Re-list and reclaim.
       const raced = await findExistingKey(userId);
-      if (!raced.ok) return fail(userId, raced.reason);
-      if (!raced.key) return fail(userId, 'existing non-revoked key not found in GET /llmux/keys');
+      if (!raced.ok) return fail(userId, baseUrl, raced.reason);
+      if (!raced.key) return fail(userId, baseUrl, 'existing non-revoked key not found in GET /llmux/keys');
       return await rotateExisting(userId, raced.key, email, baseUrl);
     }
 
     const secret = nonEmptyString(created.body?.key);
     const id = nonEmptyString(created.body?.id);
     if (created.status !== 200 || !secret || !id) {
-      return fail(userId, `POST /llmux/keys/new → ${created.status}`);
+      return fail(userId, baseUrl, `POST /llmux/keys/new → ${created.status}`);
     }
     return remember(userId, {
       id,
@@ -323,7 +344,7 @@ async function issue(userId: string, profile?: { name?: string; email?: string }
   } catch (err) {
     // Network error / timeout / abort — never propagate; the dispatch continues
     // on the shared key.
-    return fail(userId, (err as Error).message);
+    return fail(userId, baseUrl, (err as Error).message);
   }
 }
 
@@ -345,17 +366,19 @@ export async function ensureTenantKey(
   // Store hit only counts for the daemon that issued it. A record written
   // before this field existed has no `baseUrl` and is likewise a miss —
   // issuance overwrites it.
+  const baseUrl = currentBaseUrl();
   const existing = state().tenants[userId];
-  if (existing?.secret && existing.baseUrl === currentBaseUrl()) return existing.secret;
+  if (existing?.secret && existing.baseUrl === baseUrl) return existing.secret;
 
-  const failedAt = _negativeCache.get(userId);
+  const cacheKey = tenantCacheKey(baseUrl, userId);
+  const failedAt = _negativeCache.get(cacheKey);
   if (failedAt !== undefined && Date.now() - failedAt < NEGATIVE_CACHE_MS) return null;
 
-  const pending = _inFlight.get(userId);
+  const pending = _inFlight.get(cacheKey);
   if (pending) return pending;
 
-  const attempt = issue(userId, profile).finally(() => _inFlight.delete(userId));
-  _inFlight.set(userId, attempt);
+  const attempt = issue(userId, profile).finally(() => _inFlight.delete(cacheKey));
+  _inFlight.set(cacheKey, attempt);
   return attempt;
 }
 

--- a/src/auth/llmux-tenant-keys.ts
+++ b/src/auth/llmux-tenant-keys.ts
@@ -1,0 +1,306 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { DATA_DIR } from '../env-paths';
+import { Logger } from '../logger';
+import { getAuthMode, getLlmuxAdminKey, getLlmuxSettings } from './auth-runtime';
+
+const logger = new Logger('LlmuxTenantKeys');
+
+/**
+ * Per-Slack-user llmux client keys (`lmk-…`) — multi-tenant metering.
+ *
+ * In llmux mode every dispatch used to authenticate with ONE shared
+ * `getLlmuxSettings().apiKey`, so llmux attributed every user's tokens to a
+ * single tenant. This store issues one llmux client key per Slack user (lazily,
+ * on that user's first dispatch) and hands it to `buildQueryEnv` as
+ * `ANTHROPIC_API_KEY`, so llmux meters each user separately.
+ *
+ * Degradation contract: issuance is best effort. Every failure path returns
+ * `null` and the caller falls back to the shared key (the legacy tenant) — a
+ * user must never lose their dispatch because llmux would not mint a key.
+ * {@link ensureTenantKey} therefore NEVER throws.
+ *
+ * Persistence: `DATA_DIR/llmux-tenant-keys.json`, written atomically
+ * (tmp + rename) and chmod 0600 — it holds plaintext secrets, which llmux shows
+ * exactly once at issuance. Nothing else logs or persists them; logs carry only
+ * key ids and prefixes.
+ */
+interface TenantKeyRecord {
+  /** llmux key id — safe to log. */
+  id: string;
+  /** Plaintext `lmk-…` secret. NEVER log this. */
+  secret: string;
+  /** Non-secret display prefix llmux returns alongside the secret. */
+  keyPrefix: string;
+  /** llmux key name — `${slackName} (${userId})`, unique per user by construction. */
+  name: string;
+  email?: string;
+  issuedAtMs: number;
+  rotatedAtMs?: number;
+}
+
+interface TenantKeyStore {
+  version: 1;
+  tenants: Record<string, TenantKeyRecord>;
+}
+
+/** Response of `POST /llmux/keys/new` and `POST /llmux/keys/rotate` (`.key`). */
+interface LlmuxIssuedKey {
+  id?: unknown;
+  name?: unknown;
+  key_prefix?: unknown;
+  /** Plaintext secret — shown ONCE, at issuance/rotation. */
+  key?: unknown;
+  revoked_at_ms?: unknown;
+}
+
+const REQUEST_TIMEOUT_MS = 5_000;
+/** How long a failed issuance suppresses retries for that user. */
+const NEGATIVE_CACHE_MS = 10 * 60 * 1000;
+
+let _state: TenantKeyStore | null = null;
+let _storePath: string | null = null;
+/** userId → epoch ms of the last failed issuance (retry suppressed until +TTL). */
+const _negativeCache = new Map<string, number>();
+/** userId → in-flight issuance, so concurrent dispatches issue at most one key. */
+const _inFlight = new Map<string, Promise<string | null>>();
+
+function storePath(): string {
+  if (_storePath === null) _storePath = path.join(DATA_DIR, 'llmux-tenant-keys.json');
+  return _storePath;
+}
+
+function emptyStore(): TenantKeyStore {
+  return { version: 1, tenants: {} };
+}
+
+/** Load persisted keys. Never throws — a corrupt file WARNs and starts empty. */
+function load(): TenantKeyStore {
+  const store = emptyStore();
+  try {
+    const parsed = JSON.parse(fs.readFileSync(storePath(), 'utf-8')) as Partial<TenantKeyStore>;
+    if (parsed?.tenants && typeof parsed.tenants === 'object') {
+      for (const [userId, record] of Object.entries(parsed.tenants)) {
+        if (record && typeof record.id === 'string' && typeof record.secret === 'string' && record.secret !== '') {
+          store.tenants[userId] = record;
+        }
+      }
+    }
+    logger.info(`Loaded llmux tenant keys: ${Object.keys(store.tenants).length} user(s)`);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      logger.warn(`llmux-tenant-keys.json unreadable (${(err as Error).message}); starting empty`);
+    }
+  }
+  return store;
+}
+
+/** Atomic persist (tmp + rename), 0600. Failure logs but never blocks a dispatch. */
+function persist(store: TenantKeyStore): void {
+  try {
+    const target = storePath();
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const tmp = `${target}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+    fs.renameSync(tmp, target);
+    // Best effort — a pre-existing file keeps its own mode across rename on
+    // some filesystems, and a failure here must not lose the key we just got.
+    try {
+      fs.chmodSync(target, 0o600);
+    } catch {
+      /* mode is advisory here; the key is already durable */
+    }
+  } catch (err) {
+    logger.error(`Failed to persist llmux tenant keys: ${(err as Error).message}`);
+  }
+}
+
+function state(): TenantKeyStore {
+  if (_state === null) _state = load();
+  return _state;
+}
+
+/**
+ * llmux key name for a user. MUST embed `userId` so it is unique per user by
+ * construction: llmux rejects a duplicate name with 409, which is exactly the
+ * signal we self-heal from (see the 409 branch below).
+ */
+function keyName(userId: string, profile?: { name?: string }): string {
+  const name = profile?.name?.trim();
+  return name ? `${name} (${userId})` : userId;
+}
+
+async function llmuxPost<T>(pathName: string, body: unknown): Promise<{ status: number; body: T | null }> {
+  const { baseUrl } = getLlmuxSettings();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(`llmux POST ${pathName} timed out`)), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/+$/, '')}${pathName}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': getLlmuxAdminKey(),
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    let parsed: T | null = null;
+    try {
+      parsed = JSON.parse(text) as T;
+    } catch {
+      /* non-JSON body — status alone drives the decision */
+    }
+    return { status: res.status, body: parsed };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function llmuxGetKeys(): Promise<{ status: number; body: { keys?: LlmuxIssuedKey[] } | null }> {
+  const { baseUrl } = getLlmuxSettings();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error('llmux GET /llmux/keys timed out')), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/+$/, '')}/llmux/keys`, {
+      method: 'GET',
+      headers: { 'content-type': 'application/json', 'x-api-key': getLlmuxAdminKey() },
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    let parsed: { keys?: LlmuxIssuedKey[] } | null = null;
+    try {
+      parsed = JSON.parse(text) as { keys?: LlmuxIssuedKey[] };
+    } catch {
+      /* non-JSON body — treated as a miss */
+    }
+    return { status: res.status, body: parsed };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+function remember(userId: string, record: TenantKeyRecord): string {
+  const store = state();
+  store.tenants[userId] = record;
+  persist(store);
+  logger.info('issued llmux tenant key', {
+    userId,
+    keyId: record.id,
+    keyPrefix: record.keyPrefix,
+    rotated: record.rotatedAtMs !== undefined,
+  });
+  return record.secret;
+}
+
+function fail(userId: string, reason: string): null {
+  _negativeCache.set(userId, Date.now());
+  logger.warn('llmux tenant key issuance failed; falling back to the shared key', { userId, reason });
+  return null;
+}
+
+/**
+ * Recover from a 409 (name already taken): our store lost a key we issued
+ * earlier — safe to reclaim because the name embeds the Slack user id, so the
+ * existing key IS this user's. llmux only ever shows a secret once, so the key
+ * must be ROTATED to learn a usable secret again.
+ */
+async function reissueExisting(userId: string, name: string, email?: string): Promise<string | null> {
+  const listed = await llmuxGetKeys();
+  if (listed.status !== 200 || !Array.isArray(listed.body?.keys)) {
+    return fail(userId, `GET /llmux/keys → ${listed.status}`);
+  }
+  const match = listed.body.keys.find(
+    (entry) => entry && entry.name === name && (entry.revoked_at_ms === null || entry.revoked_at_ms === undefined),
+  );
+  const id = nonEmptyString(match?.id);
+  if (!id) return fail(userId, 'existing non-revoked key not found in GET /llmux/keys');
+
+  const rotated = await llmuxPost<{ key?: LlmuxIssuedKey }>('/llmux/keys/rotate', { id });
+  const secret = nonEmptyString(rotated.body?.key?.key);
+  if (rotated.status !== 200 || !secret) {
+    return fail(userId, `POST /llmux/keys/rotate → ${rotated.status}`);
+  }
+  return remember(userId, {
+    id,
+    secret,
+    keyPrefix: nonEmptyString(rotated.body?.key?.key_prefix) ?? '',
+    name,
+    ...(email ? { email } : {}),
+    issuedAtMs: Date.now(),
+    rotatedAtMs: Date.now(),
+  });
+}
+
+async function issue(userId: string, profile?: { name?: string; email?: string }): Promise<string | null> {
+  const name = keyName(userId, profile);
+  const email = profile?.email?.trim() || undefined;
+  try {
+    const created = await llmuxPost<LlmuxIssuedKey>('/llmux/keys/new', {
+      name,
+      ...(email ? { email } : {}),
+      kind: 'default',
+    });
+    if (created.status === 409) return await reissueExisting(userId, name, email);
+
+    const secret = nonEmptyString(created.body?.key);
+    const id = nonEmptyString(created.body?.id);
+    if (created.status !== 200 || !secret || !id) {
+      return fail(userId, `POST /llmux/keys/new → ${created.status}`);
+    }
+    return remember(userId, {
+      id,
+      secret,
+      keyPrefix: nonEmptyString(created.body?.key_prefix) ?? '',
+      name,
+      ...(email ? { email } : {}),
+      issuedAtMs: Date.now(),
+    });
+  } catch (err) {
+    // Network error / timeout / abort — never propagate; the dispatch continues
+    // on the shared key.
+    return fail(userId, (err as Error).message);
+  }
+}
+
+/**
+ * The llmux client key to authenticate `userId`'s dispatches with, or `null`
+ * when the caller must fall back to the shared key.
+ *
+ * `null` (never a throw) for: non-llmux auth mode, a recent issuance failure
+ * (negative-cached for 10 min so one broken llmux does not add a request per
+ * dispatch), or any llmux/network error.
+ */
+export async function ensureTenantKey(
+  userId: string,
+  profile?: { name?: string; email?: string },
+): Promise<string | null> {
+  if (getAuthMode() !== 'llmux') return null;
+  if (!userId.trim()) return null;
+
+  const existing = state().tenants[userId];
+  if (existing?.secret) return existing.secret;
+
+  const failedAt = _negativeCache.get(userId);
+  if (failedAt !== undefined && Date.now() - failedAt < NEGATIVE_CACHE_MS) return null;
+
+  const pending = _inFlight.get(userId);
+  if (pending) return pending;
+
+  const attempt = issue(userId, profile).finally(() => _inFlight.delete(userId));
+  _inFlight.set(userId, attempt);
+  return attempt;
+}
+
+/** Test-only: reset module state (and optionally point the store elsewhere). */
+export function resetLlmuxTenantKeysForTests(overridePath?: string): void {
+  _state = null;
+  _storePath = overridePath ?? null;
+  _negativeCache.clear();
+  _inFlight.clear();
+}

--- a/src/auth/llmux-tenant-keys.ts
+++ b/src/auth/llmux-tenant-keys.ts
@@ -48,9 +48,34 @@ interface TenantKeyRecord {
   rotatedAtMs?: number;
 }
 
+/**
+ * On-disk shape. Keyed `[slackUserId][normalizedBaseUrl]` — a user legitimately
+ * holds one key PER daemon (an operator can flip back and forth, and two
+ * issuances for the same user can even be in flight against different daemons
+ * at once). A flat per-user slot would let the slower issuance overwrite the
+ * other daemon's record, turning the next lookup there into a miss that
+ * force-rotates — and rotation invalidates a key that live dispatches may still
+ * be using.
+ *
+ * v1 was the flat `[slackUserId] → record` shape; {@link load} migrates it.
+ */
 interface TenantKeyStore {
-  version: 1;
-  tenants: Record<string, TenantKeyRecord>;
+  version: 2;
+  tenants: Record<string, Record<string, TenantKeyRecord>>;
+}
+
+/**
+ * The control-plane endpoint an issuance talks to: URL **and** the admin
+ * credential for exactly that URL, captured together.
+ *
+ * Both halves are snapshotted once per {@link ensureTenantKey} call and threaded
+ * through every request. Re-reading either mid-issuance is a bug: an operator
+ * flip to another daemon (with its own explicit key) would otherwise send the
+ * NEW daemon's admin secret to the OLD daemon's URL.
+ */
+interface ControlPlaneTarget {
+  baseUrl: string;
+  adminKey: string;
 }
 
 /** Response of `POST /llmux/keys/new` and `POST /llmux/keys/rotate` (`.key`). */
@@ -90,22 +115,55 @@ function storePath(): string {
 }
 
 function emptyStore(): TenantKeyStore {
-  return { version: 1, tenants: {} };
+  return { version: 2, tenants: {} };
 }
 
-/** Load persisted keys. Never throws — a corrupt file WARNs and starts empty. */
+/** A usable persisted record — anything without an id + non-empty secret is noise. */
+function isTenantKeyRecord(value: unknown): value is TenantKeyRecord {
+  const record = value as TenantKeyRecord | null;
+  return !!record && typeof record.id === 'string' && typeof record.secret === 'string' && record.secret !== '';
+}
+
+function remembered(store: TenantKeyStore, userId: string, baseUrl: string, record: TenantKeyRecord): void {
+  const byDaemon = store.tenants[userId] ?? {};
+  byDaemon[baseUrl] = { ...record, baseUrl };
+  store.tenants[userId] = byDaemon;
+}
+
+/** Load persisted keys, migrating v1. Never throws — a corrupt file WARNs and starts empty. */
 function load(): TenantKeyStore {
   const store = emptyStore();
   try {
-    const parsed = JSON.parse(fs.readFileSync(storePath(), 'utf-8')) as Partial<TenantKeyStore>;
-    if (parsed?.tenants && typeof parsed.tenants === 'object') {
-      for (const [userId, record] of Object.entries(parsed.tenants)) {
-        if (record && typeof record.id === 'string' && typeof record.secret === 'string' && record.secret !== '') {
-          store.tenants[userId] = record;
+    const parsed = JSON.parse(fs.readFileSync(storePath(), 'utf-8')) as {
+      tenants?: Record<string, unknown>;
+    };
+    let migrated = 0;
+    let dropped = 0;
+    for (const [userId, entry] of Object.entries(parsed?.tenants ?? {})) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (isTenantKeyRecord(entry)) {
+        // v1: one flat record per user. Re-nest it under the daemon it names;
+        // a record predating that field cannot be attributed to any daemon, and
+        // presenting it to the wrong one 401s — so it is dropped and re-issued.
+        const baseUrl = typeof entry.baseUrl === 'string' ? entry.baseUrl.trim() : '';
+        if (baseUrl === '') {
+          dropped += 1;
+          continue;
         }
+        remembered(store, userId, baseUrl, entry);
+        migrated += 1;
+        continue;
+      }
+      for (const [baseUrl, record] of Object.entries(entry as Record<string, unknown>)) {
+        if (baseUrl.trim() !== '' && isTenantKeyRecord(record)) remembered(store, userId, baseUrl, record);
       }
     }
-    logger.info(`Loaded llmux tenant keys: ${Object.keys(store.tenants).length} user(s)`);
+    const keys = Object.values(store.tenants).reduce((n, byDaemon) => n + Object.keys(byDaemon).length, 0);
+    logger.info(`Loaded llmux tenant keys: ${keys} key(s) for ${Object.keys(store.tenants).length} user(s)`);
+    if (migrated > 0) logger.info(`Migrated ${migrated} v1 tenant key record(s) to the per-daemon layout`);
+    if (dropped > 0) {
+      logger.warn(`Dropped ${dropped} v1 tenant key record(s) with no daemon attribution; they will be re-issued`);
+    }
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== 'ENOENT') {
@@ -170,20 +228,20 @@ function currentBaseUrl(): string {
 }
 
 async function llmuxPost<T>(
-  base: string,
+  target: ControlPlaneTarget,
   pathName: string,
   body: unknown,
 ): Promise<{ status: number; body: T | null }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error(`llmux POST ${pathName} timed out`)), REQUEST_TIMEOUT_MS);
   try {
-    const res = await fetch(`${base}${pathName}`, {
+    const res = await fetch(`${target.baseUrl}${pathName}`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        // Resolved against the URL we are actually posting to — the admin
-        // credential must never be sent to a daemon it does not belong to.
-        'x-api-key': getLlmuxAdminKey(base),
+        // From the captured target — the admin credential and the URL it was
+        // resolved for always travel together.
+        'x-api-key': target.adminKey,
       },
       body: JSON.stringify(body),
       signal: controller.signal,
@@ -201,13 +259,15 @@ async function llmuxPost<T>(
   }
 }
 
-async function llmuxGetKeys(base: string): Promise<{ status: number; body: { keys?: LlmuxIssuedKey[] } | null }> {
+async function llmuxGetKeys(
+  target: ControlPlaneTarget,
+): Promise<{ status: number; body: { keys?: LlmuxIssuedKey[] } | null }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error('llmux GET /llmux/keys timed out')), REQUEST_TIMEOUT_MS);
   try {
-    const res = await fetch(`${base}/llmux/keys`, {
+    const res = await fetch(`${target.baseUrl}/llmux/keys`, {
       method: 'GET',
-      headers: { 'content-type': 'application/json', 'x-api-key': getLlmuxAdminKey(base) },
+      headers: { 'content-type': 'application/json', 'x-api-key': target.adminKey },
       signal: controller.signal,
     });
     const text = await res.text();
@@ -245,7 +305,9 @@ export interface TenantKeyLease {
 
 function remember(userId: string, record: TenantKeyRecord): TenantKeyLease {
   const store = state();
-  store.tenants[userId] = record;
+  // Slot is (user, daemon): a concurrent issuance for the same user against a
+  // DIFFERENT daemon must survive, whichever finishes last.
+  remembered(store, userId, record.baseUrl, record);
   persist(store);
   logger.info('issued llmux tenant key', {
     userId,
@@ -266,9 +328,9 @@ function fail(userId: string, baseUrl: string, reason: string): null {
 /** Outcome of looking this user up in llmux's key list. */
 type ExistingKeyLookup = { ok: true; key: { id: string; name: string } | null } | { ok: false; reason: string };
 
-/** The user's live (non-revoked) key on the daemon at `base`, per {@link isUsersKeyName}. */
-async function findExistingKey(base: string, userId: string): Promise<ExistingKeyLookup> {
-  const listed = await llmuxGetKeys(base);
+/** The user's live (non-revoked) key on the target daemon, per {@link isUsersKeyName}. */
+async function findExistingKey(target: ControlPlaneTarget, userId: string): Promise<ExistingKeyLookup> {
+  const listed = await llmuxGetKeys(target);
   if (listed.status !== 200 || !Array.isArray(listed.body?.keys)) {
     return { ok: false, reason: `GET /llmux/keys → ${listed.status}` };
   }
@@ -294,19 +356,19 @@ async function rotateExisting(
   userId: string,
   key: { id: string; name: string },
   email: string | undefined,
-  baseUrl: string,
+  target: ControlPlaneTarget,
 ): Promise<TenantKeyLease | null> {
-  const rotated = await llmuxPost<{ key?: LlmuxIssuedKey }>(baseUrl, '/llmux/keys/rotate', { id: key.id });
+  const rotated = await llmuxPost<{ key?: LlmuxIssuedKey }>(target, '/llmux/keys/rotate', { id: key.id });
   const secret = nonEmptyString(rotated.body?.key?.key);
   if (rotated.status !== 200 || !secret) {
-    return fail(userId, baseUrl, `POST /llmux/keys/rotate → ${rotated.status}`);
+    return fail(userId, target.baseUrl, `POST /llmux/keys/rotate → ${rotated.status}`);
   }
   return remember(userId, {
     id: key.id,
     secret,
     keyPrefix: nonEmptyString(rotated.body?.key?.key_prefix) ?? '',
     name: key.name,
-    baseUrl,
+    baseUrl: target.baseUrl,
     ...(email ? { email } : {}),
     issuedAtMs: Date.now(),
     rotatedAtMs: Date.now(),
@@ -314,17 +376,19 @@ async function rotateExisting(
 }
 
 /**
- * Issue (or reclaim) this user's key at `baseUrl`. `baseUrl` is passed in, never
- * re-read: every request, cache entry and the returned lease must describe ONE
- * daemon even if an operator flips the setting mid-issuance.
+ * Issue (or reclaim) this user's key at `target`. The target (URL + its admin
+ * credential) is passed in and never re-read: every request, cache entry and the
+ * returned lease must describe ONE daemon even if an operator flips the settings
+ * mid-issuance.
  */
 async function issue(
   userId: string,
-  baseUrl: string,
+  target: ControlPlaneTarget,
   profile?: { name?: string; email?: string },
 ): Promise<TenantKeyLease | null> {
   const name = keyName(userId, profile);
   const email = profile?.email?.trim() || undefined;
+  const baseUrl = target.baseUrl;
   try {
     // Reclaim BEFORE creating. A user whose display name changed since their
     // first issuance would otherwise create a second key under the new name
@@ -336,11 +400,11 @@ async function issue(
     // exactly how a transient 500 mints a duplicate tenant. Degrade to the
     // shared key instead; the next dispatch after the negative-cache window
     // retries.
-    const existing = await findExistingKey(baseUrl, userId);
+    const existing = await findExistingKey(target, userId);
     if (!existing.ok) return fail(userId, baseUrl, `preflight ${existing.reason}`);
-    if (existing.key) return await rotateExisting(userId, existing.key, email, baseUrl);
+    if (existing.key) return await rotateExisting(userId, existing.key, email, target);
 
-    const created = await llmuxPost<LlmuxIssuedKey>(baseUrl, '/llmux/keys/new', {
+    const created = await llmuxPost<LlmuxIssuedKey>(target, '/llmux/keys/new', {
       name,
       ...(email ? { email } : {}),
       kind: 'default',
@@ -348,10 +412,10 @@ async function issue(
     if (created.status === 409) {
       // Race fallback: someone issued this user's key between our (successful,
       // empty) listing and our create. Re-list and reclaim.
-      const raced = await findExistingKey(baseUrl, userId);
+      const raced = await findExistingKey(target, userId);
       if (!raced.ok) return fail(userId, baseUrl, raced.reason);
       if (!raced.key) return fail(userId, baseUrl, 'existing non-revoked key not found in GET /llmux/keys');
-      return await rotateExisting(userId, raced.key, email, baseUrl);
+      return await rotateExisting(userId, raced.key, email, target);
     }
 
     const secret = nonEmptyString(created.body?.key);
@@ -384,9 +448,10 @@ async function issue(
  * (negative-cached for 10 min so one broken llmux does not add a request per
  * dispatch), or any llmux/network error.
  *
- * The daemon is snapshotted ONCE here and threaded through the store lookup,
- * both caches, every HTTP call and the returned lease, so the result is always
- * an internally coherent pair even if the live setting changes meanwhile.
+ * The target daemon — its URL AND the admin credential resolved for that URL —
+ * is snapshotted ONCE here and threaded through the store lookup, both caches,
+ * every HTTP call and the returned lease, so the result is always internally
+ * coherent even if the live settings change meanwhile.
  */
 export async function ensureTenantKey(
   userId: string,
@@ -395,12 +460,12 @@ export async function ensureTenantKey(
   if (getAuthMode() !== 'llmux') return null;
   if (!userId.trim()) return null;
 
-  // Store hit only counts for the daemon that issued it. A record written
-  // before this field existed has no `baseUrl` and is likewise a miss —
-  // issuance overwrites it.
   const baseUrl = currentBaseUrl();
-  const existing = state().tenants[userId];
-  if (existing?.secret && existing.baseUrl === baseUrl) return { secret: existing.secret, baseUrl };
+  const target: ControlPlaneTarget = { baseUrl, adminKey: getLlmuxAdminKey(baseUrl) };
+
+  // Store hit only counts for the daemon that issued the key.
+  const existing = state().tenants[userId]?.[baseUrl];
+  if (existing?.secret) return { secret: existing.secret, baseUrl };
 
   const cacheKey = tenantCacheKey(baseUrl, userId);
   const failedAt = _negativeCache.get(cacheKey);
@@ -409,7 +474,7 @@ export async function ensureTenantKey(
   const pending = _inFlight.get(cacheKey);
   if (pending) return pending;
 
-  const attempt = issue(userId, baseUrl, profile).finally(() => _inFlight.delete(cacheKey));
+  const attempt = issue(userId, target, profile).finally(() => _inFlight.delete(cacheKey));
   _inFlight.set(cacheKey, attempt);
   return attempt;
 }

--- a/src/auth/llmux-tenant-keys.ts
+++ b/src/auth/llmux-tenant-keys.ts
@@ -32,8 +32,17 @@ interface TenantKeyRecord {
   secret: string;
   /** Non-secret display prefix llmux returns alongside the secret. */
   keyPrefix: string;
-  /** llmux key name — `${slackName} (${userId})`, unique per user by construction. */
+  /** llmux key name as the issuing daemon holds it (see {@link isUsersKeyName}). */
   name: string;
+  /**
+   * Normalized base URL of the llmux daemon that issued this key. A key only
+   * means anything to its issuer, so a record is reused ONLY while the live
+   * `baseUrl` still matches; re-pointing soma-work at another llmux re-issues
+   * instead of presenting a secret the new daemon never saw — which would 401
+   * the dispatch WITHOUT engaging the shared-key fallback, since a stored
+   * secret makes `ensureTenantKey` return non-null.
+   */
+  baseUrl: string;
   email?: string;
   issuedAtMs: number;
   rotatedAtMs?: number;
@@ -122,21 +131,39 @@ function state(): TenantKeyStore {
 }
 
 /**
- * llmux key name for a user. MUST embed `userId` so it is unique per user by
- * construction: llmux rejects a duplicate name with 409, which is exactly the
- * signal we self-heal from (see the 409 branch below).
+ * llmux key name for a user. MUST embed `userId`: the Slack id is the only
+ * immutable part of a user's identity here, and it is what makes an existing
+ * key re-identifiable as theirs (see {@link isUsersKeyName}).
  */
 function keyName(userId: string, profile?: { name?: string }): string {
   const name = profile?.name?.trim();
   return name ? `${name} (${userId})` : userId;
 }
 
+/**
+ * Whether an llmux key name denotes `userId` — the display-name-independent
+ * counterpart of {@link keyName}.
+ *
+ * Reclaim MUST NOT depend on the display name: it is mutable (Slack profile
+ * edits) and may have been unknown at first issuance, so an exact-name match
+ * would miss the user's existing key and mint a SECOND one, splitting their
+ * billing history across two llmux tenants. Matching the immutable
+ * `…(userId)` marker (or the bare id) makes reclaim deterministic.
+ */
+function isUsersKeyName(name: string, userId: string): boolean {
+  return name === userId || name.endsWith(`(${userId})`);
+}
+
+/** Live llmux base URL, trailing slashes stripped — the form stored on records. */
+function currentBaseUrl(): string {
+  return getLlmuxSettings().baseUrl.replace(/\/+$/, '');
+}
+
 async function llmuxPost<T>(pathName: string, body: unknown): Promise<{ status: number; body: T | null }> {
-  const { baseUrl } = getLlmuxSettings();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error(`llmux POST ${pathName} timed out`)), REQUEST_TIMEOUT_MS);
   try {
-    const res = await fetch(`${baseUrl.replace(/\/+$/, '')}${pathName}`, {
+    const res = await fetch(`${currentBaseUrl()}${pathName}`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -159,11 +186,10 @@ async function llmuxPost<T>(pathName: string, body: unknown): Promise<{ status: 
 }
 
 async function llmuxGetKeys(): Promise<{ status: number; body: { keys?: LlmuxIssuedKey[] } | null }> {
-  const { baseUrl } = getLlmuxSettings();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error('llmux GET /llmux/keys timed out')), REQUEST_TIMEOUT_MS);
   try {
-    const res = await fetch(`${baseUrl.replace(/\/+$/, '')}/llmux/keys`, {
+    const res = await fetch(`${currentBaseUrl()}/llmux/keys`, {
       method: 'GET',
       headers: { 'content-type': 'application/json', 'x-api-key': getLlmuxAdminKey() },
       signal: controller.signal,
@@ -204,33 +230,50 @@ function fail(userId: string, reason: string): null {
   return null;
 }
 
-/**
- * Recover from a 409 (name already taken): our store lost a key we issued
- * earlier — safe to reclaim because the name embeds the Slack user id, so the
- * existing key IS this user's. llmux only ever shows a secret once, so the key
- * must be ROTATED to learn a usable secret again.
- */
-async function reissueExisting(userId: string, name: string, email?: string): Promise<string | null> {
+/** Outcome of looking this user up in llmux's key list. */
+type ExistingKeyLookup = { ok: true; key: { id: string; name: string } | null } | { ok: false; reason: string };
+
+/** The user's live (non-revoked) key on the current daemon, per {@link isUsersKeyName}. */
+async function findExistingKey(userId: string): Promise<ExistingKeyLookup> {
   const listed = await llmuxGetKeys();
   if (listed.status !== 200 || !Array.isArray(listed.body?.keys)) {
-    return fail(userId, `GET /llmux/keys → ${listed.status}`);
+    return { ok: false, reason: `GET /llmux/keys → ${listed.status}` };
   }
   const match = listed.body.keys.find(
-    (entry) => entry && entry.name === name && (entry.revoked_at_ms === null || entry.revoked_at_ms === undefined),
+    (entry) =>
+      entry &&
+      typeof entry.name === 'string' &&
+      isUsersKeyName(entry.name, userId) &&
+      (entry.revoked_at_ms === null || entry.revoked_at_ms === undefined),
   );
   const id = nonEmptyString(match?.id);
-  if (!id) return fail(userId, 'existing non-revoked key not found in GET /llmux/keys');
+  const name = typeof match?.name === 'string' ? match.name : '';
+  return { ok: true, key: id ? { id, name } : null };
+}
 
-  const rotated = await llmuxPost<{ key?: LlmuxIssuedKey }>('/llmux/keys/rotate', { id });
+/**
+ * Take ownership of a key llmux already holds for this user (our store lost the
+ * secret, or this soma-work never had it). llmux shows a secret exactly once, so
+ * the only way back to a usable secret is a ROTATE. The key keeps its existing
+ * name — llmux has no rename, and the name is display-only.
+ */
+async function rotateExisting(
+  userId: string,
+  key: { id: string; name: string },
+  email: string | undefined,
+  baseUrl: string,
+): Promise<string | null> {
+  const rotated = await llmuxPost<{ key?: LlmuxIssuedKey }>('/llmux/keys/rotate', { id: key.id });
   const secret = nonEmptyString(rotated.body?.key?.key);
   if (rotated.status !== 200 || !secret) {
     return fail(userId, `POST /llmux/keys/rotate → ${rotated.status}`);
   }
   return remember(userId, {
-    id,
+    id: key.id,
     secret,
     keyPrefix: nonEmptyString(rotated.body?.key?.key_prefix) ?? '',
-    name,
+    name: key.name,
+    baseUrl,
     ...(email ? { email } : {}),
     issuedAtMs: Date.now(),
     rotatedAtMs: Date.now(),
@@ -240,13 +283,28 @@ async function reissueExisting(userId: string, name: string, email?: string): Pr
 async function issue(userId: string, profile?: { name?: string; email?: string }): Promise<string | null> {
   const name = keyName(userId, profile);
   const email = profile?.email?.trim() || undefined;
+  const baseUrl = currentBaseUrl();
   try {
+    // Reclaim BEFORE creating. A user whose display name changed since their
+    // first issuance would otherwise create a second key under the new name
+    // (no 409, because the names differ) and split their billing history.
+    // Costs one GET per issuance — i.e. per user per store lifetime.
+    const existing = await findExistingKey(userId);
+    if (existing.ok && existing.key) return await rotateExisting(userId, existing.key, email, baseUrl);
+
     const created = await llmuxPost<LlmuxIssuedKey>('/llmux/keys/new', {
       name,
       ...(email ? { email } : {}),
       kind: 'default',
     });
-    if (created.status === 409) return await reissueExisting(userId, name, email);
+    if (created.status === 409) {
+      // Race fallback: someone issued this user's key between our list and our
+      // create (or the list call itself failed above). Re-list and reclaim.
+      const raced = await findExistingKey(userId);
+      if (!raced.ok) return fail(userId, raced.reason);
+      if (!raced.key) return fail(userId, 'existing non-revoked key not found in GET /llmux/keys');
+      return await rotateExisting(userId, raced.key, email, baseUrl);
+    }
 
     const secret = nonEmptyString(created.body?.key);
     const id = nonEmptyString(created.body?.id);
@@ -258,6 +316,7 @@ async function issue(userId: string, profile?: { name?: string; email?: string }
       secret,
       keyPrefix: nonEmptyString(created.body?.key_prefix) ?? '',
       name,
+      baseUrl,
       ...(email ? { email } : {}),
       issuedAtMs: Date.now(),
     });
@@ -283,8 +342,11 @@ export async function ensureTenantKey(
   if (getAuthMode() !== 'llmux') return null;
   if (!userId.trim()) return null;
 
+  // Store hit only counts for the daemon that issued it. A record written
+  // before this field existed has no `baseUrl` and is likewise a miss —
+  // issuance overwrites it.
   const existing = state().tenants[userId];
-  if (existing?.secret) return existing.secret;
+  if (existing?.secret && existing.baseUrl === currentBaseUrl()) return existing.secret;
 
   const failedAt = _negativeCache.get(userId);
   if (failedAt !== undefined && Date.now() - failedAt < NEGATIVE_CACHE_MS) return null;

--- a/src/auth/llmux-tenant-keys.ts
+++ b/src/auth/llmux-tenant-keys.ts
@@ -72,7 +72,7 @@ let _storePath: string | null = null;
 /** {@link tenantCacheKey} → epoch ms of the last failed issuance (retry suppressed until +TTL). */
 const _negativeCache = new Map<string, number>();
 /** {@link tenantCacheKey} → in-flight issuance, so concurrent dispatches issue at most one key. */
-const _inFlight = new Map<string, Promise<string | null>>();
+const _inFlight = new Map<string, Promise<TenantKeyLease | null>>();
 
 /**
  * Both per-user caches are scoped to the DAEMON as well as the user: a key is
@@ -169,8 +169,11 @@ function currentBaseUrl(): string {
   return getLlmuxSettings().baseUrl.replace(/\/+$/, '');
 }
 
-async function llmuxPost<T>(pathName: string, body: unknown): Promise<{ status: number; body: T | null }> {
-  const base = currentBaseUrl();
+async function llmuxPost<T>(
+  base: string,
+  pathName: string,
+  body: unknown,
+): Promise<{ status: number; body: T | null }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error(`llmux POST ${pathName} timed out`)), REQUEST_TIMEOUT_MS);
   try {
@@ -198,8 +201,7 @@ async function llmuxPost<T>(pathName: string, body: unknown): Promise<{ status: 
   }
 }
 
-async function llmuxGetKeys(): Promise<{ status: number; body: { keys?: LlmuxIssuedKey[] } | null }> {
-  const base = currentBaseUrl();
+async function llmuxGetKeys(base: string): Promise<{ status: number; body: { keys?: LlmuxIssuedKey[] } | null }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error('llmux GET /llmux/keys timed out')), REQUEST_TIMEOUT_MS);
   try {
@@ -225,7 +227,23 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() !== '' ? value : null;
 }
 
-function remember(userId: string, record: TenantKeyRecord): string {
+/**
+ * A usable tenant credential together with the daemon it is usable AT.
+ *
+ * The pair must travel together: an operator can flip `baseUrl` while an
+ * issuance is in flight (or between the caller's `await` and its env build), and
+ * pairing daemon A's secret with daemon B's URL yields a 401 on B instead of the
+ * intended shared-key degradation. Consumers (`buildQueryEnv`) therefore take
+ * BOTH fields from the lease rather than re-reading the live settings.
+ */
+export interface TenantKeyLease {
+  /** Plaintext `lmk-…` secret. NEVER log this. */
+  secret: string;
+  /** Normalized baseUrl of the daemon that issued/validated this secret. */
+  baseUrl: string;
+}
+
+function remember(userId: string, record: TenantKeyRecord): TenantKeyLease {
   const store = state();
   store.tenants[userId] = record;
   persist(store);
@@ -233,9 +251,10 @@ function remember(userId: string, record: TenantKeyRecord): string {
     userId,
     keyId: record.id,
     keyPrefix: record.keyPrefix,
+    baseUrl: record.baseUrl,
     rotated: record.rotatedAtMs !== undefined,
   });
-  return record.secret;
+  return { secret: record.secret, baseUrl: record.baseUrl };
 }
 
 function fail(userId: string, baseUrl: string, reason: string): null {
@@ -247,9 +266,9 @@ function fail(userId: string, baseUrl: string, reason: string): null {
 /** Outcome of looking this user up in llmux's key list. */
 type ExistingKeyLookup = { ok: true; key: { id: string; name: string } | null } | { ok: false; reason: string };
 
-/** The user's live (non-revoked) key on the current daemon, per {@link isUsersKeyName}. */
-async function findExistingKey(userId: string): Promise<ExistingKeyLookup> {
-  const listed = await llmuxGetKeys();
+/** The user's live (non-revoked) key on the daemon at `base`, per {@link isUsersKeyName}. */
+async function findExistingKey(base: string, userId: string): Promise<ExistingKeyLookup> {
+  const listed = await llmuxGetKeys(base);
   if (listed.status !== 200 || !Array.isArray(listed.body?.keys)) {
     return { ok: false, reason: `GET /llmux/keys → ${listed.status}` };
   }
@@ -276,8 +295,8 @@ async function rotateExisting(
   key: { id: string; name: string },
   email: string | undefined,
   baseUrl: string,
-): Promise<string | null> {
-  const rotated = await llmuxPost<{ key?: LlmuxIssuedKey }>('/llmux/keys/rotate', { id: key.id });
+): Promise<TenantKeyLease | null> {
+  const rotated = await llmuxPost<{ key?: LlmuxIssuedKey }>(baseUrl, '/llmux/keys/rotate', { id: key.id });
   const secret = nonEmptyString(rotated.body?.key?.key);
   if (rotated.status !== 200 || !secret) {
     return fail(userId, baseUrl, `POST /llmux/keys/rotate → ${rotated.status}`);
@@ -294,10 +313,18 @@ async function rotateExisting(
   });
 }
 
-async function issue(userId: string, profile?: { name?: string; email?: string }): Promise<string | null> {
+/**
+ * Issue (or reclaim) this user's key at `baseUrl`. `baseUrl` is passed in, never
+ * re-read: every request, cache entry and the returned lease must describe ONE
+ * daemon even if an operator flips the setting mid-issuance.
+ */
+async function issue(
+  userId: string,
+  baseUrl: string,
+  profile?: { name?: string; email?: string },
+): Promise<TenantKeyLease | null> {
   const name = keyName(userId, profile);
   const email = profile?.email?.trim() || undefined;
-  const baseUrl = currentBaseUrl();
   try {
     // Reclaim BEFORE creating. A user whose display name changed since their
     // first issuance would otherwise create a second key under the new name
@@ -309,11 +336,11 @@ async function issue(userId: string, profile?: { name?: string; email?: string }
     // exactly how a transient 500 mints a duplicate tenant. Degrade to the
     // shared key instead; the next dispatch after the negative-cache window
     // retries.
-    const existing = await findExistingKey(userId);
+    const existing = await findExistingKey(baseUrl, userId);
     if (!existing.ok) return fail(userId, baseUrl, `preflight ${existing.reason}`);
     if (existing.key) return await rotateExisting(userId, existing.key, email, baseUrl);
 
-    const created = await llmuxPost<LlmuxIssuedKey>('/llmux/keys/new', {
+    const created = await llmuxPost<LlmuxIssuedKey>(baseUrl, '/llmux/keys/new', {
       name,
       ...(email ? { email } : {}),
       kind: 'default',
@@ -321,7 +348,7 @@ async function issue(userId: string, profile?: { name?: string; email?: string }
     if (created.status === 409) {
       // Race fallback: someone issued this user's key between our (successful,
       // empty) listing and our create. Re-list and reclaim.
-      const raced = await findExistingKey(userId);
+      const raced = await findExistingKey(baseUrl, userId);
       if (!raced.ok) return fail(userId, baseUrl, raced.reason);
       if (!raced.key) return fail(userId, baseUrl, 'existing non-revoked key not found in GET /llmux/keys');
       return await rotateExisting(userId, raced.key, email, baseUrl);
@@ -349,17 +376,22 @@ async function issue(userId: string, profile?: { name?: string; email?: string }
 }
 
 /**
- * The llmux client key to authenticate `userId`'s dispatches with, or `null`
- * when the caller must fall back to the shared key.
+ * The llmux credential to authenticate `userId`'s dispatches with — as a
+ * {@link TenantKeyLease} (secret + the daemon it belongs to) — or `null` when
+ * the caller must fall back to the shared key.
  *
  * `null` (never a throw) for: non-llmux auth mode, a recent issuance failure
  * (negative-cached for 10 min so one broken llmux does not add a request per
  * dispatch), or any llmux/network error.
+ *
+ * The daemon is snapshotted ONCE here and threaded through the store lookup,
+ * both caches, every HTTP call and the returned lease, so the result is always
+ * an internally coherent pair even if the live setting changes meanwhile.
  */
 export async function ensureTenantKey(
   userId: string,
   profile?: { name?: string; email?: string },
-): Promise<string | null> {
+): Promise<TenantKeyLease | null> {
   if (getAuthMode() !== 'llmux') return null;
   if (!userId.trim()) return null;
 
@@ -368,7 +400,7 @@ export async function ensureTenantKey(
   // issuance overwrites it.
   const baseUrl = currentBaseUrl();
   const existing = state().tenants[userId];
-  if (existing?.secret && existing.baseUrl === baseUrl) return existing.secret;
+  if (existing?.secret && existing.baseUrl === baseUrl) return { secret: existing.secret, baseUrl };
 
   const cacheKey = tenantCacheKey(baseUrl, userId);
   const failedAt = _negativeCache.get(cacheKey);
@@ -377,7 +409,7 @@ export async function ensureTenantKey(
   const pending = _inFlight.get(cacheKey);
   if (pending) return pending;
 
-  const attempt = issue(userId, profile).finally(() => _inFlight.delete(cacheKey));
+  const attempt = issue(userId, baseUrl, profile).finally(() => _inFlight.delete(cacheKey));
   _inFlight.set(cacheKey, attempt);
   return attempt;
 }

--- a/src/auth/query-env-builder.ts
+++ b/src/auth/query-env-builder.ts
@@ -1,5 +1,6 @@
 import type { SlotAuthLease } from '../credentials-manager';
 import { getAuthMode, getLlmuxSettings } from './auth-runtime';
+import type { TenantKeyLease } from './llmux-tenant-keys';
 
 /**
  * Result of {@link buildQueryEnv}: a fresh env map suitable for the Claude
@@ -17,10 +18,11 @@ export interface QueryEnvResult {
 /** Per-call inputs that only some dispatches can supply. */
 export interface QueryEnvOptions {
   /**
-   * Per-user llmux client key (`lmk-…`) from `ensureTenantKey`; llmux mode
-   * only. `null`/omitted → the shared key (legacy tenant).
+   * Per-user llmux credential from `ensureTenantKey` — the secret AND the
+   * daemon it is valid at; llmux mode only. `null`/omitted → the shared key
+   * against the live daemon (legacy tenant).
    */
-  llmuxTenantKey?: string | null;
+  llmuxTenant?: TenantKeyLease | null;
 }
 
 /**
@@ -118,11 +120,15 @@ export function getQueryEnvAdditional(): Record<string, string> {
  *          overridden by config.
  *        - `'llmux'`: set `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY` and DELETE
  *          `CLAUDE_CODE_OAUTH_TOKEN` so the local llmux proxy owns upstream
- *          auth. The lease token is unused in this mode. The API key is
- *          `opts.llmuxTenantKey` (the triggering user's own llmux client key,
- *          so llmux meters them as their own tenant) when the dispatch has a
- *          user identity; the shared key remains the fallback and is what
- *          identity-less system dispatches use (the legacy tenant).
+ *          auth. The lease token is unused in this mode. When the dispatch has
+ *          a user identity, BOTH values come from `opts.llmuxTenant` — the
+ *          triggering user's own llmux client key and the daemon that issued
+ *          it, taken as an atomic pair so a mid-dispatch daemon flip can never
+ *          combine one daemon's key with another's URL (the flip applies from
+ *          the next dispatch, matching auth-runtime's "in-flight calls keep the
+ *          env they were built with" contract). Without a tenant lease the live
+ *          settings + shared key are used — what identity-less system
+ *          dispatches run on (the legacy tenant).
  *
  * Contract:
  *   - NEVER mutates `process.env`.
@@ -178,11 +184,14 @@ export function buildQueryEnv(lease: SlotAuthLease, opts?: QueryEnvOptions): Que
     // otherwise silently bypass the proxy. `lease.accessToken` is intentionally
     // unused here; the synthetic llmux lease carries the placeholder key for
     // symmetry only.
+    // Per-user tenant credential when the dispatch knows who triggered it (so
+    // llmux meters that user separately), else the live shared settings. URL
+    // and key ALWAYS come from the same source — mixing a tenant key with a
+    // different daemon's URL 401s instead of degrading to the shared key.
     const llmux = getLlmuxSettings();
-    env.ANTHROPIC_BASE_URL = llmux.baseUrl;
-    // Per-user tenant key when the dispatch knows who triggered it, so llmux
-    // meters that user separately; shared key otherwise (legacy tenant).
-    env.ANTHROPIC_API_KEY = opts?.llmuxTenantKey || llmux.apiKey;
+    const tenant = opts?.llmuxTenant;
+    env.ANTHROPIC_BASE_URL = tenant ? tenant.baseUrl : llmux.baseUrl;
+    env.ANTHROPIC_API_KEY = tenant ? tenant.secret : llmux.apiKey;
     delete env.CLAUDE_CODE_OAUTH_TOKEN;
     return { env };
   }

--- a/src/auth/query-env-builder.ts
+++ b/src/auth/query-env-builder.ts
@@ -14,6 +14,15 @@ export interface QueryEnvResult {
   env: Record<string, string>;
 }
 
+/** Per-call inputs that only some dispatches can supply. */
+export interface QueryEnvOptions {
+  /**
+   * Per-user llmux client key (`lmk-…`) from `ensureTenantKey`; llmux mode
+   * only. `null`/omitted → the shared key (legacy tenant).
+   */
+  llmuxTenantKey?: string | null;
+}
+
 /**
  * Reserved env keys that operators MUST NOT set via `config.json#claude.env`.
  *
@@ -107,9 +116,13 @@ export function getQueryEnvAdditional(): Record<string, string> {
  *          ALWAYS last — defense in depth even if the load-time denylist in
  *          `parseClaudeEnv` is bypassed, the lease's fresh token cannot be
  *          overridden by config.
- *        - `'llmux'`: set `ANTHROPIC_BASE_URL` + throwaway `ANTHROPIC_API_KEY`
- *          and DELETE `CLAUDE_CODE_OAUTH_TOKEN` so the local llmux proxy owns
- *          upstream auth. The lease token is unused in this mode.
+ *        - `'llmux'`: set `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY` and DELETE
+ *          `CLAUDE_CODE_OAUTH_TOKEN` so the local llmux proxy owns upstream
+ *          auth. The lease token is unused in this mode. The API key is
+ *          `opts.llmuxTenantKey` (the triggering user's own llmux client key,
+ *          so llmux meters them as their own tenant) when the dispatch has a
+ *          user identity; the shared key remains the fallback and is what
+ *          identity-less system dispatches use (the legacy tenant).
  *
  * Contract:
  *   - NEVER mutates `process.env`.
@@ -125,7 +138,7 @@ export function getQueryEnvAdditional(): Record<string, string> {
  *   - `api_key` lease kind + `ANTHROPIC_API_KEY` env var.
  *   - `CLAUDE_CONFIG_DIR` credential-directory isolation.
  */
-export function buildQueryEnv(lease: SlotAuthLease): QueryEnvResult {
+export function buildQueryEnv(lease: SlotAuthLease, opts?: QueryEnvOptions): QueryEnvResult {
   // Shallow-copy process.env into a plain record. process.env is a proxy
   // whose enumerable string values are what Node forwards to subprocesses,
   // so copying owned string entries is both correct and explicit.
@@ -158,15 +171,18 @@ export function buildQueryEnv(lease: SlotAuthLease): QueryEnvResult {
   // boot-time default only.
   if (getAuthMode() === 'llmux') {
     // llmux mode: the local proxy (https://github.com/2lab-ai/llmux) owns the
-    // real upstream account pool. Point the SDK at it with a throwaway API key
-    // and SUPPRESS the OAuth token — Claude Code prefers CLAUDE_CODE_OAUTH_TOKEN
-    // over ANTHROPIC_API_KEY when both are present, so an inherited token from
-    // process.env (or a future code path) would otherwise silently bypass the
-    // proxy. `lease.accessToken` is intentionally unused here; the synthetic
-    // llmux lease carries the placeholder key for symmetry only.
+    // real upstream account pool. Point the SDK at it with the caller's llmux
+    // key and SUPPRESS the OAuth token — Claude Code prefers
+    // CLAUDE_CODE_OAUTH_TOKEN over ANTHROPIC_API_KEY when both are present, so
+    // an inherited token from process.env (or a future code path) would
+    // otherwise silently bypass the proxy. `lease.accessToken` is intentionally
+    // unused here; the synthetic llmux lease carries the placeholder key for
+    // symmetry only.
     const llmux = getLlmuxSettings();
     env.ANTHROPIC_BASE_URL = llmux.baseUrl;
-    env.ANTHROPIC_API_KEY = llmux.apiKey;
+    // Per-user tenant key when the dispatch knows who triggered it, so llmux
+    // meters that user separately; shared key otherwise (legacy tenant).
+    env.ANTHROPIC_API_KEY = opts?.llmuxTenantKey || llmux.apiKey;
     delete env.CLAUDE_CODE_OAUTH_TOKEN;
     return { env };
   }

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -940,12 +940,14 @@ export class ClaudeHandler {
       // variable — concurrent streams holding leases on different slots
       // therefore cannot clobber each other's auth.
       //
-      // Per-user llmux tenant key (multi-tenant metering): attribute this
-      // stream's tokens to the triggering Slack user. Null (issuance
+      // Per-user llmux tenant credential (multi-tenant metering): attribute
+      // this stream's tokens to the triggering Slack user. Null (issuance
       // unavailable / ccp mode) falls back to the shared key = legacy tenant.
+      // The lease carries the daemon it belongs to, so an llmux switch during
+      // issuance cannot pair this key with a different daemon's URL.
       const tenantUserId = session?.currentInitiatorId || session?.userId || slackContext?.user;
-      const llmuxTenantKey = tenantUserId ? await ensureTenantKey(tenantUserId, tenantKeyProfile(tenantUserId)) : null;
-      const { env: queryEnv } = buildQueryEnv(lease, { llmuxTenantKey });
+      const llmuxTenant = tenantUserId ? await ensureTenantKey(tenantUserId, tenantKeyProfile(tenantUserId)) : null;
+      const { env: queryEnv } = buildQueryEnv(lease, { llmuxTenant });
       const { options, getStderrBuffer } = await buildStreamOptions(
         { queryEnv, session, abortController, workingDirectory, slackContext },
         {

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -16,6 +16,7 @@ import { type AgentRunOptions, type AgentStreamEvent, runAgentStream, runOneShot
 import { buildStreamOptions } from './agent-runtime/claude-code/build-stream-options';
 import type { SafetyClassifier } from './agent-runtime/policy/safety-classifier';
 import { buildSafetyClassifier } from './agent-runtime/policy/safety-classifier-factory';
+import { ensureTenantKey } from './auth/llmux-tenant-keys';
 import { buildQueryEnv } from './auth/query-env-builder';
 import { Logger } from './logger';
 import type { McpManager } from './mcp-manager';
@@ -76,7 +77,7 @@ import { McpConfigBuilder, type SlackContext } from './mcp-config-builder';
 import { getAvailablePersonas, PromptBuilder } from './prompt-builder';
 import { type CrashRecoveredSession, SessionExpiryCallbacks, SessionRegistry } from './session-registry';
 import { getTokenManager } from './token-manager';
-import { DEFAULT_SHOW_THINKING, type EffortLevel } from './user-settings-store';
+import { DEFAULT_SHOW_THINKING, type EffortLevel, userSettingsStore } from './user-settings-store';
 
 /** Heartbeat interval for long-running Claude CLI calls. */
 const CLAUDE_LEASE_HEARTBEAT_MS = 5 * 60 * 1000;
@@ -102,6 +103,16 @@ class UsageLimitDispatchError extends Error {
     super(`Claude usage limit hit during one-shot dispatch: ${capNotice.slice(0, 200)}`);
     this.name = 'UsageLimitDispatchError';
   }
+}
+
+/**
+ * Naming/contact hints for a user's llmux client key, so the key is legible in
+ * llmux's own admin surfaces. Both fields are optional — an unknown user still
+ * gets a key (named by Slack id alone).
+ */
+function tenantKeyProfile(userId: string): { name?: string; email?: string } {
+  const settings = userSettingsStore.getUserSettings(userId);
+  return { name: settings?.slackName, email: settings?.email };
 }
 
 // Re-export for backward compatibility
@@ -646,7 +657,9 @@ export class ClaudeHandler {
         // Build a per-call env map (containing the lease's fresh token) and
         // thread it through to `query()` via `options.env`. This never mutates
         // `process.env`, so concurrent dispatches on different slots are
-        // isolated by construction.
+        // isolated by construction. No llmux tenant key: a one-shot dispatch
+        // (classification / goal eval) carries no user identity, so these
+        // system dispatches stay on the shared key = legacy tenant.
         const { env } = buildQueryEnv(lease);
         let result: string;
         try {
@@ -926,7 +939,13 @@ export class ClaudeHandler {
       // never crosses the shared `process.env.CLAUDE_CODE_OAUTH_TOKEN`
       // variable — concurrent streams holding leases on different slots
       // therefore cannot clobber each other's auth.
-      const { env: queryEnv } = buildQueryEnv(lease);
+      //
+      // Per-user llmux tenant key (multi-tenant metering): attribute this
+      // stream's tokens to the triggering Slack user. Null (issuance
+      // unavailable / ccp mode) falls back to the shared key = legacy tenant.
+      const tenantUserId = session?.currentInitiatorId || session?.userId || slackContext?.user;
+      const llmuxTenantKey = tenantUserId ? await ensureTenantKey(tenantUserId, tenantKeyProfile(tenantUserId)) : null;
+      const { env: queryEnv } = buildQueryEnv(lease, { llmuxTenantKey });
       const { options, getStderrBuffer } = await buildStreamOptions(
         { queryEnv, session, abortController, workingDirectory, slackContext },
         {

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,6 +125,16 @@ export function parseAuthMode(raw: string | undefined): AuthMode {
   return 'ccp';
 }
 
+/**
+ * Sentinel used for `config.auth.llmux.apiKey` when `ANTHROPIC_API_KEY` is
+ * unset. It is a placeholder, NOT a credential: llmux accepts any value on the
+ * data plane for loopback callers. Its presence therefore means "the operator
+ * never configured an llmux key", which `getLlmuxAdminKey()`
+ * (auth/auth-runtime.ts) uses to decide whether it may fall back to the
+ * co-located llmux config file for a real admin credential.
+ */
+export const LLMUX_PLACEHOLDER_API_KEY = 'llmux-local';
+
 export const config = {
   slack: {
     botToken: process.env.SLACK_BOT_TOKEN!,
@@ -178,7 +188,7 @@ export const config = {
        * non-empty placeholder works ("API_KEY 아무거나"); a sentinel is used
        * when `ANTHROPIC_API_KEY` is unset. Only consulted in `'llmux'` mode.
        */
-      apiKey: process.env.ANTHROPIC_API_KEY || 'llmux-local',
+      apiKey: process.env.ANTHROPIC_API_KEY || LLMUX_PLACEHOLDER_API_KEY,
     },
   },
   credentials: {

--- a/src/memory-auto-capture.ts
+++ b/src/memory-auto-capture.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import { memoryRoot } from 'somalib/model-commands/hierarchical-memory-store';
 import { runOneShotText } from './agent-runtime';
 import { buildOneShotOptions } from './agent-runtime/one-shot-options';
+import { ensureTenantKey } from './auth/llmux-tenant-keys';
 import { buildQueryEnv } from './auth/query-env-builder';
 import { config } from './config';
 import { ensureActiveSlotAuth, NoHealthySlotError, type SlotAuthLease } from './credentials-manager';
@@ -25,6 +26,7 @@ import { hierarchicalMemoryStore } from './hierarchical-memory';
 import { Logger } from './logger';
 import { getTokenManager } from './token-manager';
 import * as userMemoryStore from './user-memory-store';
+import { userSettingsStore } from './user-settings-store';
 
 const logger = new Logger('MemoryAutoCapture');
 
@@ -139,11 +141,15 @@ const CONSOLIDATION_SYSTEM_PROMPT = `당신은 Slack AI assistant의 장기기�
 - 출력은 JSON만. 형식: {"memory": ["..."], "user": ["..."]}. 각 항목은 한 줄, MEMORY 250자/USER 200자 이내.
 - 새로 배울 게 없으면 기존 엔트리를 그대로 반환한다.`;
 
-async function runConsolidationQuery(prompt: string): Promise<string> {
+async function runConsolidationQuery(prompt: string, userId: string): Promise<string> {
   let lease: SlotAuthLease | null = null;
   try {
     lease = await ensureActiveSlotAuth(getTokenManager(), 'memory-dreaming');
-    const { env } = buildQueryEnv(lease);
+    // Dreaming is work done ON BEHALF OF one user, so it is metered against
+    // that user's llmux tenant (null → shared key = legacy tenant).
+    const settings = userSettingsStore.getUserSettings(userId);
+    const llmuxTenantKey = await ensureTenantKey(userId, { name: settings?.slackName, email: settings?.email });
+    const { env } = buildQueryEnv(lease, { llmuxTenantKey });
     const options = buildOneShotOptions({
       model: config.conversation.summaryModel,
       systemPrompt: CONSOLIDATION_SYSTEM_PROMPT,
@@ -210,7 +216,8 @@ export interface ConsolidationDeps {
     entries: string[],
     expectedOld?: string[],
   ) => { ok: boolean; reason?: string };
-  runQuery: (prompt: string) => Promise<string>;
+  /** `userId` is the memory's owner — it selects the llmux tenant the LLM call is billed to. */
+  runQuery: (prompt: string, userId: string) => Promise<string>;
   dataDir: string;
 }
 
@@ -267,7 +274,7 @@ export async function consolidateUserMemory(
       episodic.slice(0, 6000),
     ].join('\n');
 
-    const raw = await deps.runQuery(prompt);
+    const raw = await deps.runQuery(prompt, userId);
     const parsed = parseJsonObject(raw);
     if (parsed) {
       applyL1(deps, userId, 'memory', parsed.memory, mem.entries);

--- a/src/memory-auto-capture.ts
+++ b/src/memory-auto-capture.ts
@@ -148,8 +148,8 @@ async function runConsolidationQuery(prompt: string, userId: string): Promise<st
     // Dreaming is work done ON BEHALF OF one user, so it is metered against
     // that user's llmux tenant (null → shared key = legacy tenant).
     const settings = userSettingsStore.getUserSettings(userId);
-    const llmuxTenantKey = await ensureTenantKey(userId, { name: settings?.slackName, email: settings?.email });
-    const { env } = buildQueryEnv(lease, { llmuxTenantKey });
+    const llmuxTenant = await ensureTenantKey(userId, { name: settings?.slackName, email: settings?.email });
+    const { env } = buildQueryEnv(lease, { llmuxTenant });
     const options = buildOneShotOptions({
       model: config.conversation.summaryModel,
       systemPrompt: CONSOLIDATION_SYSTEM_PROMPT,


### PR DESCRIPTION
## What

In llmux auth mode, every Slack user's dispatches now authenticate to the llmux proxy with their OWN issued client key (`lmk-…`) instead of the single shared key, so llmux (≥ multi-tenant preview-2026-08-06, [llmux#137](https://github.com/2lab-ai/llmux/pull/137)) recognizes each user as a separate tenant and meters usage/cost per user in its keys tab & activity log.

- **`src/auth/llmux-tenant-keys.ts` (new)** — per-user key store (`DATA_DIR/llmux-tenant-keys.json`, atomic tmp+rename, 0600). Lazy issuance on a user's first dispatch via `POST /llmux/keys/new` (name = `{slackName} ({userId})`, email from UserSettingsStore). Deterministic reclaim on the immutable Slack id (preflight `GET /llmux/keys` → rotate; 409 branch kept as race fallback). 10-min negative cache + in-flight dedupe. Records are bound to the issuing daemon (`baseUrl`); a daemon change is a store miss. **Never throws — every failure returns null and the dispatch falls back to the shared key (legacy tenant).**
- **`buildQueryEnv(lease, {llmuxTenantKey})`** — llmux branch uses the triggering user's key as `ANTHROPIC_API_KEY`; identity-less system dispatches (classification, goal eval) stay on the shared key.
- **`streamQuery`** — resolves `currentInitiatorId || userId || slackContext.user` and threads the tenant key; memory dreaming (`runConsolidationQuery`) is billed to the memory owner's tenant.
- **`getLlmuxAdminKey()`** — multi-tenant llmux gates every `/llmux/*` control endpoint on an ADMIN credential even from loopback, which broke `/llmux/status` etc. when `ANTHROPIC_API_KEY` was left unset. Resolution: operator-set key wins → else (placeholder + **loopback baseUrl only**) the co-located llmux config's `proxy.api_key` (mirrors llmux's own local-CLI behavior, 60s TTL) → else placeholder. `llmux-client` now sends this admin key.

## Review

External 2-persona review (strategist + first-principles) round 1 → 3 MUST-FIX (admin-key off-host leak via remote baseUrl, stale key on daemon change bypassing the fallback, duplicate tenant on display-name change + store loss) — all fixed in 8fd3afd with RED proof (guards stripped → exactly the 7 new tests fail).

## Verification

- `npm run lint` exit 0; `npm run test` **7961 passed** (auth suite 55→59)
- Live receipt vs a real scratch multi-tenant llmux daemon (0.2.19 preview-2026-08-06): admin auto-key fixes control-plane 403 → 200; issue → `lmk-` secret persisted (0600) → reuse without re-issue; `buildQueryEnv` carries the tenant key + OAuth token suppressed; suspend → data-plane 401 `client key suspended` → resume; store-loss 409→rotate self-heal keeps the same key id; rename + store loss reclaims the SAME key (no duplicate tenant); two users → two distinct keys.

## Ops notes

- Zero-config on co-located deployments (loopback llmux): admin key auto-resolved from `~/.config/llmux.json`. Remote llmux: set a real admin key (`auth` settings / `ANTHROPIC_API_KEY`) — the local-config fallback deliberately refuses to ship the local secret off-host.
- Older (pre-multi-tenant) llmux: issuance 404s → negative-cached → everything runs on the shared key exactly as before.
- Known residual: negative cache is keyed by userId only — re-pointing daemons inside a failure window degrades to the shared key for ≤10 min (no breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)